### PR TITLE
🚚 core: More consistent naming for reply params generics

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,7 @@
         * `untagged` repr
 * zlink-core
   * Make idl::List have `str` as type so `CustomEnum` can contain `&st` instead of `&&str`
+  * `varlink_service::Proxy` methods should allow chaining.
 * zlink-macros
   * `proxy` attribute macro
     * gated behind (default) `proxy` feature

--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -97,11 +97,11 @@ where
     /// Receives a method call reply.
     ///
     /// Convenience wrapper around [`ReadConnection::receive_reply`].
-    pub async fn receive_reply<'r, Params, ReplyError>(
+    pub async fn receive_reply<'r, ReplyParams, ReplyError>(
         &'r mut self,
-    ) -> Result<reply::Result<Params, ReplyError>>
+    ) -> Result<reply::Result<ReplyParams, ReplyError>>
     where
-        Params: Deserialize<'r> + Debug,
+        ReplyParams: Deserialize<'r> + Debug,
         ReplyError: Deserialize<'r> + Debug,
     {
         self.read.receive_reply().await
@@ -111,13 +111,13 @@ where
     ///
     /// This is a convenience method that combines [`Connection::send_call`] and
     /// [`Connection::receive_reply`].
-    pub async fn call_method<'r, Method, Params, ReplyError>(
+    pub async fn call_method<'r, Method, ReplyParams, ReplyError>(
         &'r mut self,
         call: &Call<Method>,
-    ) -> Result<reply::Result<Params, ReplyError>>
+    ) -> Result<reply::Result<ReplyParams, ReplyError>>
     where
         Method: Serialize + Debug,
-        Params: Deserialize<'r> + Debug,
+        ReplyParams: Deserialize<'r> + Debug,
         ReplyError: Deserialize<'r> + Debug,
     {
         self.send_call(call).await?;
@@ -137,9 +137,9 @@ where
     /// Send a reply over the socket.
     ///
     /// Convenience wrapper around [`WriteConnection::send_reply`].
-    pub async fn send_reply<Params>(&mut self, reply: &Reply<Params>) -> Result<()>
+    pub async fn send_reply<ReplyParams>(&mut self, reply: &Reply<ReplyParams>) -> Result<()>
     where
-        Params: Serialize + Debug,
+        ReplyParams: Serialize + Debug,
     {
         self.write.send_reply(reply).await
     }
@@ -284,13 +284,13 @@ where
     ///
     /// Instead of multiple write operations, the chain sends all calls in a single
     /// write operation, reducing context switching and therefore minimizing latency.
-    pub fn chain_call<'c, Method, Params, ReplyError>(
+    pub fn chain_call<'c, Method, ReplyParams, ReplyError>(
         &'c mut self,
         call: &Call<Method>,
-    ) -> Result<Chain<'c, S, Method, Params, ReplyError>>
+    ) -> Result<Chain<'c, S, Method, ReplyParams, ReplyError>>
     where
         Method: Serialize + Debug,
-        Params: Deserialize<'c> + Debug,
+        ReplyParams: Deserialize<'c> + Debug,
         ReplyError: Deserialize<'c> + Debug,
     {
         Chain::new(self, call)

--- a/zlink-core/src/connection/read_connection.rs
+++ b/zlink-core/src/connection/read_connection.rs
@@ -52,8 +52,8 @@ impl<Read: ReadHalf> ReadConnection<Read> {
     ///
     /// The generic parameters needs some explanation:
     ///
-    /// * `Params` is the type of the successful reply. This should be a type that can deserialize
-    ///   itself from the `parameters` field of the reply.
+    /// * `ReplyParams` is the type of the successful reply. This should be a type that can
+    ///   deserialize itself from the `parameters` field of the reply.
     /// * `ReplyError` is the type of the error reply. This should be a type that can deserialize
     ///   itself from the whole reply object itself and must fail when there is no `error` field in
     ///   the object. This can be easily achieved using the `serde::Deserialize` derive:
@@ -72,11 +72,11 @@ impl<Read: ReadHalf> ReadConnection<Read> {
     ///    Charlie { param1: String },
     /// }
     /// ```
-    pub async fn receive_reply<'r, Params, ReplyError>(
+    pub async fn receive_reply<'r, ReplyParams, ReplyError>(
         &'r mut self,
-    ) -> Result<reply::Result<Params, ReplyError>>
+    ) -> Result<reply::Result<ReplyParams, ReplyError>>
     where
-        Params: Deserialize<'r> + Debug,
+        ReplyParams: Deserialize<'r> + Debug,
         ReplyError: Deserialize<'r> + Debug,
     {
         let id = self.id;
@@ -88,7 +88,7 @@ impl<Read: ReadHalf> ReadConnection<Read> {
         // that information. Perhaps a simple parser using `winnow`?
         let ret = match from_slice::<ReplyError>(buffer) {
             Ok(e) => Ok(Err(e)),
-            Err(_) => from_slice::<Reply<Params>>(buffer).map(Ok),
+            Err(_) => from_slice::<Reply<ReplyParams>>(buffer).map(Ok),
         };
         trace!("connection {}: received reply: {:?}", id, ret);
 


### PR DESCRIPTION
- **🚚 core: More consistent naming for reply params generics**
- **📝 TODO: Update**
