### PR TITLE
🐛 core: `idl` types now include comments during serialization

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,8 +2,10 @@
 
 ## Release 0.1.0
 
+* zlink-core
+  * Fix `cargo c -p zlink-core --release --no-default-features --features embedded,introspection`
+     * Also add to the CI
 * zlink-macros
-  * Display impls of IDL types should add comments.
   * derive macros should take the doc comments and add them to the appropriate IDL type generated.
 * zlink-core
   * `varlink_service::Proxy` methods should allow chaining.

--- a/zlink-core/src/idl/custom_enum.rs
+++ b/zlink-core/src/idl/custom_enum.rs
@@ -61,6 +61,10 @@ impl<'a> CustomEnum<'a> {
 
 impl<'a> fmt::Display for CustomEnum<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Comments first
+        for comment in self.comments.iter() {
+            writeln!(f, "{comment}")?;
+        }
         write!(f, "type {} (", self.name)?;
         let mut first = true;
         for variant in self.variants.iter() {
@@ -77,5 +81,32 @@ impl<'a> fmt::Display for CustomEnum<'a> {
 impl<'a> PartialEq for CustomEnum<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name && self.variants == other.variants
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idl::Comment;
+    use core::fmt::Write;
+
+    #[test]
+    fn display_with_comments() {
+        let comment1 = Comment::new("Status enumeration");
+        let comment2 = Comment::new("Represents current state");
+        let comments = [&comment1, &comment2];
+
+        let var1 = "active";
+        let var2 = "inactive";
+        let var3 = "pending";
+        let variants = [&var1, &var2, &var3];
+
+        let custom_enum = CustomEnum::new("Status", &variants, &comments);
+        let mut displayed = mayheap::String::<128>::new();
+        write!(&mut displayed, "{}", custom_enum).unwrap();
+        assert_eq!(
+            displayed,
+            "# Status enumeration\n# Represents current state\ntype Status (active, inactive, pending)"
+        );
     }
 }

--- a/zlink-core/src/idl/custom_object.rs
+++ b/zlink-core/src/idl/custom_object.rs
@@ -61,6 +61,10 @@ impl<'a> CustomObject<'a> {
 
 impl<'a> fmt::Display for CustomObject<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Comments first
+        for comment in self.comments.iter() {
+            writeln!(f, "{comment}")?;
+        }
         write!(f, "type {} (", self.name)?;
         let mut first = true;
         for field in self.fields.iter() {
@@ -77,5 +81,31 @@ impl<'a> fmt::Display for CustomObject<'a> {
 impl<'a> PartialEq for CustomObject<'a> {
     fn eq(&self, other: &Self) -> bool {
         self.name == other.name && self.fields == other.fields
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idl::{Comment, Field, Type};
+    use core::fmt::Write;
+
+    #[test]
+    fn display_with_comments() {
+        let comment1 = Comment::new("User data structure");
+        let comment2 = Comment::new("Contains basic user information");
+        let comments = [&comment1, &comment2];
+
+        let name_field = Field::new("name", &Type::String, &[]);
+        let age_field = Field::new("age", &Type::Int, &[]);
+        let fields = [&name_field, &age_field];
+
+        let custom_object = CustomObject::new("User", &fields, &comments);
+        let mut displayed = mayheap::String::<128>::new();
+        write!(&mut displayed, "{}", custom_object).unwrap();
+        assert_eq!(
+            displayed,
+            "# User data structure\n# Contains basic user information\ntype User (name: string, age: int)"
+        );
     }
 }

--- a/zlink-core/src/idl/field.rs
+++ b/zlink-core/src/idl/field.rs
@@ -57,6 +57,10 @@ impl<'a> Field<'a> {
 
 impl<'a> fmt::Display for Field<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Comments first
+        for comment in self.comments.iter() {
+            writeln!(f, "{comment}")?;
+        }
         write!(f, "{}: {}", self.name, self.ty)
     }
 }
@@ -84,5 +88,23 @@ mod tests {
         let param: Parameter<'_> = Field::new("input", &Type::String, &[]);
         assert_eq!(param.name(), "input");
         assert_eq!(param.ty(), &Type::String);
+    }
+
+    #[test]
+    fn display_with_comments() {
+        use crate::idl::Comment;
+        use core::fmt::Write;
+
+        let comment1 = Comment::new("User's email address");
+        let comment2 = Comment::new("Must be valid format");
+        let comments = [&comment1, &comment2];
+
+        let field = Field::new("email", &Type::String, &comments);
+        let mut displayed = mayheap::String::<128>::new();
+        write!(&mut displayed, "{}", field).unwrap();
+        assert_eq!(
+            displayed,
+            "# User's email address\n# Must be valid format\nemail: string"
+        );
     }
 }

--- a/zlink-core/src/idl/method.rs
+++ b/zlink-core/src/idl/method.rs
@@ -82,6 +82,10 @@ impl<'a> Method<'a> {
 
 impl<'a> fmt::Display for Method<'a> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Comments first
+        for comment in self.comments.iter() {
+            writeln!(f, "{comment}")?;
+        }
         write!(f, "method {}(", self.name)?;
         let mut first = true;
         for param in self.inputs.iter() {
@@ -167,5 +171,25 @@ mod tests {
         let mut displayed = mayheap::String::<64>::new();
         write!(&mut displayed, "{}", method).unwrap();
         assert_eq!(displayed, "method Register(name: string, id: string) -> ()");
+    }
+
+    #[test]
+    fn display_with_comments() {
+        use crate::idl::Comment;
+        use core::fmt::Write;
+
+        let comment1 = Comment::new("Get user information");
+        let comment2 = Comment::new("Returns user details by ID");
+        let comments = [&comment1, &comment2];
+
+        let input = Parameter::new("id", &Type::Int, &[]);
+        let output = Parameter::new("user", &Type::Custom("User"), &[]);
+        let inputs = [&input];
+        let outputs = [&output];
+
+        let method = Method::new("GetUser", &inputs, &outputs, &comments);
+        let mut displayed = mayheap::String::<128>::new();
+        write!(&mut displayed, "{}", method).unwrap();
+        assert_eq!(displayed, "# Get user information\n# Returns user details by ID\nmethod GetUser(id: int) -> (user: User)");
     }
 }


### PR DESCRIPTION
- **🐛 core: `idl` types now include comments during serialization**
- **📝 TODO: Update**
