### PR TITLE
🚑️ core: Fix `Call` ser/de for embedded

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -94,6 +94,10 @@ jobs:
         run: |
           cargo test --release --features introspection,idl-parse
           cargo test -p zlink-core --release --no-default-features --features embedded,introspection
+          # The tests enable the `alloc` feature of `serde` and hence the previous command doesn't
+          # really ensure if the serde bits build successfully without `std` and `alloc`. Hence why
+          # this is needed.
+          cargo check -p zlink-core --release --no-default-features --features embedded,introspection
 
   doc_build:
     runs-on: ubuntu-latest

--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,6 @@
 
 ## Release 0.1.0
 
-* zlink-core
-  * Fix `cargo c -p zlink-core --release --no-default-features --features embedded,introspection`
-     * Also add to the CI
 * zlink-macros
   * derive macros should take the doc comments and add them to the appropriate IDL type generated.
 * zlink-core

--- a/TODO.md
+++ b/TODO.md
@@ -3,17 +3,8 @@
 ## Release 0.1.0
 
 * zlink-core
-  * Fix `cargo check -p zlink-core --no-default-features --features embedded,introspection`
-  * Turns out we need allocation even for serialization
-    * Enable `alloc` feature in deps.
-    * Declare `extern crate alloc;` in root when `embedded` is enabled.
-    * Replace `mayheap` usage with `alloc`.
-    * Drop `mayheap` dependency.
-    * Replace `std` usage with `alloc` everywhere possible.
-    * `idle-parse` no longer requires `std` feature.
-    * Drop IO buffer size features.
-    * Revert commit c0fb08fb1f4c51dcfeb28d3a2459167f61eac6bf
-  * Add to the CI
+  * Fix `cargo c -p zlink-core --release --no-default-features --features embedded,introspection`
+     * Also add to the CI
 * zlink-macros
   * derive macros should take the doc comments and add them to the appropriate IDL type generated.
 * zlink-core

--- a/zlink-core/src/call/de.rs
+++ b/zlink-core/src/call/de.rs
@@ -1,0 +1,121 @@
+use core::{cell::Cell, fmt, marker::PhantomData};
+
+use serde::{
+    de::{
+        self, value::MapAccessDeserializer, DeserializeSeed, IntoDeserializer, MapAccess, Visitor,
+    },
+    Deserialize, Deserializer,
+};
+
+use super::Call;
+
+impl<'de, M> Deserialize<'de> for Call<M>
+where
+    M: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct CallVisitor<M>(PhantomData<M>);
+
+        impl<'de, M> Visitor<'de> for CallVisitor<M>
+        where
+            M: Deserialize<'de>,
+        {
+            type Value = Call<M>;
+
+            fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    f,
+                    "a map with optional booleans and flattened method fields"
+                )
+            }
+
+            fn visit_map<A>(self, map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                // 1) Prepare interior-mutable storage for optionals
+                let oneway_cell = Cell::new(None);
+                let more_cell = Cell::new(None);
+                let upgrade_cell = Cell::new(None);
+
+                // 2) Streaming adapter capturing booleans by Cell refs
+                struct FilterMap<'a, MAcc> {
+                    inner: MAcc,
+                    oneway: &'a Cell<Option<bool>>,
+                    more: &'a Cell<Option<bool>>,
+                    upgrade: &'a Cell<Option<bool>>,
+                }
+                impl<'de, 'a, MAcc> MapAccess<'de> for FilterMap<'a, MAcc>
+                where
+                    MAcc: MapAccess<'de>,
+                {
+                    type Error = MAcc::Error;
+
+                    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, MAcc::Error>
+                    where
+                        K: DeserializeSeed<'de>,
+                    {
+                        while let Some(key) = self.inner.next_key::<&str>()? {
+                            match key {
+                                "oneway" => {
+                                    let v = self.inner.next_value()?;
+                                    self.oneway.set(Some(v));
+                                    continue;
+                                }
+                                "more" => {
+                                    let v = self.inner.next_value()?;
+                                    self.more.set(Some(v));
+                                    continue;
+                                }
+                                "upgrade" => {
+                                    let v = self.inner.next_value()?;
+                                    self.upgrade.set(Some(v));
+                                    continue;
+                                }
+                                other => {
+                                    let de = other.into_deserializer();
+                                    return seed.deserialize(de).map(Some);
+                                }
+                            }
+                        }
+                        Ok(None)
+                    }
+
+                    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, MAcc::Error>
+                    where
+                        V: DeserializeSeed<'de>,
+                    {
+                        self.inner.next_value_seed(seed)
+                    }
+                }
+
+                // 3) Deserialize method: M using our FilterMap
+                let filter = FilterMap {
+                    inner: map,
+                    oneway: &oneway_cell,
+                    more: &more_cell,
+                    upgrade: &upgrade_cell,
+                };
+                let method = M::deserialize(MapAccessDeserializer::new(filter))
+                    .map_err(de::Error::custom)?;
+
+                // 4) Extract boolean fields from Cells
+                let oneway = oneway_cell.get();
+                let more = more_cell.get();
+                let upgrade = upgrade_cell.get();
+
+                Ok(Call {
+                    method,
+                    oneway,
+                    more,
+                    upgrade,
+                })
+            }
+        }
+
+        deserializer.deserialize_map(CallVisitor(PhantomData))
+    }
+}

