### PR TITLE
✨ Add `idl` module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "winnow"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da01e24d23aeb852fb05609f2701ce4da9f73d58857239ed3853667cf178f204"
+
+[[package]]
 name = "zlink"
 version = "0.0.1-alpha.1"
 dependencies = [
@@ -837,6 +843,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "winnow",
 ]
 
 [[package]]

--- a/TODO.md
+++ b/TODO.md
@@ -1,21 +1,27 @@
 # TODO
 
-* zlink-core
-  * IDL <https://varlink.org/Service>
-    * `idl` mod
-    * Type that describes a type: Interface, Method, Type, Error
-    * Trait that gives the IDL name of the type
-      * impl for common types
-    * `Service`
-      * `Info` type with fields of `GetInfo` method
-      * impl `GetInfo` method for test case
+* IDL <https://varlink.org/Interface-Definition>
+  * zlink-core
+    * Test for parsing org.varlink.service IDL
+    * Test for parsing io.systemd.Resolve IDL
+    * Update to latest winnow
+    * `introspect` module containing [Introspection](https://varlink.org/Service>) API
+      * structs for methods and errors (to be used for client and server)
+        * impl Serialize+Deserialize in such a way that it can be used as return value of service and
+        connection (for client-side)
+      * Make use of zlink-macros' derives
+      * `IntrospectionProxy`
+        * client-side API
     * cargo features to allow use of `idl` only
-  * IntrospectionProxy
+  * zlink-macros
+    * Provide introspection derives
+      * `TypeInfo`
+      * `ReplyErrors`
+  * zlink
+    * impl [`Service`](https://varlink.org/Service>) interface for lowlevel-ftl test
+      * Make use of `zlink_core::introspect` and `zlink-macros`
 * zlink-macros
-  * Provide introspection derives
-  * Update `Service` example/test to make use of these
-* zlink-macros
-  * `proxy` attribute macro (wraps `Proxy`)
+  * `proxy` attribute macro
     * gated behind (default)`proxy` feature
   * `service` attribute macro (see below)
     * gated behind `service` feature

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -16,6 +16,10 @@ io-buffer-2kb = []
 io-buffer-4kb = []
 io-buffer-16kb = []
 io-buffer-1mb = []
+# IDL and introspection support
+idl = []
+idl-parse = ["idl", "dep:winnow", "std"]
+introspection = ["idl-parse"]
 
 [dependencies]
 serde = { version = "1.0.218", default-features = false, features = ["derive"] }
@@ -34,6 +38,9 @@ futures-util = { version = "0.3.31", default-features = false, features = [
 tracing = { version = "0.1.41", default-features = false, optional = true }
 defmt = { version = "1.0.1", default-features = false, optional = true }
 pin-project-lite = "0.2.16"
+winnow = { version = "0.3", default-features = false, features = [
+    "alloc",
+], optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.218", default-features = false, features = ["alloc"] }

--- a/zlink-core/src/idl/custom_type.rs
+++ b/zlink-core/src/idl/custom_type.rs
@@ -1,0 +1,227 @@
+//! Custom type, field and parameter definitions for Varlink IDL.
+
+use core::fmt;
+
+use serde::Serialize;
+
+#[cfg(feature = "idl-parse")]
+use serde::Deserialize;
+
+use super::{List, Type, TypeRef};
+
+/// A field in a custom type or method parameter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Field<'a> {
+    /// The name of the field.
+    name: &'a str,
+    /// The type of the field.
+    ty: TypeRef<'a>,
+}
+
+/// Type alias for method parameters, which have the same structure as fields.
+pub type Parameter<'a> = Field<'a>;
+
+/// A custom type definition in Varlink IDL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CustomType<'a> {
+    /// The name of the custom type.
+    name: &'a str,
+    /// The fields of the custom type.
+    fields: List<'a, Field<'a>>,
+}
+
+impl<'a> CustomType<'a> {
+    /// Creates a new custom type with the given name and borrowed fields.
+    pub const fn new(name: &'a str, fields: &'a [&'a Field<'a>]) -> Self {
+        Self {
+            name,
+            fields: List::Borrowed(fields),
+        }
+    }
+
+    /// Creates a new custom type with the given name and owned fields.
+    #[cfg(feature = "std")]
+    pub fn new_owned(name: &'a str, fields: Vec<Field<'a>>) -> Self {
+        Self {
+            name,
+            fields: List::Owned(fields),
+        }
+    }
+
+    /// Returns the name of the custom type.
+    pub fn name(&self) -> &'a str {
+        self.name
+    }
+
+    /// Returns an iterator over the fields of the custom type.
+    pub fn fields(&self) -> impl Iterator<Item = &Field<'a>> {
+        self.fields.iter()
+    }
+}
+
+impl<'a> fmt::Display for CustomType<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "type {} (", self.name)?;
+        let mut first = true;
+        for field in self.fields.iter() {
+            if !first {
+                write!(f, ", ")?;
+            }
+            first = false;
+            write!(f, "{}", field)?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl<'a> Serialize for CustomType<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de, 'a> Deserialize<'de> for CustomType<'a>
+where
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+        super::parse::parse_custom_type(s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl<'a> Field<'a> {
+    /// Creates a new field with the given name and type.
+    pub const fn new(name: &'a str, ty: &'a Type<'a>) -> Self {
+        Self {
+            name,
+            ty: TypeRef::borrowed(ty),
+        }
+    }
+
+    /// Same as `new` but takes `ty` by value.
+    pub fn new_owned(name: &'a str, ty: Type<'a>) -> Self {
+        Self {
+            name,
+            ty: TypeRef::new(ty),
+        }
+    }
+
+    /// Returns the name of the field.
+    pub fn name(&self) -> &'a str {
+        self.name
+    }
+
+    /// Returns the type of the field.
+    pub fn ty(&self) -> &Type<'a> {
+        self.ty.inner()
+    }
+}
+
+impl<'a> fmt::Display for Field<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.name, self.ty)
+    }
+}
+
+impl<'a> Serialize for Field<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de, 'a> Deserialize<'de> for Field<'a>
+where
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+        super::parse::parse_field(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idl::{Type, TypeInfo};
+
+    #[test]
+    fn field_creation() {
+        let field = Field::new("age", <i32>::TYPE_INFO);
+        assert_eq!(field.name(), "age");
+        assert_eq!(field.ty(), &Type::Int);
+    }
+
+    #[test]
+    fn field_serialization() {
+        let field = Field::new("count", <i32>::TYPE_INFO);
+        #[cfg(feature = "std")]
+        let json = serde_json::to_string(&field).unwrap();
+        #[cfg(feature = "embedded")]
+        let json = {
+            let mut buffer = [0u8; 16];
+            let len = serde_json_core::to_slice(&field, &mut buffer).unwrap();
+            let vec = mayheap::Vec::<_, 16>::from_slice(&buffer[..len]).unwrap();
+            mayheap::String::<16>::from_utf8(vec).unwrap()
+        };
+        assert_eq!(json, r#""count: int""#);
+    }
+
+    #[test]
+    fn parameter_alias() {
+        let param: Parameter<'_> = Field::new("input", <&str>::TYPE_INFO);
+        assert_eq!(param.name(), "input");
+        assert_eq!(param.ty(), &Type::String);
+    }
+
+    #[test]
+    fn custom_type_creation() {
+        let field_x = Field::new("x", <f64>::TYPE_INFO);
+        let field_y = Field::new("y", <f64>::TYPE_INFO);
+        let fields = [&field_x, &field_y];
+
+        let custom_type = CustomType::new("Point", &fields);
+        assert_eq!(custom_type.name(), "Point");
+        assert_eq!(custom_type.fields().count(), 2);
+
+        // Check the fields individually - order and values.
+        let fields_vec: mayheap::Vec<_, 8> = custom_type.fields().collect();
+        assert_eq!(fields_vec[0].name(), "x");
+        assert_eq!(fields_vec[0].ty(), &Type::Float);
+        assert_eq!(fields_vec[1].name(), "y");
+        assert_eq!(fields_vec[1].ty(), &Type::Float);
+    }
+
+    #[test]
+    fn custom_type_serialization() {
+        let field_x = Field::new("x", <f64>::TYPE_INFO);
+        let field_y = Field::new("y", <f64>::TYPE_INFO);
+        let fields = [&field_x, &field_y];
+
+        let custom_type = CustomType::new("Point", &fields);
+        #[cfg(feature = "std")]
+        let json = serde_json::to_string(&custom_type).unwrap();
+        #[cfg(feature = "embedded")]
+        let json = {
+            let mut buffer = [0u8; 64];
+            let len = serde_json_core::to_slice(&custom_type, &mut buffer).unwrap();
+            let vec = mayheap::Vec::<_, 64>::from_slice(&buffer[..len]).unwrap();
+            mayheap::String::<64>::from_utf8(vec).unwrap()
+        };
+        assert_eq!(json, r#""type Point (x: float, y: float)""#);
+    }
+}

--- a/zlink-core/src/idl/error.rs
+++ b/zlink-core/src/idl/error.rs
@@ -1,0 +1,153 @@
+//! Error definitions for Varlink IDL.
+
+use core::fmt;
+
+use serde::Serialize;
+
+#[cfg(feature = "idl-parse")]
+use serde::Deserialize;
+
+use super::{Field, List};
+
+/// An error definition in Varlink IDL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Error<'a> {
+    /// The name of the error.
+    name: &'a str,
+    /// The fields of the error.
+    fields: List<'a, Field<'a>>,
+}
+
+impl<'a> Error<'a> {
+    /// Creates a new error with the given name and borrowed fields.
+    pub const fn new(name: &'a str, fields: &'a [&'a Field<'a>]) -> Self {
+        Self {
+            name,
+            fields: List::Borrowed(fields),
+        }
+    }
+
+    /// Creates a new error with the given name and owned fields.
+    #[cfg(feature = "std")]
+    pub fn new_owned(name: &'a str, fields: Vec<Field<'a>>) -> Self {
+        Self {
+            name,
+            fields: List::Owned(fields),
+        }
+    }
+
+    /// Returns the name of the error.
+    pub fn name(&self) -> &'a str {
+        self.name
+    }
+
+    /// Returns an iterator over the fields of the error.
+    pub fn fields(&self) -> impl Iterator<Item = &Field<'a>> {
+        self.fields.iter()
+    }
+
+    /// Returns true if the error has no fields.
+    pub fn has_no_fields(&self) -> bool {
+        self.fields.is_empty()
+    }
+}
+
+impl<'a> fmt::Display for Error<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "error {} (", self.name)?;
+        let mut first = true;
+        for field in self.fields.iter() {
+            if !first {
+                write!(f, ", ")?;
+            }
+            first = false;
+            write!(f, "{}", field)?;
+        }
+        write!(f, ")")
+    }
+}
+
+impl<'a> Serialize for Error<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de, 'a> Deserialize<'de> for Error<'a>
+where
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+        super::parse::parse_error(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idl::{Type, TypeInfo};
+
+    #[test]
+    fn error_creation() {
+        let message_field = Field::new("message", <&str>::TYPE_INFO);
+        let code_field = Field::new("code", <i32>::TYPE_INFO);
+        let fields = [&message_field, &code_field];
+
+        let error = Error::new("InvalidInput", &fields);
+        assert_eq!(error.name(), "InvalidInput");
+        assert_eq!(error.fields().count(), 2);
+        assert!(!error.has_no_fields());
+
+        // Check the fields individually - order and values.
+        let fields_vec: mayheap::Vec<_, 8> = error.fields().collect();
+        assert_eq!(fields_vec[0].name(), "message");
+        assert_eq!(fields_vec[0].ty(), &Type::String);
+        assert_eq!(fields_vec[1].name(), "code");
+        assert_eq!(fields_vec[1].ty(), &Type::Int);
+    }
+
+    #[test]
+    fn error_no_fields() {
+        let error = Error::new("UnknownError", &[]);
+        assert_eq!(error.name(), "UnknownError");
+        assert!(error.has_no_fields());
+    }
+
+    #[test]
+    fn error_serialization() {
+        let message_field = Field::new("message", <&str>::TYPE_INFO);
+        let details_field = Field::new("details", &Type::Object);
+        let fields = [&message_field, &details_field];
+
+        let error = Error::new("ValidationError", &fields);
+
+        // Check the fields individually - order and values.
+        let fields_vec: mayheap::Vec<_, 8> = error.fields().collect();
+        assert_eq!(fields_vec[0].name(), "message");
+        assert_eq!(fields_vec[0].ty(), &Type::String);
+        assert_eq!(fields_vec[1].name(), "details");
+        assert_eq!(fields_vec[1].ty(), &Type::Object);
+
+        #[cfg(feature = "std")]
+        let json = serde_json::to_string(&error).unwrap();
+        #[cfg(feature = "embedded")]
+        let json = {
+            let mut buffer = [0u8; 128];
+            let len = serde_json_core::to_slice(&error, &mut buffer).unwrap();
+            let vec = mayheap::Vec::<_, 128>::from_slice(&buffer[..len]).unwrap();
+            mayheap::String::<128>::from_utf8(vec).unwrap()
+        };
+        assert_eq!(
+            json,
+            r#""error ValidationError (message: string, details: object)""#
+        );
+    }
+}

