### PR TITLE
🚸 core: Promote varlink_service::InterfaceDescription

### DIFF
--- a/zlink-core/src/varlink_service/interface_description.rs
+++ b/zlink-core/src/varlink_service/interface_description.rs
@@ -1,0 +1,123 @@
+use core::fmt::Debug;
+
+use crate::{idl::Interface, introspect::Type};
+#[cfg(feature = "idl-parse")]
+use serde::Deserialize;
+use serde::Serialize;
+
+/// The interface description.
+///
+/// Use [`InterfaceDescription::parse`] to get the [`Interface`].
+///
+/// Under the hood, the interface description is either a parsed [`Interface`] or a raw string.
+#[derive(Debug, Serialize, Type, Clone)]
+#[zlink(crate = "crate")]
+pub struct InterfaceDescription<'a> {
+    description: Description<'a>,
+}
+
+impl<'a> InterfaceDescription<'a> {
+    /// Parse the interface description as an [`Interface`].
+    ///
+    /// If the description is already parsed, it is returned as is. If the description is a raw
+    /// string, it is parsed as an [`Interface`] and returned.
+    pub fn parse(&self) -> crate::Result<Interface<'_>> {
+        match &self.description {
+            Description::Parsed(interface) => Ok(interface.clone()),
+            #[cfg(feature = "idl-parse")]
+            Description::Raw(description) => description.as_str().try_into(),
+        }
+    }
+
+    /// The raw interface description, if `self` is based on a raw description.
+    pub fn as_raw(&self) -> Option<&str> {
+        match &self.description {
+            Description::Parsed(_) => None,
+            #[cfg(feature = "idl-parse")]
+            Description::Raw(description) => Some(description.as_str()),
+        }
+    }
+}
+
+impl<'a> From<&Interface<'a>> for InterfaceDescription<'a> {
+    fn from(interface: &Interface<'a>) -> Self {
+        Self {
+            description: Description::Parsed(interface.clone()),
+        }
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de> Deserialize<'de> for InterfaceDescription<'static> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        use core::fmt;
+
+        use serde::de::{Error, MapAccess, Visitor};
+
+        struct IDVisitor;
+
+        impl<'de> Visitor<'de> for IDVisitor {
+            type Value = InterfaceDescription<'static>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("a valid interface description")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let (field_name, description): (&str, String) = map
+                    .next_entry()?
+                    .ok_or_else(|| A::Error::invalid_length(0, &self))?;
+                if field_name != "description" {
+                    return Err(A::Error::unknown_field(field_name, &["description"]));
+                }
+
+                Ok(InterfaceDescription {
+                    description: Description::Raw(description),
+                })
+            }
+        }
+
+        deserializer.deserialize_map(IDVisitor)
+    }
+}
+
+#[derive(Debug, Clone)]
+enum Description<'a> {
+    Parsed(Interface<'a>),
+    #[cfg(feature = "idl-parse")]
+    Raw(String),
+}
+
+impl Type for Description<'_> {
+    const TYPE: &'static crate::idl::Type<'static> = &crate::idl::Type::String;
+}
+
+impl Serialize for Description<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Description::Parsed(interface) => serializer.collect_str(interface),
+            #[cfg(feature = "idl-parse")]
+            Description::Raw(description) => serializer.serialize_str(description),
+        }
+    }
+}
+
+#[cfg(feature = "idl-parse")]
+impl<'de> Deserialize<'de> for Description<'static> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let description = String::deserialize(deserializer)?;
+        Ok(Description::Raw(description))
+    }
+}

--- a/zlink-core/src/varlink_service/mod.rs
+++ b/zlink-core/src/varlink_service/mod.rs
@@ -11,4 +11,7 @@ pub use error::{Error, Result};
 #[cfg(feature = "idl-parse")]
 mod proxy;
 #[cfg(feature = "idl-parse")]
-pub use proxy::{InterfaceDescription, Proxy};
+pub use proxy::Proxy;
+
+mod interface_description;
+pub use interface_description::InterfaceDescription;

--- a/zlink-macros/src/utils.rs
+++ b/zlink-macros/src/utils.rs
@@ -63,7 +63,11 @@ pub(crate) fn remove_lifetimes_from_type(ty: &Type) -> Type {
                                     ));
                                 }
                                 GenericArgument::Lifetime(_) => {
-                                    // Remove lifetime arguments entirely
+                                    // Replace with elided lifetime '_
+                                    new_args.push(GenericArgument::Lifetime(syn::Lifetime::new(
+                                        "'_",
+                                        proc_macro2::Span::call_site(),
+                                    )));
                                 }
                                 other => {
                                     new_args.push(other.clone());

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -23,8 +23,8 @@ impl MockMachinedService {
 impl Service for MockMachinedService {
     type MethodCall<'de> = MockMethod<'de>;
     type ReplyParams<'ser> = MockReply;
-    type ReplyStream = futures_util::stream::Empty<zlink::Reply<MockReply>>;
-    type ReplyStreamParams = MockReply;
+    type ReplyStream = futures_util::stream::Empty<zlink::Reply<()>>;
+    type ReplyStreamParams = ();
     type ReplyError<'ser> = MockError<'ser>;
 
     async fn handle<'ser>(

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -91,7 +91,7 @@ pub enum MockMethod<'a> {
 #[serde(untagged)]
 pub enum MockReply {
     Info(Info<'static>),
-    InterfaceDescription(InterfaceDescription),
+    InterfaceDescription(InterfaceDescription<'static>),
 }
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]


### PR DESCRIPTION
* Make it no_std-compatible.
* Move it from proxy submodule to top-level.

These changes allow it to be used as return type from services as well.