--- a/zlink-core/src/call/mod.rs
+++ b/zlink-core/src/call/mod.rs
@@ -1,17 +1,18 @@
-use core::fmt::Debug;
+// We manually implement `Serialize` and `Deserialize` for `Call` because we need to flatten the
+// `method` field and `serde` requires `alloc` for both serialization and deserialization when
+// using the `flatten` attribute.
+mod de;
+mod ser;
 
-use serde::{Deserialize, Serialize};
+#[cfg(test)]
+mod tests;
 
 /// A method call.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct Call<M> {
-    #[serde(flatten)]
     pub(super) method: M,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) oneway: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) more: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) upgrade: Option<bool>,
 }
 

--- a/zlink-core/src/call/ser.rs
+++ b/zlink-core/src/call/ser.rs
@@ -1,0 +1,250 @@
+use serde::{
+    ser::{Error, Impossible, SerializeMap, SerializeStruct},
+    Serialize, Serializer,
+};
+
+use super::Call;
+
+impl<M> Serialize for Call<M>
+where
+    M: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(Some(4))?;
+
+        let flat_ser = FlatSerializer(&mut map);
+        self.method.serialize(flat_ser)?;
+
+        if let Some(oneway) = self.oneway {
+            map.serialize_entry("oneway", &oneway)?;
+        }
+        if let Some(more) = self.more {
+            map.serialize_entry("more", &more)?;
+        }
+        if let Some(upgrade) = self.upgrade {
+            map.serialize_entry("upgrade", &upgrade)?;
+        }
+
+        map.end()
+    }
+}
+
+struct FlatSerializer<'a, M: SerializeMap>(&'a mut M);
+
+impl<'a, M> Serializer for FlatSerializer<'a, M>
+where
+    M: SerializeMap,
+{
+    type Ok = ();
+    type Error = M::Error;
+
+    type SerializeMap = Self;
+    type SerializeStruct = Self;
+    // we only support `map` and `struct`
+    type SerializeSeq = Impossible<Self::Ok, Self::Error>;
+    type SerializeTuple = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleStruct = Impossible<Self::Ok, Self::Error>;
+    type SerializeTupleVariant = Impossible<Self::Ok, Self::Error>;
+    type SerializeStructVariant = Impossible<Self::Ok, Self::Error>;
+
+    // … you’d do the same for serialize_i32, serialize_str, etc.
+
+    // entry-point for T’s Map or Struct
+    fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
+        Ok(self)
+    }
+
+    fn serialize_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStruct, Self::Error> {
+        Ok(self)
+    }
+
+    // Dummy impl for all other serializer methods.
+    fn serialize_bool(self, _: bool) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_unit_struct(self, _name: &'static str) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_unit_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+    ) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_struct_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeStructVariant, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_newtype_struct<T>(
+        self,
+        _name: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_tuple_struct(
+        self,
+        _name: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_tuple_variant(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _len: usize,
+    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_newtype_variant<T>(
+        self,
+        _name: &'static str,
+        _variant_index: u32,
+        _variant: &'static str,
+        _value: &T,
+    ) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_bytes(self, _v: &[u8]) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_u8(self, _v: u8) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_u16(self, _v: u16) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_u32(self, _v: u32) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_u64(self, _v: u64) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_u128(self, _v: u128) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_i8(self, _v: i8) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_i16(self, _v: i16) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_i32(self, _v: i32) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_i64(self, _v: i64) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_i128(self, _v: i128) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_f32(self, _v: f32) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_f64(self, _v: f64) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_char(self, _v: char) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn serialize_str(self, _v: &str) -> Result<Self::Ok, Self::Error> {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+    fn collect_str<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where
+        T: ?Sized + core::fmt::Display,
+    {
+        Err(<M as SerializeMap>::Error::custom(ERR_MESSAGE))
+    }
+}
+
+impl<M> SerializeMap for FlatSerializer<'_, M>
+where
+    M: SerializeMap,
+{
+    type Ok = ();
+    type Error = M::Error;
+
+    // now forward keys & values into the real map
+    fn serialize_key<K>(&mut self, key: &K) -> Result<(), Self::Error>
+    where
+        K: ?Sized + Serialize,
+    {
+        self.0.serialize_key(key)
+    }
+
+    fn serialize_value<V>(&mut self, value: &V) -> Result<(), Self::Error>
+    where
+        V: ?Sized + Serialize,
+    {
+        self.0.serialize_value(value)
+    }
+
+    // end of inner map
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+impl<M> SerializeStruct for FlatSerializer<'_, M>
+where
+    M: SerializeMap,
+{
+    type Ok = ();
+    type Error = M::Error;
+
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where
+        T: ?Sized + Serialize,
+    {
+        self.0.serialize_key(key)?;
+        self.0.serialize_value(value)
+    }
+
+    fn end(self) -> Result<Self::Ok, Self::Error> {
+        Ok(())
+    }
+}
+
+const ERR_MESSAGE: &str =
+    "Must serialize as a map or struct with 2 fields/entries: `method` and `parameters`";

--- a/zlink-core/src/call/tests.rs
+++ b/zlink-core/src/call/tests.rs
@@ -1,0 +1,527 @@
+//! Unit tests for `Call` serialization and deserialization.
+
+use super::Call;
+use serde::{Deserialize, Serialize};
+
+#[cfg(feature = "std")]
+mod std {
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct ExtendedParams<'a> {
+        #[serde(flatten)]
+        middle: MiddleParams<'a>,
+        metadata: &'a str,
+        priority: u8,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct MiddleParams<'a> {
+        #[serde(flatten)]
+        base: BaseParams<'a>,
+        category: &'a str,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct BaseParams<'a> {
+        name: &'a str,
+        value: i32,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    #[serde(tag = "method", content = "parameters")]
+    enum TestServiceMethods<'a> {
+        #[serde(rename = "org.example.test.Simple")]
+        Simple,
+        #[serde(rename = "org.example.test.Method")]
+        Method { name: &'a str, value: i32 },
+        #[serde(rename = "org.example.test.GetInfo")]
+        GetInfo { id: u32 },
+        #[serde(rename = "org.example.test.Reset")]
+        Reset,
+        #[serde(rename = "org.example.test.WithFlattened")]
+        WithFlattened(ExtendedParams<'a>),
+    }
+
+    #[test]
+    fn serialize_call_with_method_only() {
+        let method = TestServiceMethods::Method {
+            name: "test",
+            value: 42,
+        };
+        let call = Call::new(method);
+
+        let json = serde_json::to_string(&call).unwrap();
+        let expected =
+            r#"{"method":"org.example.test.Method","parameters":{"name":"test","value":42}}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn serialize_call_with_oneway_true() {
+        let method = TestServiceMethods::Simple;
+        let call = Call::new(method).set_oneway(Some(true));
+
+        let json = serde_json::to_string(&call).unwrap();
+        let expected = r#"{"method":"org.example.test.Simple","oneway":true}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn serialize_call_with_oneway_false() {
+        let method = TestServiceMethods::Simple;
+        let call = Call::new(method).set_oneway(Some(false));
+
+        let json = serde_json::to_string(&call).unwrap();
+        let expected = r#"{"method":"org.example.test.Simple","oneway":false}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn serialize_call_with_more_true() {
+        let method = TestServiceMethods::Simple;
+        let call = Call::new(method).set_more(Some(true));
+
+        let json = serde_json::to_string(&call).unwrap();
+        let expected = r#"{"method":"org.example.test.Simple","more":true}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn serialize_call_with_upgrade_true() {
+        let method = TestServiceMethods::Simple;
+        let call = Call::new(method).set_upgrade(Some(true));
+
+        let json = serde_json::to_string(&call).unwrap();
+        let expected = r#"{"method":"org.example.test.Simple","upgrade":true}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn serialize_call_with_all_flags() {
+        let method = TestServiceMethods::Method {
+            name: "test",
+            value: 42,
+        };
+        let call = Call::new(method)
+            .set_oneway(Some(true))
+            .set_more(Some(false))
+            .set_upgrade(Some(true));
+
+        let json = serde_json::to_string(&call).unwrap();
+        // Note: The order might vary, so we parse and check the structure.
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(parsed["method"], "org.example.test.Method");
+        assert_eq!(parsed["parameters"]["name"], "test");
+        assert_eq!(parsed["parameters"]["value"], 42);
+        assert_eq!(parsed["oneway"], true);
+        assert_eq!(parsed["more"], false);
+        assert_eq!(parsed["upgrade"], true);
+    }
+
+    #[test]
+    fn serialize_call_with_none_flags() {
+        let method = TestServiceMethods::Simple;
+        let call = Call::new(method)
+            .set_oneway(None)
+            .set_more(None)
+            .set_upgrade(None);
+
+        let json = serde_json::to_string(&call).unwrap();
+        let expected = r#"{"method":"org.example.test.Simple"}"#;
+        assert_eq!(json, expected);
+    }
+
+    #[test]
+    fn deserialize_call_with_method_only() {
+        let json =
+            r#"{"method":"org.example.test.Method","parameters":{"name":"test","value":42}}"#;
+        let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+
+        match call.method() {
+            TestServiceMethods::Method { name, value } => {
+                assert_eq!(*name, "test");
+                assert_eq!(*value, 42);
+            }
+            _ => panic!("Expected Method variant"),
+        }
+        assert_eq!(call.oneway(), None);
+        assert_eq!(call.more(), None);
+        assert_eq!(call.upgrade(), None);
+    }
+
+    #[test]
+    fn deserialize_call_with_oneway_true() {
+        let json = r#"{"method":"org.example.test.Simple","oneway":true}"#;
+        let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+
+        assert!(matches!(call.method(), TestServiceMethods::Simple));
+        assert_eq!(call.oneway(), Some(true));
+        assert_eq!(call.more(), None);
+        assert_eq!(call.upgrade(), None);
+    }
+
+    #[test]
+    fn deserialize_call_with_oneway_false() {
+        let json = r#"{"method":"org.example.test.Simple","oneway":false}"#;
+        let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+
+        assert!(matches!(call.method(), TestServiceMethods::Simple));
+        assert_eq!(call.oneway(), Some(false));
+        assert_eq!(call.more(), None);
+        assert_eq!(call.upgrade(), None);
+    }
+
+    #[test]
+    fn deserialize_call_with_more_true() {
+        let json = r#"{"method":"org.example.test.Simple","more":true}"#;
+        let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+
+        assert!(matches!(call.method(), TestServiceMethods::Simple));
+        assert_eq!(call.oneway(), None);
+        assert_eq!(call.more(), Some(true));
+        assert_eq!(call.upgrade(), None);
+    }
+
+    #[test]
+    fn deserialize_call_with_upgrade_true() {
+        let json = r#"{"method":"org.example.test.Simple","upgrade":true}"#;
+        let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+
+        assert!(matches!(call.method(), TestServiceMethods::Simple));
+        assert_eq!(call.oneway(), None);
+        assert_eq!(call.more(), None);
+        assert_eq!(call.upgrade(), Some(true));
+    }
+
+    #[test]
+    fn deserialize_call_with_all_flags() {
+        let json = r#"{"method":"org.example.test.Method","parameters":{"name":"test","value":42},"oneway":true,"more":false,"upgrade":true}"#;
+        let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+
+        match call.method() {
+            TestServiceMethods::Method { name, value } => {
+                assert_eq!(*name, "test");
+                assert_eq!(*value, 42);
+            }
+            _ => panic!("Expected Method variant"),
+        }
+        assert_eq!(call.oneway(), Some(true));
+        assert_eq!(call.more(), Some(false));
+        assert_eq!(call.upgrade(), Some(true));
+    }
+
+    #[test]
+    fn deserialize_call_with_extra_fields() {
+        let json =
+            r#"{"method":"org.example.test.Simple","extra":"ignored","oneway":true,"unknown":42}"#;
+        let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+
+        assert!(matches!(call.method(), TestServiceMethods::Simple));
+        assert_eq!(call.oneway(), Some(true));
+        assert_eq!(call.more(), None);
+        assert_eq!(call.upgrade(), None);
+    }
+
+    #[test]
+    fn roundtrip_serialization() {
+        let method = TestServiceMethods::Method {
+            name: "roundtrip",
+            value: 123,
+        };
+        let original = Call::new(method)
+            .set_oneway(Some(false))
+            .set_more(Some(true))
+            .set_upgrade(Some(false));
+
+        let json = serde_json::to_string(&original).unwrap();
+        let deserialized: Call<TestServiceMethods<'_>> = serde_json::from_str(&json).unwrap();
+
+        match (original.method(), deserialized.method()) {
+            (
+                TestServiceMethods::Method {
+                    name: name1,
+                    value: value1,
+                },
+                TestServiceMethods::Method {
+                    name: name2,
+                    value: value2,
+                },
+            ) => {
+                assert_eq!(name1, name2);
+                assert_eq!(value1, value2);
+            }
+            _ => panic!("Expected Method variants"),
+        }
+        assert_eq!(original.oneway(), deserialized.oneway());
+        assert_eq!(original.more(), deserialized.more());
+        assert_eq!(original.upgrade(), deserialized.upgrade());
+    }
+
+    #[test]
+    fn field_order_independence() {
+        // Test with Simple method.
+        let simple_jsons = [
+            r#"{"method":"org.example.test.Simple","oneway":true,"more":false}"#,
+            r#"{"oneway":true,"method":"org.example.test.Simple","more":false}"#,
+            r#"{"more":false,"oneway":true,"method":"org.example.test.Simple"}"#,
+        ];
+
+        for json in &simple_jsons {
+            let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+            assert!(matches!(call.method(), TestServiceMethods::Simple));
+            assert_eq!(call.oneway(), Some(true));
+            assert_eq!(call.more(), Some(false));
+        }
+
+        // Test with Method that has parameters - various field orderings.
+        let method_jsons = [
+            r#"{"method":"org.example.test.Method","parameters":{"name":"test","value":42},"oneway":true}"#,
+            r#"{"parameters":{"name":"test","value":42},"method":"org.example.test.Method","oneway":true}"#,
+            r#"{"oneway":true,"method":"org.example.test.Method","parameters":{"name":"test","value":42}}"#,
+            r#"{"oneway":true,"parameters":{"name":"test","value":42},"method":"org.example.test.Method"}"#,
+        ];
+
+        for json in &method_jsons {
+            let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+            match call.method() {
+                TestServiceMethods::Method { name, value } => {
+                    assert_eq!(*name, "test");
+                    assert_eq!(*value, 42);
+                }
+                _ => panic!("Expected Method variant"),
+            }
+            assert_eq!(call.oneway(), Some(true));
+        }
+
+        // Test parameter field order within parameters object.
+        let param_order_jsons = [
+            r#"{"method":"org.example.test.Method","parameters":{"name":"test","value":42}}"#,
+            r#"{"method":"org.example.test.Method","parameters":{"value":42,"name":"test"}}"#,
+        ];
+
+        for json in &param_order_jsons {
+            let call: Call<TestServiceMethods<'_>> = serde_json::from_str(json).unwrap();
+            match call.method() {
+                TestServiceMethods::Method { name, value } => {
+                    assert_eq!(*name, "test");
+                    assert_eq!(*value, 42);
+                }
+                _ => panic!("Expected Method variant"),
+            }
+        }
+    }
+
+    #[test]
+    fn comprehensive_service_methods() {
+        // Demonstrates a complete service with multiple method types
+        let methods = vec![
+            TestServiceMethods::Simple,
+            TestServiceMethods::Method {
+                name: "complete",
+                value: 456,
+            },
+            TestServiceMethods::GetInfo { id: 789 },
+            TestServiceMethods::Reset,
+        ];
+
+        for method in methods {
+            let call = Call::new(method.clone())
+                .set_oneway(Some(true))
+                .set_more(Some(false));
+
+            let json = serde_json::to_string(&call).unwrap();
+            let deserialized: Call<TestServiceMethods<'_>> = serde_json::from_str(&json).unwrap();
+
+            // Verify the method matches after roundtrip
+            assert_eq!(call.oneway(), deserialized.oneway());
+            assert_eq!(call.more(), deserialized.more());
+            assert_eq!(call.upgrade(), deserialized.upgrade());
+
+            // Method-specific verification
+            match (call.method(), deserialized.method()) {
+                (TestServiceMethods::Simple, TestServiceMethods::Simple) => {}
+                (TestServiceMethods::Reset, TestServiceMethods::Reset) => {}
+                (
+                    TestServiceMethods::Method {
+                        name: n1,
+                        value: v1,
+                    },
+                    TestServiceMethods::Method {
+                        name: n2,
+                        value: v2,
+                    },
+                ) => {
+                    assert_eq!(n1, n2);
+                    assert_eq!(v1, v2);
+                }
+                (
+                    TestServiceMethods::GetInfo { id: id1 },
+                    TestServiceMethods::GetInfo { id: id2 },
+                ) => {
+                    assert_eq!(id1, id2);
+                }
+                (TestServiceMethods::WithFlattened(p1), TestServiceMethods::WithFlattened(p2)) => {
+                    assert_eq!(p1, p2);
+                }
+                _ => panic!("Method variants don't match"),
+            }
+        }
+    }
+
+    #[test]
+    fn serde_flatten_in_variant() {
+        // Test serialization with multiple layers of flattened parameters.
+        let extended_params = ExtendedParams {
+            middle: MiddleParams {
+                base: BaseParams {
+                    name: "test_flatten",
+                    value: 42,
+                },
+                category: "testing",
+            },
+            metadata: "important",
+            priority: 5,
+        };
+        let method = TestServiceMethods::WithFlattened(extended_params);
+        let call = Call::new(method).set_oneway(Some(true));
+
+        let json = serde_json::to_string(&call).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+
+        // Verify that all flattened fields appear at the top level of parameters.
+        assert_eq!(parsed["method"], "org.example.test.WithFlattened");
+        assert_eq!(parsed["parameters"]["name"], "test_flatten");
+        assert_eq!(parsed["parameters"]["value"], 42);
+        assert_eq!(parsed["parameters"]["category"], "testing");
+        assert_eq!(parsed["parameters"]["metadata"], "important");
+        assert_eq!(parsed["parameters"]["priority"], 5);
+        assert_eq!(parsed["oneway"], true);
+
+        // Test deserialization with flattened parameters.
+        let deserialized: Call<TestServiceMethods<'_>> = serde_json::from_str(&json).unwrap();
+
+        match deserialized.method() {
+            TestServiceMethods::WithFlattened(params) => {
+                assert_eq!(params.middle.base.name, "test_flatten");
+                assert_eq!(params.middle.base.value, 42);
+                assert_eq!(params.middle.category, "testing");
+                assert_eq!(params.metadata, "important");
+                assert_eq!(params.priority, 5);
+            }
+            _ => panic!("Expected WithFlattened variant"),
+        }
+        assert_eq!(deserialized.oneway(), Some(true));
+
+        // Test roundtrip serialization maintains flattened structure.
+        let json2 = serde_json::to_string(&deserialized).unwrap();
+        let parsed2: serde_json::Value = serde_json::from_str(&json2).unwrap();
+        assert_eq!(parsed, parsed2);
+    }
+}
+
+#[cfg(feature = "embedded")]
+mod embedded {
+    use super::*;
+    use serde_json_core;
+
+    // Embedded service methods using structs (serde-json-core doesn't support enums).
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct SimpleMethod<'a> {
+        method: &'a str,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct ComplexMethod<'a> {
+        method: &'a str,
+        parameters: MethodParams<'a>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct GetInfoMethod<'a> {
+        method: &'a str,
+        parameters: GetInfoParams,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct MethodParams<'a> {
+        name: &'a str,
+        value: i32,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct GetInfoParams {
+        id: u32,
+    }
+
+    #[test]
+    fn serialize_call_embedded() {
+        let method = SimpleMethod {
+            method: "org.example.test.Simple",
+        };
+        let call = Call::new(method).set_oneway(Some(true));
+
+        let mut buf = [0u8; 256];
+        let json_len = serde_json_core::to_slice(&call, &mut buf).unwrap();
+        let json_str = core::str::from_utf8(&buf[..json_len]).unwrap();
+
+        // Verify the JSON contains expected parts.
+        assert!(json_str.contains(r#""method":"org.example.test.Simple""#));
+        assert!(json_str.contains(r#""oneway":true"#));
+    }
+
+    #[test]
+    fn deserialize_call_embedded() {
+        // Test roundtrip serialization/deserialization
+        let original_method = GetInfoMethod {
+            method: "org.example.test.GetInfo",
+            parameters: GetInfoParams { id: 123 },
+        };
+        let original_call = Call::new(original_method).set_more(Some(true));
+
+        let mut buf = [0u8; 256];
+        let json_len = serde_json_core::to_slice(&original_call, &mut buf).unwrap();
+        let deserialized: Call<GetInfoMethod<'_>> =
+            serde_json_core::from_slice(&buf[..json_len]).unwrap().0;
+
+        assert_eq!(deserialized.method().method, original_call.method().method);
+        assert_eq!(
+            deserialized.method().parameters.id,
+            original_call.method().parameters.id
+        );
+        assert_eq!(deserialized.oneway(), None);
+        assert_eq!(deserialized.more(), Some(true));
+        assert_eq!(deserialized.upgrade(), None);
+    }
+
+    #[test]
+    fn roundtrip_serialization_embedded() {
+        let method = ComplexMethod {
+            method: "org.example.test.Method",
+            parameters: MethodParams {
+                name: "embedded",
+                value: 99,
+            },
+        };
+        let original = Call::new(method).set_upgrade(Some(true));
+
+        let mut buf = [0u8; 256];
+        let json_len = serde_json_core::to_slice(&original, &mut buf).unwrap();
+        let deserialized: Call<ComplexMethod<'_>> =
+            serde_json_core::from_slice(&buf[..json_len]).unwrap().0;
+
+        assert_eq!(original.method().method, deserialized.method().method);
+        assert_eq!(
+            original.method().parameters.name,
+            deserialized.method().parameters.name
+        );
+        assert_eq!(
+            original.method().parameters.value,
+            deserialized.method().parameters.value
+        );
+        assert_eq!(original.oneway(), deserialized.oneway());
+        assert_eq!(original.more(), deserialized.more());
+        assert_eq!(original.upgrade(), deserialized.upgrade());
+    }
+}

--- a/zlink-core/src/connection/chain/mod.rs
+++ b/zlink-core/src/connection/chain/mod.rs
@@ -421,7 +421,7 @@ mod tests {
         let delete_response = replies.next().await.unwrap()?.unwrap();
         if let HeterogeneousResponses::DeleteResult(result) = delete_response.parameters().unwrap()
         {
-            assert_eq!(result.success, true);
+            assert!(result.success);
         } else {
             panic!("Expected DeleteResult response");
         }

--- a/zlink-core/src/connection/write_connection.rs
+++ b/zlink-core/src/connection/write_connection.rs
@@ -392,15 +392,12 @@ mod tests {
             let pos = null_positions[i];
             assert!(
                 pos > 0,
-                "Null terminator at position {} should not be at start",
-                pos
+                "Null terminator at position {pos} should not be at start"
             );
             let preceding_byte = buffer[pos - 1];
             assert!(
                 preceding_byte == b'}' || preceding_byte == b'"' || preceding_byte.is_ascii_digit(),
-                "Null terminator at position {} should be after valid JSON ending, found byte: {}",
-                pos,
-                preceding_byte
+                "Null terminator at position {pos} should be after valid JSON ending, found byte: {preceding_byte}"
             );
         }
 

--- a/zlink/examples/resolved.rs
+++ b/zlink/examples/resolved.rs
@@ -26,12 +26,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map(|r| r.map(|r| r.into_parameters().unwrap().addresses))?
         {
             Ok(addresses) => {
-                println!("Results for '{}':", name);
+                println!("Results for '{name}':");
                 for address in addresses {
-                    println!("\t{}", address);
+                    println!("\t{address}");
                 }
             }
-            Err(e) => eprintln!("Error resolving '{}': {}", name, e),
+            Err(e) => eprintln!("Error resolving '{name}': {e}"),
         }
     }
 
@@ -65,19 +65,19 @@ impl Display for ResolvedAddress {
                 let ip = <[u8; 4]>::try_from(self.address.as_slice())
                     .map(IpAddr::from)
                     .unwrap();
-                format!("IPv4: {}", ip)
+                format!("IPv4: {ip}")
             }
             ProtocolFamily::Inet6 => {
                 let ip = <[u8; 16]>::try_from(self.address.as_slice())
                     .map(IpAddr::from)
                     .unwrap();
-                format!("IPv6: {}", ip)
+                format!("IPv6: {ip}")
             }
             ProtocolFamily::Unspec => {
                 format!("Unspecified protocol family: {:?}", self.address)
             }
         };
-        write!(f, "{}", ip)
+        write!(f, "{ip}")
     }
 }
 
@@ -129,7 +129,7 @@ enum ReplyError<'e> {
 
 impl Display for ReplyError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 


### PR DESCRIPTION
Unfortunately, it turns out that `#[serde(flatten)]` requires allocation for both ser and de so we now switch to manual impls that avoid allocation for this very specific simple case.