--- a/zlink-core/src/idl/interface.rs
+++ b/zlink-core/src/idl/interface.rs
@@ -1,0 +1,231 @@
+//! Interface definitions for Varlink IDL.
+
+use core::fmt;
+
+use serde::Serialize;
+
+#[cfg(feature = "idl-parse")]
+use serde::Deserialize;
+
+use super::{List, Member};
+
+/// A Varlink interface definition.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Interface<'a> {
+    /// The name of the interface in reverse-domain notation.
+    name: &'a str,
+    /// The members of the interface (types, methods, errors).
+    members: List<'a, Member<'a>>,
+}
+
+impl<'a> Interface<'a> {
+    /// Creates a new interface with the given name and borrowed members.
+    pub const fn new(name: &'a str, members: &'a [&'a Member<'a>]) -> Self {
+        Self {
+            name,
+            members: List::Borrowed(members),
+        }
+    }
+
+    /// Creates a new interface with the given name and owned members.
+    #[cfg(feature = "std")]
+    pub fn new_owned(name: &'a str, members: Vec<Member<'a>>) -> Self {
+        Self {
+            name,
+            members: List::Owned(members),
+        }
+    }
+
+    /// Returns the name of the interface.
+    pub fn name(&self) -> &'a str {
+        self.name
+    }
+
+    /// Returns an iterator over the members of the interface.
+    pub fn members(&self) -> impl Iterator<Item = &Member<'a>> {
+        self.members.iter()
+    }
+
+    /// Returns true if the interface has no members.
+    pub fn is_empty(&self) -> bool {
+        self.members.is_empty()
+    }
+
+    /// Returns an iterator over the methods in this interface.
+    pub fn methods(&self) -> impl Iterator<Item = &super::Method<'a>> {
+        self.members.iter().filter_map(|member| match member {
+            Member::Method(method) => Some(method),
+            _ => None,
+        })
+    }
+
+    /// Returns an iterator over the custom types in this interface.
+    pub fn custom_types(&self) -> impl Iterator<Item = &super::CustomType<'a>> {
+        self.members.iter().filter_map(|member| match member {
+            Member::Custom(custom) => Some(custom),
+            _ => None,
+        })
+    }
+
+    /// Returns an iterator over the errors in this interface.
+    pub fn errors(&self) -> impl Iterator<Item = &super::Error<'a>> {
+        self.members.iter().filter_map(|member| match member {
+            Member::Error(error) => Some(error),
+            _ => None,
+        })
+    }
+}
+
+impl<'a> fmt::Display for Interface<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "interface {}", self.name)?;
+        for member in self.members.iter() {
+            write!(f, "\n\n{}", member)?;
+        }
+        Ok(())
+    }
+}
+
+impl<'a> Serialize for Interface<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de, 'a> Deserialize<'de> for Interface<'a>
+where
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+        super::parse::parse_interface(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idl::{Error, Field, Method, Parameter, Type, TypeInfo};
+
+    #[test]
+    fn org_varlink_service_interface() {
+        use crate::idl::TypeRef;
+
+        // Build the org.varlink.service interface as our test case
+        let vendor_param = Parameter::new("vendor", <&str>::TYPE_INFO);
+        let product_param = Parameter::new("product", <&str>::TYPE_INFO);
+        let version_param = Parameter::new("version", <&str>::TYPE_INFO);
+        let url_param = Parameter::new("url", <&str>::TYPE_INFO);
+        let interfaces_type = Type::Array(TypeRef::borrowed(&Type::String));
+        let interfaces_param = Parameter::new("interfaces", &interfaces_type);
+        let get_info_outputs = [
+            &vendor_param,
+            &product_param,
+            &version_param,
+            &url_param,
+            &interfaces_param,
+        ];
+
+        let get_interface_desc_input = Parameter::new("interface", <&str>::TYPE_INFO);
+        let get_interface_desc_inputs = [&get_interface_desc_input];
+
+        let get_interface_desc_output = Parameter::new("description", <&str>::TYPE_INFO);
+        let get_interface_desc_outputs = [&get_interface_desc_output];
+
+        let interface_not_found_field = Field::new("interface", <&str>::TYPE_INFO);
+        let interface_not_found_fields = [&interface_not_found_field];
+
+        let method_not_found_field = Field::new("method", <&str>::TYPE_INFO);
+        let method_not_found_fields = [&method_not_found_field];
+
+        let method_not_impl_field = Field::new("method", <&str>::TYPE_INFO);
+        let method_not_impl_fields = [&method_not_impl_field];
+
+        let invalid_param_field = Field::new("parameter", <&str>::TYPE_INFO);
+        let invalid_param_fields = [&invalid_param_field];
+
+        let get_info = Method::new("GetInfo", &[], &get_info_outputs);
+        let get_interface_desc = Method::new(
+            "GetInterfaceDescription",
+            &get_interface_desc_inputs,
+            &get_interface_desc_outputs,
+        );
+        let interface_not_found = Error::new("InterfaceNotFound", &interface_not_found_fields);
+        let method_not_found = Error::new("MethodNotFound", &method_not_found_fields);
+        let method_not_impl = Error::new("MethodNotImplemented", &method_not_impl_fields);
+        let invalid_param = Error::new("InvalidParameter", &invalid_param_fields);
+        let permission_denied = Error::new("PermissionDenied", &[]);
+        let expected_more = Error::new("ExpectedMore", &[]);
+
+        let members = &[
+            &Member::Method(get_info),
+            &Member::Method(get_interface_desc),
+            &Member::Error(interface_not_found),
+            &Member::Error(method_not_found),
+            &Member::Error(method_not_impl),
+            &Member::Error(invalid_param),
+            &Member::Error(permission_denied),
+            &Member::Error(expected_more),
+        ];
+
+        let interface = Interface::new("org.varlink.service", members);
+
+        assert_eq!(interface.name(), "org.varlink.service");
+        assert_eq!(interface.members().count(), 8);
+        assert!(!interface.is_empty());
+
+        // Check method count
+        assert_eq!(interface.methods().count(), 2);
+
+        // Check error count
+        assert_eq!(interface.errors().count(), 6);
+
+        // Test Display output
+        use core::fmt::Write;
+        let mut idl = mayheap::String::<2048>::new();
+        write!(idl, "{}", interface).unwrap();
+        assert!(idl.as_str().starts_with("interface org.varlink.service"));
+        assert!(idl.as_str().contains("method GetInfo()"));
+        assert!(idl
+            .as_str()
+            .contains("method GetInterfaceDescription(interface: string)"));
+        assert!(idl
+            .as_str()
+            .contains("error InterfaceNotFound (interface: string)"));
+        assert!(idl.as_str().contains("error PermissionDenied ()"));
+    }
+
+    #[test]
+    fn interface_serialization() {
+        let simple_method = Method::new("Ping", &[], &[]);
+
+        let members = [&Member::Method(simple_method)];
+        let interface = Interface::new("com.example.ping", &members);
+        #[cfg(feature = "std")]
+        let json = serde_json::to_string(&interface).unwrap();
+        #[cfg(feature = "embedded")]
+        let json = {
+            let mut buffer = [0u8; 64];
+            let len = serde_json_core::to_slice(&interface, &mut buffer).unwrap();
+            let vec = mayheap::Vec::<_, 64>::from_slice(&buffer[..len]).unwrap();
+            mayheap::String::<64>::from_utf8(vec).unwrap()
+        };
+        assert_eq!(json, r#""interface com.example.ping\n\nmethod Ping()""#);
+    }
+
+    #[test]
+    fn empty_interface() {
+        let interface = Interface::new("com.example.empty", &[]);
+        assert!(interface.is_empty());
+        assert_eq!(interface.methods().count(), 0);
+        assert_eq!(interface.errors().count(), 0);
+        assert_eq!(interface.custom_types().count(), 0);
+    }
+}

--- a/zlink-core/src/idl/list.rs
+++ b/zlink-core/src/idl/list.rs
@@ -1,0 +1,191 @@
+//! List type for holding either borrowed or owned collections.
+
+use serde::Serialize;
+
+#[cfg(feature = "idl-parse")]
+use serde::Deserialize;
+
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+/// A list that can be either borrowed or owned.
+///
+/// This type is useful for const contexts where we need borrowed data,
+/// as well as for deserialization where we need owned data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum List<'a, T> {
+    /// Borrowed slice of references, useful for const contexts.
+    Borrowed(&'a [&'a T]),
+    /// Owned vector, used for deserialization.
+    #[cfg(feature = "std")]
+    Owned(Vec<T>),
+}
+
+impl<'a, T> List<'a, T> {
+    /// Returns an iterator over references to the items.
+    pub fn iter(&self) -> impl Iterator<Item = &T> {
+        match self {
+            List::Borrowed(slice) => ListIter::Borrowed(slice.iter()),
+            #[cfg(feature = "std")]
+            List::Owned(vec) => ListIter::Owned(vec.iter()),
+        }
+    }
+
+    /// Returns the number of items in the list.
+    pub fn len(&self) -> usize {
+        match self {
+            List::Borrowed(slice) => slice.len(),
+            #[cfg(feature = "std")]
+            List::Owned(vec) => vec.len(),
+        }
+    }
+
+    /// Returns true if the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Iterator over list items.
+enum ListIter<'a, T> {
+    Borrowed(core::slice::Iter<'a, &'a T>),
+    #[cfg(feature = "std")]
+    Owned(core::slice::Iter<'a, T>),
+}
+
+impl<'a, T> Iterator for ListIter<'a, T> {
+    type Item = &'a T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            ListIter::Borrowed(iter) => iter.next().copied(),
+            #[cfg(feature = "std")]
+            ListIter::Owned(iter) => iter.next(),
+        }
+    }
+}
+
+impl<'a, T> Serialize for List<'a, T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeSeq;
+
+        let mut seq = serializer.serialize_seq(Some(self.len()))?;
+        for item in self.iter() {
+            seq.serialize_element(item)?;
+        }
+        seq.end()
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de, 'a, T> Deserialize<'de> for List<'a, T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let vec = Vec::<T>::deserialize(deserializer)?;
+        Ok(List::Owned(vec))
+    }
+}
+
+impl<'a, T> Default for List<'a, T> {
+    fn default() -> Self {
+        List::Borrowed(&[])
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a, T> From<Vec<T>> for List<'a, T> {
+    fn from(vec: Vec<T>) -> Self {
+        List::Owned(vec)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a, T, const N: usize> From<mayheap::Vec<T, N>> for List<'a, T> {
+    fn from(vec: mayheap::Vec<T, N>) -> Self {
+        List::Owned(vec.into())
+    }
+}
+
+impl<'a, T> From<&'a [&'a T]> for List<'a, T> {
+    fn from(slice: &'a [&'a T]) -> Self {
+        List::Borrowed(slice)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn list_borrowed() {
+        static ITEM_ONE: &str = "one";
+        static ITEM_TWO: &str = "two";
+        static ITEM_THREE: &str = "three";
+        static ITEMS: [&'static &str; 3] = [&ITEM_ONE, &ITEM_TWO, &ITEM_THREE];
+        let list: List<'_, &str> = List::Borrowed(&ITEMS);
+
+        assert_eq!(list.len(), 3);
+        assert!(!list.is_empty());
+
+        let expected = ["one", "two", "three"];
+        let mut actual = mayheap::Vec::<&str, 8>::new();
+        for item in list.iter() {
+            actual.push(*item).unwrap();
+        }
+        assert_eq!(actual.as_slice(), &expected);
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn list_owned() {
+        let vec = vec!["one".to_string(), "two".to_string(), "three".to_string()];
+        let list: List<'_, String> = List::from(vec);
+
+        assert_eq!(list.len(), 3);
+        assert!(!list.is_empty());
+
+        let collected: Vec<_> = list.iter().map(|s| s.as_str()).collect();
+        assert_eq!(collected, vec!["one", "two", "three"]);
+    }
+
+    #[test]
+    fn serialization() {
+        static REFS: [&i32; 3] = [&1, &2, &3];
+        let list: List<'_, i32> = List::Borrowed(&REFS);
+
+        #[cfg(feature = "std")]
+        let json = serde_json::to_string(&list).unwrap();
+        #[cfg(feature = "embedded")]
+        let json = {
+            let mut buffer = [0u8; 16];
+            let len = serde_json_core::to_slice(&list, &mut buffer).unwrap();
+            let vec = mayheap::Vec::<_, 16>::from_slice(&buffer[..len]).unwrap();
+            mayheap::String::<16>::from_utf8(vec).unwrap()
+        };
+
+        assert_eq!(json, "[1,2,3]");
+    }
+
+    #[cfg(feature = "idl-parse")]
+    #[test]
+    fn deserialization() {
+        let json = "[1,2,3]";
+        let list: List<'_, i32> = serde_json::from_str(json).unwrap();
+
+        match list {
+            List::Owned(vec) => assert_eq!(vec, vec![1, 2, 3]),
+            _ => panic!("Expected owned list"),
+        }
+    }
+}

--- a/zlink-core/src/idl/member.rs
+++ b/zlink-core/src/idl/member.rs
@@ -1,0 +1,174 @@
+//! Member definitions for Varlink interfaces.
+
+use core::fmt;
+
+use serde::Serialize;
+
+#[cfg(feature = "idl-parse")]
+use serde::Deserialize;
+
+use super::{CustomType, Error, Method};
+
+/// A member of a Varlink interface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Member<'a> {
+    /// A custom type definition.
+    Custom(CustomType<'a>),
+    /// A method definition.
+    Method(Method<'a>),
+    /// An error definition.
+    Error(Error<'a>),
+}
+
+impl<'a> Member<'a> {
+    /// Returns the name of this member.
+    pub fn name(&self) -> &'a str {
+        match self {
+            Member::Custom(custom) => custom.name(),
+            Member::Method(method) => method.name(),
+            Member::Error(error) => error.name(),
+        }
+    }
+}
+
+impl<'a> fmt::Display for Member<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Member::Custom(custom) => write!(f, "{}", custom),
+            Member::Method(method) => write!(f, "{}", method),
+            Member::Error(error) => write!(f, "{}", error),
+        }
+    }
+}
+
+impl<'a> Serialize for Member<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de, 'a> Deserialize<'de> for Member<'a>
+where
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+        super::parse::parse_member(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "std")]
+    use crate::idl::Type;
+    use crate::idl::{CustomType, Error, Field, Method, Parameter, TypeInfo};
+
+    #[test]
+    fn member_custom_type() {
+        let vendor_field = Field::new("vendor", <&str>::TYPE_INFO);
+        let product_field = Field::new("product", <&str>::TYPE_INFO);
+        let version_field = Field::new("version", <&str>::TYPE_INFO);
+        let fields = [&vendor_field, &product_field, &version_field];
+
+        let custom = CustomType::new("ServiceInfo", &fields);
+        let member = Member::Custom(custom);
+
+        assert_eq!(member.name(), "ServiceInfo");
+
+        use core::fmt::Write;
+        let mut buf = mayheap::String::<128>::new();
+        write!(buf, "{}", member).unwrap();
+        assert_eq!(
+            buf.as_str(),
+            "type ServiceInfo (vendor: string, product: string, version: string)"
+        );
+    }
+
+    #[test]
+    fn member_method() {
+        #[cfg(feature = "std")]
+        {
+            use crate::idl::TypeRef;
+            let interfaces_type = Type::Array(TypeRef::borrowed(<&str>::TYPE_INFO));
+            let outputs = vec![
+                Parameter::new("vendor", <&str>::TYPE_INFO),
+                Parameter::new("product", <&str>::TYPE_INFO),
+                Parameter::new("version", <&str>::TYPE_INFO),
+                Parameter::new("url", <&str>::TYPE_INFO),
+                Parameter::new("interfaces", &interfaces_type),
+            ];
+            let method = Method::new_owned("GetInfo", vec![], outputs);
+            let member = Member::Method(method);
+
+            assert_eq!(member.name(), "GetInfo");
+            use core::fmt::Write;
+            let mut buf = mayheap::String::<256>::new();
+            write!(buf, "{}", member).unwrap();
+            assert_eq!(
+                buf.as_str(),
+                "method GetInfo() -> (vendor: string, product: string, version: string, url: string, interfaces: []string)"
+            );
+        }
+
+        #[cfg(not(feature = "std"))]
+        {
+            let vendor_param = Parameter::new("vendor", <&str>::TYPE_INFO);
+            let product_param = Parameter::new("product", <&str>::TYPE_INFO);
+            let version_param = Parameter::new("version", <&str>::TYPE_INFO);
+            let url_param = Parameter::new("url", <&str>::TYPE_INFO);
+            let outputs = [&vendor_param, &product_param, &version_param, &url_param];
+
+            let method = Method::new("GetInfo", &[], &outputs);
+            let member = Member::Method(method);
+
+            assert_eq!(member.name(), "GetInfo");
+            use core::fmt::Write;
+            let mut buf = mayheap::String::<256>::new();
+            write!(buf, "{}", member).unwrap();
+            assert_eq!(
+                buf.as_str(),
+                "method GetInfo() -> (vendor: string, product: string, version: string, url: string)"
+            );
+        }
+    }
+
+    #[test]
+    fn member_error() {
+        let interface_field = Field::new("interface", <&str>::TYPE_INFO);
+        let fields = [&interface_field];
+
+        let error = Error::new("InterfaceNotFound", &fields);
+        let member = Member::Error(error);
+
+        assert_eq!(member.name(), "InterfaceNotFound");
+
+        use core::fmt::Write;
+        let mut buf = mayheap::String::<64>::new();
+        write!(buf, "{}", member).unwrap();
+        assert_eq!(buf.as_str(), "error InterfaceNotFound (interface: string)");
+    }
+
+    #[test]
+    fn member_serialization() {
+        let error = Error::new("PermissionDenied", &[]);
+        let member = Member::Error(error);
+        #[cfg(feature = "std")]
+        let json = serde_json::to_string(&member).unwrap();
+        #[cfg(feature = "embedded")]
+        let json = {
+            let mut buffer = [0u8; 64];
+            let len = serde_json_core::to_slice(&member, &mut buffer).unwrap();
+            let vec = mayheap::Vec::<_, 64>::from_slice(&buffer[..len]).unwrap();
+            mayheap::String::<64>::from_utf8(vec).unwrap()
+        };
+        assert_eq!(json, r#""error PermissionDenied ()""#);
+    }
+}

--- a/zlink-core/src/idl/method.rs
+++ b/zlink-core/src/idl/method.rs
@@ -1,0 +1,202 @@
+//! Method definitions for Varlink IDL.
+
+use core::fmt;
+
+use serde::Serialize;
+
+#[cfg(feature = "idl-parse")]
+use serde::Deserialize;
+
+use super::{List, Parameter};
+
+/// A method definition in Varlink IDL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Method<'a> {
+    /// The name of the method.
+    name: &'a str,
+    /// Input parameters for the method.
+    inputs: List<'a, Parameter<'a>>,
+    /// Output parameters for the method.
+    outputs: List<'a, Parameter<'a>>,
+}
+
+impl<'a> Method<'a> {
+    /// Creates a new method with the given name and borrowed parameters.
+    pub const fn new(
+        name: &'a str,
+        inputs: &'a [&'a Parameter<'a>],
+        outputs: &'a [&'a Parameter<'a>],
+    ) -> Self {
+        Self {
+            name,
+            inputs: List::Borrowed(inputs),
+            outputs: List::Borrowed(outputs),
+        }
+    }
+
+    /// Creates a new method with the given name and owned parameters.
+    #[cfg(feature = "std")]
+    pub fn new_owned(
+        name: &'a str,
+        inputs: Vec<Parameter<'a>>,
+        outputs: Vec<Parameter<'a>>,
+    ) -> Self {
+        Self {
+            name,
+            inputs: List::Owned(inputs),
+            outputs: List::Owned(outputs),
+        }
+    }
+
+    /// Returns the name of the method.
+    pub fn name(&self) -> &'a str {
+        self.name
+    }
+
+    /// Returns an iterator over the input parameters.
+    pub fn inputs(&self) -> impl Iterator<Item = &Parameter<'a>> {
+        self.inputs.iter()
+    }
+
+    /// Returns an iterator over the output parameters.
+    pub fn outputs(&self) -> impl Iterator<Item = &Parameter<'a>> {
+        self.outputs.iter()
+    }
+
+    /// Returns true if the method has no input parameters.
+    pub fn has_no_inputs(&self) -> bool {
+        self.inputs.is_empty()
+    }
+
+    /// Returns true if the method has no output parameters.
+    pub fn has_no_outputs(&self) -> bool {
+        self.outputs.is_empty()
+    }
+}
+
+impl<'a> fmt::Display for Method<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "method {}(", self.name)?;
+        let mut first = true;
+        for param in self.inputs.iter() {
+            if !first {
+                write!(f, ", ")?;
+            }
+            first = false;
+            write!(f, "{}", param)?;
+        }
+        write!(f, ")")?;
+
+        if !self.has_no_outputs() {
+            write!(f, " -> (")?;
+            let mut first = true;
+            for param in self.outputs.iter() {
+                if !first {
+                    write!(f, ", ")?;
+                }
+                first = false;
+                write!(f, "{}", param)?;
+            }
+            write!(f, ")")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> Serialize for Method<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de, 'a> Deserialize<'de> for Method<'a>
+where
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+        super::parse::parse_method(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idl::{Parameter, Type, TypeInfo};
+
+    #[test]
+    fn method_creation() {
+        let input = Parameter::new("id", <i32>::TYPE_INFO);
+        let output = Parameter::new("name", <&str>::TYPE_INFO);
+        let inputs = [&input];
+        let outputs = [&output];
+
+        let method = Method::new("GetName", &inputs, &outputs);
+        assert_eq!(method.name(), "GetName");
+        assert_eq!(method.inputs().count(), 1);
+        assert_eq!(method.outputs().count(), 1);
+        assert!(!method.has_no_inputs());
+        assert!(!method.has_no_outputs());
+
+        // Check the parameters individually - order and values.
+        let inputs_vec: mayheap::Vec<_, 8> = method.inputs().collect();
+        assert_eq!(inputs_vec[0].name(), "id");
+        assert_eq!(inputs_vec[0].ty(), &Type::Int);
+
+        let outputs_vec: mayheap::Vec<_, 8> = method.outputs().collect();
+        assert_eq!(outputs_vec[0].name(), "name");
+        assert_eq!(outputs_vec[0].ty(), &Type::String);
+    }
+
+    #[test]
+    fn method_no_params() {
+        let method = Method::new("Ping", &[], &[]);
+        assert_eq!(method.name(), "Ping");
+        assert!(method.has_no_inputs());
+        assert!(method.has_no_outputs());
+    }
+
+    #[test]
+    fn method_serialization() {
+        let input_x = Parameter::new("x", <f64>::TYPE_INFO);
+        let input_y = Parameter::new("y", <f64>::TYPE_INFO);
+        let output = Parameter::new("distance", <f64>::TYPE_INFO);
+        let inputs = [&input_x, &input_y];
+        let outputs = [&output];
+
+        let method = Method::new("CalculateDistance", &inputs, &outputs);
+
+        // Check the parameters individually - order and values.
+        let inputs_vec: mayheap::Vec<_, 8> = method.inputs().collect();
+        assert_eq!(inputs_vec[0].name(), "x");
+        assert_eq!(inputs_vec[0].ty(), &Type::Float);
+        assert_eq!(inputs_vec[1].name(), "y");
+        assert_eq!(inputs_vec[1].ty(), &Type::Float);
+
+        let outputs_vec: mayheap::Vec<_, 8> = method.outputs().collect();
+        assert_eq!(outputs_vec[0].name(), "distance");
+        assert_eq!(outputs_vec[0].ty(), &Type::Float);
+
+        #[cfg(feature = "std")]
+        let json = serde_json::to_string(&method).unwrap();
+        #[cfg(feature = "embedded")]
+        let json = {
+            let mut buffer = [0u8; 128];
+            let len = serde_json_core::to_slice(&method, &mut buffer).unwrap();
+            let vec = mayheap::Vec::<_, 128>::from_slice(&buffer[..len]).unwrap();
+            mayheap::String::<128>::from_utf8(vec).unwrap()
+        };
+        assert_eq!(
+            json,
+            r#""method CalculateDistance(x: float, y: float) -> (distance: float)""#
+        );
+    }
+}

--- a/zlink-core/src/idl/mod.rs
+++ b/zlink-core/src/idl/mod.rs
@@ -1,0 +1,35 @@
+//! Interface Definition Language (IDL) support for Varlink.
+//!
+//! This module provides types and parsers for working with Varlink IDL definitions.
+
+#![deny(missing_docs)]
+
+mod list;
+pub use list::List;
+
+mod r#type;
+pub use r#type::{Type, TypeRef};
+
+mod custom_type;
+pub use custom_type::{CustomType, Field, Parameter};
+
+mod method;
+pub use method::Method;
+
+mod error;
+pub use error::Error;
+
+mod member;
+pub use member::Member;
+
+mod interface;
+pub use interface::Interface;
+
+mod type_info;
+pub use type_info::TypeInfo;
+
+mod reply_errors;
+pub use reply_errors::ReplyErrors;
+
+#[cfg(feature = "idl-parse")]
+mod parse;

--- a/zlink-core/src/idl/parse.rs
+++ b/zlink-core/src/idl/parse.rs
@@ -1,0 +1,636 @@
+//! Parsers for Varlink IDL using winnow.
+//!
+//! This module provides parsers for converting IDL strings into the corresponding
+//! Rust types defined in the parent module. Uses byte-based parsing to avoid UTF-8 overhead.
+
+use winnow::{
+    branch::alt,
+    bytes::{tag, take_while0},
+    character::multispace0,
+    multi::separated0,
+    IResult, Parser,
+};
+
+use super::{CustomType, Error, Field, Interface, List, Member, Method, Parameter, Type, TypeRef};
+
+#[cfg(feature = "std")]
+use std::vec::Vec;
+
+/// Parse whitespace.
+fn ws(input: &[u8]) -> IResult<&[u8], ()> {
+    multispace0.map(|_| ()).parse_next(input)
+}
+
+/// Convert bytes to str with input lifetime.
+fn bytes_to_str(bytes: &[u8]) -> &str {
+    // SAFETY: We only accept ASCII characters in our parsers
+    core::str::from_utf8(bytes).unwrap()
+}
+
+/// Parse a field name: starts with letter, continues with alphanumeric and underscores.
+fn field_name(input: &[u8]) -> IResult<&[u8], &str> {
+    let mut pos = 0;
+
+    // First character must be alphabetic
+    if pos >= input.len() || !input[pos].is_ascii_alphabetic() {
+        return Err(winnow::error::ErrMode::Backtrack(
+            winnow::error::Error::new(input, winnow::error::ErrorKind::Alpha),
+        ));
+    }
+    pos += 1;
+
+    // Continue with alphanumeric and underscores
+    while pos < input.len() && (input[pos].is_ascii_alphanumeric() || input[pos] == b'_') {
+        pos += 1;
+    }
+
+    let name_bytes = &input[0..pos];
+    let remaining = &input[pos..];
+    Ok((remaining, bytes_to_str(name_bytes)))
+}
+
+/// Parse a type name: starts with uppercase letter, continues with alphanumeric.
+fn type_name(input: &[u8]) -> IResult<&[u8], &str> {
+    if input.is_empty() || !input[0].is_ascii_uppercase() {
+        return Err(winnow::error::ErrMode::Backtrack(
+            winnow::error::Error::new(input, winnow::error::ErrorKind::Alpha),
+        ));
+    }
+
+    let mut end = 1;
+    while end < input.len() && input[end].is_ascii_alphanumeric() {
+        end += 1;
+    }
+
+    let name_bytes = &input[0..end];
+    let remaining = &input[end..];
+    Ok((remaining, bytes_to_str(name_bytes)))
+}
+
+/// Parse a primitive type.
+fn primitive_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    alt((
+        tag("bool").map(|_| Type::Bool),
+        tag("int").map(|_| Type::Int),
+        tag("float").map(|_| Type::Float),
+        tag("string").map(|_| Type::String),
+        tag("object").map(|_| Type::Object),
+    ))
+    .parse_next(input)
+}
+
+/// Parse a field in a struct or parameter list.
+fn field<'a>(input: &'a [u8]) -> IResult<&'a [u8], Field<'a>> {
+    let (input, name) = field_name(input)?;
+    let (input, _) = ws(input)?;
+    let (input, _) = tag(":")(input)?;
+    let (input, _) = ws(input)?;
+    let (input, ty) = varlink_type(input)?;
+    Ok((input, Field::new_owned(name, ty)))
+}
+
+/// Parse an inline struct type: (field1: type1, field2: type2).
+fn struct_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    let (input, _) = tag("(")(input)?;
+    let (input, _) = ws(input)?;
+    let (input, fields): (&[u8], Vec<Field<'a>>) = separated0(field, (ws, tag(","), ws))(input)?;
+    let (input, _) = ws(input)?;
+    let (input, _) = tag(")")(input)?;
+    Ok((input, Type::Struct(List::from(fields))))
+}
+
+/// Parse an inline enum type: (variant1, variant2, variant3).
+fn enum_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    let (input, _) = tag("(")(input)?;
+    let (input, _) = ws(input)?;
+    let (input, variants): (&[u8], Vec<&str>) = separated0(field_name, (ws, tag(","), ws))(input)?;
+    let (input, _) = ws(input)?;
+    let (input, _) = tag(")")(input)?;
+    Ok((input, Type::Enum(List::from(variants))))
+}
+
+/// Parse an inline type (struct or enum).
+/// Determines if it's a struct by looking for ':' character.
+fn inline_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    // Look ahead to see if this contains a colon (indicating struct)
+    if let Some(pos) = input.iter().position(|&b| b == b')') {
+        let content = &input[1..pos]; // Skip opening paren
+        if content.contains(&b':') {
+            struct_type(input)
+        } else {
+            enum_type(input)
+        }
+    } else {
+        Err(winnow::error::ErrMode::Backtrack(
+            winnow::error::Error::new(input, winnow::error::ErrorKind::Tag),
+        ))
+    }
+}
+
+/// Parse an element type (primitive, custom, or inline).
+fn element_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    alt((primitive_type, type_name.map(Type::Custom), inline_type))(input)
+}
+
+/// Parse an optional type: ?type.
+fn optional_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    let (input, _) = tag("?")(input)?;
+    let (input, inner) = non_optional_type(input)?;
+    Ok((input, Type::Optional(TypeRef::new(inner))))
+}
+
+/// Parse any type except optional (to avoid recursion).
+fn non_optional_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    alt((array_type, map_type, element_type))(input)
+}
+
+/// Parse an array type: []type.
+fn array_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    let (input, _) = tag("[]")(input)?;
+    let (input, inner) = varlink_type(input)?;
+    Ok((input, Type::Array(TypeRef::new(inner))))
+}
+
+/// Parse a map type: [string]type.
+fn map_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    let (input, _) = tag("[string]")(input)?;
+    let (input, inner) = varlink_type(input)?;
+    Ok((input, Type::Map(TypeRef::new(inner))))
+}
+
+/// Parse any Varlink type.
+fn varlink_type<'a>(input: &'a [u8]) -> IResult<&'a [u8], Type<'a>> {
+    alt((optional_type, array_type, map_type, element_type))(input)
+}
+
+/// Parse a Varlink type from a string.
+pub(super) fn parse_type(input: &str) -> Result<Type<'_>, &'static str> {
+    let input_bytes = input.trim().as_bytes();
+    if input_bytes.is_empty() {
+        return Err("Empty input");
+    }
+
+    match varlink_type(input_bytes) {
+        Ok((remaining, result)) => {
+            if remaining.is_empty() {
+                Ok(result)
+            } else {
+                Err("Unexpected remaining input")
+            }
+        }
+        Err(_) => Err("Parse error"),
+    }
+}
+
+/// Parse an interface name: reverse domain notation like org.example.test.
+fn interface_name(input: &[u8]) -> IResult<&[u8], &str> {
+    let mut pos = 0;
+
+    // First segment: [A-Za-z]([-]*[A-Za-z0-9])*
+    if pos >= input.len() || !input[pos].is_ascii_alphabetic() {
+        return Err(winnow::error::ErrMode::Backtrack(
+            winnow::error::Error::new(input, winnow::error::ErrorKind::Alpha),
+        ));
+    }
+    pos += 1;
+
+    while pos < input.len() && (input[pos].is_ascii_alphanumeric() || input[pos] == b'-') {
+        pos += 1;
+    }
+
+    // Must have at least one dot and more segments
+    let mut found_dot = false;
+    while pos < input.len() && input[pos] == b'.' {
+        found_dot = true;
+        pos += 1;
+
+        // Next segment: [A-Za-z0-9]([-]*[A-Za-z0-9])*
+        if pos >= input.len() || !input[pos].is_ascii_alphanumeric() {
+            break;
+        }
+        pos += 1;
+
+        while pos < input.len() && (input[pos].is_ascii_alphanumeric() || input[pos] == b'-') {
+            pos += 1;
+        }
+    }
+
+    if !found_dot {
+        return Err(winnow::error::ErrMode::Backtrack(
+            winnow::error::Error::new(input, winnow::error::ErrorKind::Alpha),
+        ));
+    }
+
+    let name_bytes = &input[0..pos];
+    let remaining = &input[pos..];
+    Ok((remaining, bytes_to_str(name_bytes)))
+}
+
+/// Parse a parameter definition: name: type.
+fn parameter<'a>(input: &'a [u8]) -> IResult<&'a [u8], Parameter<'a>> {
+    let (input, name) = field_name(input)?;
+    let (input, _) = ws(input)?;
+    let (input, _) = tag(":")(input)?;
+    let (input, _) = ws(input)?;
+    let (input, ty) = varlink_type(input)?;
+    Ok((input, Parameter::new_owned(name, ty)))
+}
+
+/// Parse a parameter list: (param1: type1, param2: type2).
+fn parameter_list<'a>(input: &'a [u8]) -> IResult<&'a [u8], Vec<Parameter<'a>>> {
+    let (input, _) = tag("(")(input)?;
+    let (input, _) = ws(input)?;
+    let (input, params): (&[u8], Vec<Parameter<'a>>) =
+        separated0(parameter, (ws, tag(","), ws))(input)?;
+    let (input, _) = ws(input)?;
+    let (input, _) = tag(")")(input)?;
+    Ok((input, params))
+}
+
+/// Parse a method definition: method Name(params) -> (returns).
+fn method_def<'a>(input: &'a [u8]) -> IResult<&'a [u8], Method<'a>> {
+    let (input, _) = tag("method")(input)?;
+    let (input, _) = take_while0(|c: u8| c.is_ascii_whitespace())(input)?;
+    let (input, name) = type_name(input)?;
+    let (input, _) = ws(input)?;
+    let (input, input_params) = parameter_list(input)?;
+    let (input, _) = ws(input)?;
+    let (input, _) = tag("->")(input)?;
+    let (input, _) = ws(input)?;
+    let (input, output_params) = parameter_list(input)?;
+
+    Ok((input, Method::new_owned(name, input_params, output_params)))
+}
+
+/// Parse an error definition: error Name(params).
+fn error_def<'a>(input: &'a [u8]) -> IResult<&'a [u8], Error<'a>> {
+    let (input, _) = tag("error")(input)?;
+    let (input, _) = take_while0(|c: u8| c.is_ascii_whitespace())(input)?;
+    let (input, name) = type_name(input)?;
+    let (input, _) = ws(input)?;
+    let (input, params) = parameter_list(input)?;
+
+    Ok((input, Error::new_owned(name, params)))
+}
+
+/// Parse a type definition: type Name (fields).
+fn type_def<'a>(input: &'a [u8]) -> IResult<&'a [u8], CustomType<'a>> {
+    let (input, _) = tag("type")(input)?;
+    let (input, _) = take_while0(|c: u8| c.is_ascii_whitespace())(input)?;
+    let (input, name) = type_name(input)?;
+    let (input, _) = ws(input)?;
+    let (input, _) = tag("(")(input)?;
+    let (input, _) = ws(input)?;
+
+    // Parse as struct - type definitions must have typed fields
+    let (input, fields): (&[u8], Vec<Field<'a>>) = separated0(field, (ws, tag(","), ws))(input)?;
+    let (input, _) = ws(input)?;
+    let (input, _) = tag(")")(input)?;
+    Ok((input, CustomType::new_owned(name, fields)))
+}
+
+/// Parse a member definition (type, method, or error).
+fn member_def<'a>(input: &'a [u8]) -> IResult<&'a [u8], Member<'a>> {
+    alt((
+        type_def.map(Member::Custom),
+        method_def.map(Member::Method),
+        error_def.map(Member::Error),
+    ))(input)
+}
+
+/// Parse a complete interface definition.
+fn interface_def<'a>(input: &'a [u8]) -> IResult<&'a [u8], Interface<'a>> {
+    let (input, _) = ws(input)?;
+    let (input, _) = tag("interface")(input)?;
+    let (input, _) = take_while0(|c: u8| c.is_ascii_whitespace())(input)?;
+    let (input, name) = interface_name(input)?;
+    let (input, _) = ws(input)?;
+
+    // Parse members separated by whitespace/newlines
+    let mut members = Vec::new();
+    let mut remaining = input;
+
+    while !remaining.is_empty() {
+        let (new_remaining, _) = ws(remaining)?;
+        remaining = new_remaining;
+
+        if remaining.is_empty() {
+            break;
+        }
+
+        match member_def(remaining) {
+            Ok((new_remaining, member)) => {
+                members.push(member);
+                remaining = new_remaining;
+            }
+            Err(_) => break,
+        }
+    }
+
+    Ok((remaining, Interface::new_owned(name, members)))
+}
+
+/// Parse an interface from a string.
+pub(super) fn parse_interface(input: &str) -> Result<Interface<'_>, &'static str> {
+    parse_from_str(input, interface_def)
+}
+
+/// Parse a member from a string.
+pub(super) fn parse_member(input: &str) -> Result<Member<'_>, &'static str> {
+    parse_from_str(input, member_def)
+}
+
+/// Parse a method from a string.
+pub(super) fn parse_method(input: &str) -> Result<Method<'_>, &'static str> {
+    parse_from_str(input, method_def)
+}
+
+/// Parse an error from a string.
+pub(super) fn parse_error(input: &str) -> Result<Error<'_>, &'static str> {
+    parse_from_str(input, error_def)
+}
+
+/// Parse a custom type from a string.
+pub(super) fn parse_custom_type(input: &str) -> Result<CustomType<'_>, &'static str> {
+    parse_from_str(input, type_def)
+}
+
+/// Parse a field from a string.
+pub(super) fn parse_field(input: &str) -> Result<Field<'_>, &'static str> {
+    parse_from_str(input, field)
+}
+
+/// Helper function to parse from string using byte-based parsers.
+fn parse_from_str<'a, T>(
+    input: &'a str,
+    parser: impl Fn(&'a [u8]) -> IResult<&'a [u8], T>,
+) -> Result<T, &'static str> {
+    let input_bytes = input.trim().as_bytes();
+    if input_bytes.is_empty() {
+        return Err("Empty input");
+    }
+
+    match parser(input_bytes) {
+        Ok((remaining, result)) => {
+            let (remaining, _) = ws(remaining).unwrap_or((remaining, ()));
+            if remaining.is_empty() {
+                Ok(result)
+            } else {
+                Err("Unexpected remaining input")
+            }
+        }
+        Err(_) => Err("Parse error"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_primitive_types() {
+        assert_eq!(parse_type("bool").unwrap(), Type::Bool);
+        assert_eq!(parse_type("int").unwrap(), Type::Int);
+        assert_eq!(parse_type("float").unwrap(), Type::Float);
+        assert_eq!(parse_type("string").unwrap(), Type::String);
+        assert_eq!(parse_type("object").unwrap(), Type::Object);
+    }
+
+    #[test]
+    fn test_parse_custom_types() {
+        match parse_type("Person").unwrap() {
+            Type::Custom(name) => {
+                assert_eq!(name, "Person");
+            }
+            _ => panic!("Expected custom type"),
+        }
+    }
+
+    #[test]
+    fn test_parse_composite_types() {
+        // Test optional type
+        match parse_type("?int").unwrap() {
+            Type::Optional(optional) => {
+                assert_eq!(*optional, Type::Int);
+            }
+            _ => panic!("Expected optional type"),
+        }
+
+        // Test array type
+        match parse_type("[]string").unwrap() {
+            Type::Array(array) => {
+                assert_eq!(*array, Type::String);
+            }
+            _ => panic!("Expected array type"),
+        }
+
+        // Test map type
+        match parse_type("[string]bool").unwrap() {
+            Type::Map(map) => {
+                assert_eq!(*map, Type::Bool);
+            }
+            _ => panic!("Expected map type"),
+        }
+    }
+
+    #[test]
+    fn test_parse_nested_types() {
+        // Test nested optional array
+        match parse_type("?[]string").unwrap() {
+            Type::Optional(optional) => match &*optional {
+                Type::Array(array) => {
+                    assert_eq!(*array, Type::String);
+                }
+                _ => panic!("Expected array inside optional"),
+            },
+            _ => panic!("Expected optional type"),
+        }
+    }
+
+    #[test]
+    fn test_parse_inline_enum() {
+        match parse_type("(one, two, three)").unwrap() {
+            Type::Enum(variants) => {
+                let collected: Vec<_> = variants.iter().collect();
+                assert_eq!(collected.len(), 3);
+            }
+            _ => panic!("Expected enum type"),
+        }
+    }
+
+    #[test]
+    fn test_parse_inline_struct() {
+        match parse_type("(x: float, y: float)").unwrap() {
+            Type::Struct(fields) => {
+                let collected: Vec<_> = fields.iter().collect();
+                assert_eq!(collected.len(), 2);
+                assert_eq!(collected[0].name(), "x");
+                assert_eq!(collected[0].ty(), &Type::Float);
+                assert_eq!(collected[1].name(), "y");
+                assert_eq!(collected[1].ty(), &Type::Float);
+            }
+            _ => panic!("Expected struct type"),
+        }
+    }
+
+    #[test]
+    fn test_parse_whitespace() {
+        // Test that whitespace is handled correctly
+        assert_eq!(parse_type("  bool  ").unwrap(), Type::Bool);
+        assert_eq!(parse_type("\tbool\n").unwrap(), Type::Bool);
+    }
+
+    #[test]
+    fn test_parse_errors() {
+        assert!(parse_type("").is_err());
+        assert!(parse_type("invalid").is_err());
+        assert!(parse_type("bool extra").is_err());
+    }
+
+    #[test]
+    fn test_parse_interface_name() {
+        let input = b"org.example.test";
+        let (remaining, result) = interface_name(input).unwrap();
+        assert_eq!(result, "org.example.test");
+        assert!(remaining.is_empty());
+
+        let input = b"com.example.foo.bar";
+        let (remaining, result) = interface_name(input).unwrap();
+        assert_eq!(result, "com.example.foo.bar");
+        assert!(remaining.is_empty());
+
+        // Invalid: no dot
+        assert!(interface_name(b"example").is_err());
+
+        // Invalid: starts with number
+        assert!(interface_name(b"1example.test").is_err());
+    }
+
+    #[test]
+    fn test_parse_method() {
+        let input = "method GetInfo() -> (info: string)";
+        let method = parse_method(input).unwrap();
+        assert_eq!(method.name(), "GetInfo");
+        assert_eq!(method.inputs().count(), 0);
+        let mut outputs = method.outputs();
+        assert_eq!(
+            outputs.next().unwrap(),
+            &Parameter::new("info", &Type::String)
+        );
+        assert!(outputs.next().is_none());
+
+        let input = "method Add(a: int, b: int) -> (sum: int)";
+        let method = parse_method(input).unwrap();
+        assert_eq!(method.name(), "Add");
+        let mut inputs = method.inputs();
+        assert_eq!(inputs.next().unwrap(), &Parameter::new("a", &Type::Int));
+        assert_eq!(inputs.next().unwrap(), &Parameter::new("b", &Type::Int));
+        assert!(inputs.next().is_none());
+        let mut outputs = method.outputs();
+        assert_eq!(outputs.next().unwrap(), &Parameter::new("sum", &Type::Int));
+        assert!(outputs.next().is_none());
+    }
+
+    #[test]
+    fn test_parse_error() {
+        let input = "error NotFound(resource: string)";
+        let error = parse_error(input).unwrap();
+        assert_eq!(error.name(), "NotFound");
+        assert_eq!(error.fields().count(), 1);
+        let mut fields = error.fields();
+        assert_eq!(
+            fields.next().unwrap(),
+            &Field::new("resource", &Type::String)
+        );
+        assert!(fields.next().is_none());
+
+        let input = "error InvalidInput()";
+        let error = parse_error(input).unwrap();
+        assert_eq!(error.name(), "InvalidInput");
+        assert_eq!(error.fields().count(), 0);
+    }
+
+    #[test]
+    fn test_parse_custom_type() {
+        let input = "type Person (name: string, age: int)";
+        let custom_type = parse_custom_type(input).unwrap();
+        assert_eq!(custom_type.name(), "Person");
+        let mut fields = custom_type.fields();
+        assert_eq!(fields.next().unwrap(), &Field::new("name", &Type::String));
+        assert_eq!(fields.next().unwrap(), &Field::new("age", &Type::Int));
+        assert!(fields.next().is_none());
+
+        let input = "type Config (host: string, port: int, enabled: bool)";
+        let custom_type = parse_custom_type(input).unwrap();
+        assert_eq!(custom_type.name(), "Config");
+        assert_eq!(custom_type.fields().count(), 3);
+        let mut fields = custom_type.fields();
+        assert_eq!(fields.next().unwrap(), &Field::new("host", &Type::String));
+        assert_eq!(fields.next().unwrap(), &Field::new("port", &Type::Int));
+        assert_eq!(fields.next().unwrap(), &Field::new("enabled", &Type::Bool));
+        assert!(fields.next().is_none());
+
+        // Invalid: enum-style definitions are not allowed for type definitions
+        assert!(parse_custom_type("type Color (red, green, blue)").is_err());
+    }
+
+    #[test]
+    fn test_parse_field() {
+        let input = "name: string";
+        let field = parse_field(input).unwrap();
+        assert_eq!(field.name(), "name");
+        assert_eq!(field.ty(), &Type::String);
+
+        let input = "items: []int";
+        let field = parse_field(input).unwrap();
+        assert_eq!(field.name(), "items");
+        assert_eq!(field.ty(), &Type::Array(TypeRef::borrowed(&Type::Int)));
+    }
+
+    #[test]
+    fn test_parse_interface() {
+        let input = r#"
+interface org.example.test
+
+type Person (name: string, age: int)
+
+method GetPerson(id: int) -> (person: Person)
+
+error NotFound(id: int)
+        "#;
+
+        let interface = parse_interface(input).unwrap();
+        assert_eq!(interface.name(), "org.example.test");
+        assert_eq!(interface.members().count(), 3);
+    }
+
+    #[test]
+    fn test_deserialize_functionality() {
+        // Test that serde_json deserialization works correctly
+        let method_json = r#""method GetInfo() -> (info: string)""#;
+        let method: Method<'_> = serde_json::from_str(method_json).unwrap();
+        assert_eq!(method.name(), "GetInfo");
+        assert_eq!(method.inputs().count(), 0);
+        assert_eq!(method.outputs().count(), 1);
+
+        let error_json = r#""error NotFound(id: int)""#;
+        let error: Error<'_> = serde_json::from_str(error_json).unwrap();
+        assert_eq!(error.name(), "NotFound");
+        let mut fields = error.fields();
+        assert_eq!(fields.next().unwrap(), &Field::new("id", &Type::Int));
+        assert!(fields.next().is_none());
+
+        let custom_type_json = r#""type Person (name: string, age: int)""#;
+        let custom_type: CustomType<'_> = serde_json::from_str(custom_type_json).unwrap();
+        assert_eq!(custom_type.name(), "Person");
+        let mut fields = custom_type.fields();
+        assert_eq!(fields.next().unwrap(), &Field::new("name", &Type::String));
+        assert_eq!(fields.next().unwrap(), &Field::new("age", &Type::Int));
+        assert!(fields.next().is_none());
+
+        let field_json = r#""name: string""#;
+        let field: Field<'_> = serde_json::from_str(field_json).unwrap();
+        assert_eq!(field.name(), "name");
+        assert_eq!(field.ty(), &Type::String);
+    }
+}

--- a/zlink-core/src/idl/reply_errors.rs
+++ b/zlink-core/src/idl/reply_errors.rs
@@ -1,0 +1,27 @@
+use super::Error;
+
+/// Introspection trait for method reply errors type.
+pub trait ReplyErrors {
+    /// The list of possible errors this type can return.
+    const REPLY_ERRORS: &'static [&'static Error<'static>];
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reply_errors() {
+        // Test with a type that implements ReplyErrors.
+        struct MyType;
+
+        const MY_ERROR: Error<'static> = Error::new("MyError", &[]);
+
+        impl ReplyErrors for MyType {
+            const REPLY_ERRORS: &'static [&'static Error<'static>] = &[&MY_ERROR];
+        }
+
+        assert_eq!(MyType::REPLY_ERRORS.len(), 1);
+        assert_eq!(MyType::REPLY_ERRORS[0].name(), "MyError");
+    }
+}

--- a/zlink-core/src/idl/type/mod.rs
+++ b/zlink-core/src/idl/type/mod.rs
@@ -1,0 +1,202 @@
+//! Type definitions for Varlink IDL.
+
+mod type_ref;
+pub use type_ref::TypeRef;
+
+use core::fmt;
+use serde::Serialize;
+
+#[cfg(feature = "idl-parse")]
+use serde::Deserialize;
+
+use super::{Field, List};
+
+/// Represents a type in Varlink IDL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Type<'a> {
+    /// Boolean type.
+    Bool,
+    /// 64-bit signed integer.
+    Int,
+    /// 64-bit floating point.
+    Float,
+    /// UTF-8 string.
+    String,
+    /// Foreign untyped object.
+    Object,
+    /// Optional/nullable type.
+    Optional(TypeRef<'a>),
+    /// Array type.
+    Array(TypeRef<'a>),
+    /// Map type with string keys.
+    Map(TypeRef<'a>),
+    /// Custom named type reference.
+    Custom(&'a str),
+    /// Inline enum type.
+    Enum(List<'a, &'a str>),
+    /// Inline struct type.
+    Struct(List<'a, Field<'a>>),
+}
+
+impl<'a> fmt::Display for Type<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Type::Bool => write!(f, "bool"),
+            Type::Int => write!(f, "int"),
+            Type::Float => write!(f, "float"),
+            Type::String => write!(f, "string"),
+            Type::Object => write!(f, "object"),
+            Type::Optional(optional) => write!(f, "?{}", optional),
+            Type::Array(array) => write!(f, "[]{}", array),
+            Type::Map(map) => write!(f, "[string]{}", map),
+            Type::Custom(name) => write!(f, "{}", name),
+            Type::Enum(variants) => {
+                write!(f, "(")?;
+                let mut first = true;
+                for variant in variants.iter() {
+                    if !first {
+                        write!(f, ", ")?;
+                    }
+                    first = false;
+                    write!(f, "{}", variant)?;
+                }
+                write!(f, ")")
+            }
+            Type::Struct(fields) => {
+                write!(f, "(")?;
+                let mut first = true;
+                for field in fields.iter() {
+                    if !first {
+                        write!(f, ", ")?;
+                    }
+                    first = false;
+                    write!(f, "{}", field)?;
+                }
+                write!(f, ")")
+            }
+        }
+    }
+}
+
+impl<'a> PartialEq<TypeRef<'a>> for Type<'a> {
+    fn eq(&self, other: &TypeRef<'a>) -> bool {
+        self == other.inner()
+    }
+}
+
+impl<'a> Serialize for Type<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de, 'a> Deserialize<'de> for Type<'a>
+where
+    'de: 'a,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <&str>::deserialize(deserializer)?;
+        super::parse::parse_type(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn type_names() {
+        use core::fmt::Write;
+        let mut buf = mayheap::String::<32>::new();
+
+        buf.clear();
+        write!(buf, "{}", Type::Bool).unwrap();
+        assert_eq!(buf, "bool");
+
+        buf.clear();
+        write!(buf, "{}", Type::Int).unwrap();
+        assert_eq!(buf, "int");
+
+        buf.clear();
+        write!(buf, "{}", Type::Float).unwrap();
+        assert_eq!(buf, "float");
+
+        buf.clear();
+        write!(buf, "{}", Type::String).unwrap();
+        assert_eq!(buf, "string");
+
+        buf.clear();
+        write!(buf, "{}", Type::Object).unwrap();
+        assert_eq!(buf, "object");
+    }
+
+    #[test]
+    fn complex_type_names() {
+        // Test with const-friendly borrowed variants
+        const INT_TYPE: Type<'static> = Type::Int;
+        const STRING_TYPE: Type<'static> = Type::String;
+        const BOOL_TYPE: Type<'static> = Type::Bool;
+
+        use core::fmt::Write;
+        let mut buf = mayheap::String::<64>::new();
+
+        buf.clear();
+        write!(buf, "{}", Type::Optional(TypeRef::borrowed(&INT_TYPE))).unwrap();
+        assert_eq!(buf, "?int");
+
+        buf.clear();
+        write!(buf, "{}", Type::Array(TypeRef::borrowed(&STRING_TYPE))).unwrap();
+        assert_eq!(buf, "[]string");
+
+        buf.clear();
+        write!(buf, "{}", Type::Map(TypeRef::borrowed(&BOOL_TYPE))).unwrap();
+        assert_eq!(buf, "[string]bool");
+
+        // Test with owned variants
+        #[cfg(feature = "std")]
+        {
+            assert_eq!(Type::Optional(TypeRef::new(Type::Int)).to_string(), "?int");
+            assert_eq!(
+                Type::Array(TypeRef::new(Type::String)).to_string(),
+                "[]string"
+            );
+
+            // Test complex nested types
+            let nested_type = Type::Array(TypeRef::new(Type::Optional(TypeRef::new(Type::String))));
+            assert_eq!(nested_type.to_string(), "[]?string");
+
+            // Test inline enum
+            let enum_type = Type::Enum(List::from(vec!["one", "two", "three"]));
+            assert_eq!(enum_type.to_string(), "(one, two, three)");
+
+            // Test inline struct
+            let struct_type = Type::Struct(List::from(vec![
+                Field::new("first", &Type::Int),
+                Field::new("second", &Type::String),
+            ]));
+            assert_eq!(struct_type.to_string(), "(first: int, second: string)");
+        }
+    }
+
+    #[test]
+    fn type_serialization() {
+        let ty = Type::Array(TypeRef::borrowed(&Type::Int));
+        #[cfg(feature = "std")]
+        let json = serde_json::to_string(&ty).unwrap();
+        #[cfg(feature = "embedded")]
+        let json = {
+            let mut buffer = [0u8; 16];
+            let len = serde_json_core::to_slice(&ty, &mut buffer).unwrap();
+            let vec = mayheap::Vec::<_, 16>::from_slice(&buffer[..len]).unwrap();
+            mayheap::String::<16>::from_utf8(vec).unwrap()
+        };
+        assert_eq!(json, r#""[]int""#);
+    }
+}

--- a/zlink-core/src/idl/type/type_ref.rs
+++ b/zlink-core/src/idl/type/type_ref.rs
@@ -1,0 +1,73 @@
+use super::Type;
+use core::{fmt, ops::Deref};
+#[cfg(feature = "std")]
+use std::boxed::Box;
+
+impl<'a> TypeRef<'a> {
+    /// Creates a new type reference with an owned type.
+    #[cfg(feature = "std")]
+    pub fn new(inner: Type<'a>) -> Self {
+        Self(TypeRefInner::Owned(Box::new(inner)))
+    }
+
+    /// Creates a new type reference with a borrowed type reference.
+    pub const fn borrowed(inner: &'a Type<'a>) -> Self {
+        Self(TypeRefInner::Borrowed(inner))
+    }
+
+    /// Returns a reference to the inner type.
+    pub fn inner(&self) -> &Type<'a> {
+        self.0.ty()
+    }
+}
+
+impl<'a> Deref for TypeRef<'a> {
+    type Target = Type<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        self.inner()
+    }
+}
+
+impl<'a> fmt::Display for TypeRef<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.inner())
+    }
+}
+
+impl<'a> PartialEq<Type<'a>> for TypeRef<'a> {
+    fn eq(&self, other: &Type<'a>) -> bool {
+        self.inner() == other
+    }
+}
+
+/// A type reference that can be either borrowed or owned.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeRef<'a>(TypeRefInner<'a>);
+
+#[derive(Debug, Clone, Eq)]
+enum TypeRefInner<'a> {
+    Borrowed(&'a Type<'a>),
+    #[cfg(feature = "std")]
+    Owned(Box<Type<'a>>),
+}
+
+impl<'a> TypeRefInner<'a> {
+    /// A reference to the inner type.
+    fn ty(&self) -> &Type<'a> {
+        match self {
+            TypeRefInner::Borrowed(inner) => *inner,
+            #[cfg(feature = "std")]
+            TypeRefInner::Owned(inner) => &inner,
+        }
+    }
+}
+
+impl PartialEq for TypeRefInner<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        let ty = self.ty();
+        let other_ty = other.ty();
+
+        ty.eq(other_ty)
+    }
+}

--- a/zlink-core/src/idl/type_info.rs
+++ b/zlink-core/src/idl/type_info.rs
@@ -1,0 +1,95 @@
+use super::{Type, TypeRef};
+
+/// Type introspection.
+pub trait TypeInfo {
+    /// The type information.
+    const TYPE_INFO: &'static Type<'static>;
+}
+
+/// Macro to implement TypeInfo for multiple types with the same Type variant.
+macro_rules! impl_type_info {
+    ($($ty:ty),* => $variant:expr) => {
+        $(
+            impl TypeInfo for $ty {
+                const TYPE_INFO: &'static Type<'static> = &$variant;
+            }
+        )*
+    };
+}
+
+// Implementations for primitive types.
+impl_type_info!(bool => Type::Bool);
+impl_type_info!(i8, i16, i32, i64, u8, u16, u32, u64 => Type::Int);
+impl_type_info!(f32, f64 => Type::Float);
+impl_type_info!(&str => Type::String);
+
+#[cfg(feature = "std")]
+impl_type_info!(String => Type::String);
+
+// Optional types.
+impl<T: TypeInfo> TypeInfo for Option<T> {
+    const TYPE_INFO: &'static Type<'static> = &Type::Optional(TypeRef::borrowed(T::TYPE_INFO));
+}
+
+// Array types.
+#[cfg(feature = "std")]
+impl<T: TypeInfo> TypeInfo for Vec<T> {
+    const TYPE_INFO: &'static Type<'static> = &Type::Array(TypeRef::borrowed(T::TYPE_INFO));
+}
+
+impl<T: TypeInfo> TypeInfo for &[T] {
+    const TYPE_INFO: &'static Type<'static> = &Type::Array(TypeRef::borrowed(T::TYPE_INFO));
+}
+
+// For raw objects.
+#[cfg(feature = "std")]
+impl TypeInfo for serde_json::Value {
+    const TYPE_INFO: &'static Type<'static> = &Type::Object;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn primitive_type_info() {
+        assert_eq!(*bool::TYPE_INFO, Type::Bool);
+        assert_eq!(*i32::TYPE_INFO, Type::Int);
+        assert_eq!(*f64::TYPE_INFO, Type::Float);
+        assert_eq!(*<&str>::TYPE_INFO, Type::String);
+        #[cfg(feature = "std")]
+        {
+            assert_eq!(*String::TYPE_INFO, Type::String);
+        }
+    }
+
+    #[test]
+    fn optional_type_info() {
+        match <Option<i32>>::TYPE_INFO {
+            Type::Optional(optional) => assert_eq!(*optional, Type::Int),
+            _ => panic!("Expected optional type"),
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn array_type_info() {
+        match <Vec<String>>::TYPE_INFO {
+            Type::Array(array) => assert_eq!(*array, Type::String),
+            _ => panic!("Expected array type"),
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn complex_type_info() {
+        // Test Option<Vec<bool>>
+        match <Option<Vec<bool>>>::TYPE_INFO {
+            Type::Optional(optional) => match &**optional {
+                Type::Array(array) => assert_eq!(*array, Type::Bool),
+                _ => panic!("Expected array inside optional"),
+            },
+            _ => panic!("Expected optional type"),
+        }
+    }
+}

--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -28,3 +28,5 @@ mod call;
 pub use call::Call;
 pub mod reply;
 pub use reply::Reply;
+#[cfg(feature = "idl")]
+pub mod idl;


### PR DESCRIPTION
Add API to handle parsing and serialization of
[Varlink Interface Definition Language](https://varlink.org/Interface-Definition).

This module is only enabled when `idl` feature is enabled. The parsing unfortunately requires
allocation and hence need the `std` feature. Fortunately parsing is not required on the server
side, which is the interesting part of embedded targets.

