### PR TITLE
A bunch of unrelated changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,15 +4,11 @@
 
 * zlink-core
   * Any method call can return varlink_service::Error
-    *  manually impl `Deserialize` for `varlink_service::api` enums, in `no_std` case
-      * Assume tag fields to be first in the JSON.
     * Add `VarlinkService` variant to `zlink_core::Error`
     * ReadConnection::receive_reply
-      * untagged Enum, `Response` with `Reply` as one variant and `ReplyError` as another.
-        * For `std`, use `Deserialize` derive.
-        * For `no_std`, manually impl Deserialize that assume error to be the first field.
-      * Add `varlink_service::Error` variant to `Response`.
-      * in case of `varlink_service::Error`, return `zlink_core::Error::VarlinkService`
+      * if error name has `org.varlink.service` prefix,
+        * deserialize to `varlink_service::Error`
+        * return `zlink_core::Error::VarlinkService`
 * zlink-macros
   * `proxy` attribute macro
     * check macro code for other cleanups refactors possible

--- a/zlink-core/src/introspect/type.rs
+++ b/zlink-core/src/introspect/type.rs
@@ -42,6 +42,10 @@ impl<T: Type, const N: usize> Type for mayheap::Vec<T, N> {
     const TYPE: &'static idl::Type<'static> = &idl::Type::Array(TypeRef::new(T::TYPE));
 }
 
+impl<const N: usize> Type for mayheap::string::String<N> {
+    const TYPE: &'static idl::Type<'static> = &idl::Type::String;
+}
+
 impl<T: Type> Type for &[T] {
     const TYPE: &'static idl::Type<'static> = &idl::Type::Array(TypeRef::new(T::TYPE));
 }

--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -32,7 +32,6 @@ pub use reply::Reply;
 pub mod idl;
 #[cfg(feature = "introspection")]
 pub mod introspect;
-#[cfg(feature = "introspection")]
 pub mod varlink_service;
 
 #[cfg(feature = "proxy")]

--- a/zlink-core/src/varlink_service/api.rs
+++ b/zlink-core/src/varlink_service/api.rs
@@ -7,9 +7,12 @@ use serde::{
     Deserialize,
 };
 
+#[cfg(feature = "introspection")]
 use crate::introspect;
 
-use super::{Info, InterfaceDescription};
+use super::Info;
+#[cfg(feature = "idl")]
+use super::InterfaceDescription;
 
 /// `org.varlink.service` interface methods.
 #[derive(Debug, Serialize)]
@@ -39,12 +42,14 @@ pub enum Reply<'a> {
     Info(Info<'a>),
     /// Reply for `GetInterfaceDescription` method.
     /// Note: InterfaceDescription only supports 'static lifetime for deserialization.
+    #[cfg(feature = "idl")]
     InterfaceDescription(InterfaceDescription<'static>),
 }
 
 /// Errors that can be returned by the `org.varlink.service` interface.
-#[derive(Debug, Clone, PartialEq, Serialize, introspect::ReplyError)]
-#[zlink(crate = "crate")]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(feature = "introspection", derive(introspect::ReplyError))]
+#[cfg_attr(feature = "introspection", zlink(crate = "crate"))]
 #[cfg_attr(feature = "std", derive(Deserialize))]
 #[serde(tag = "error", content = "parameters")]
 pub enum Error<'a> {

--- a/zlink-core/src/varlink_service/api.rs
+++ b/zlink-core/src/varlink_service/api.rs
@@ -80,9 +80,8 @@ pub enum Error<'a> {
     ExpectedMore,
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for Error<'_> {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for Error<'_> {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         None
     }
 }

--- a/zlink-core/src/varlink_service/api.rs
+++ b/zlink-core/src/varlink_service/api.rs
@@ -1,6 +1,11 @@
 #[cfg(feature = "std")]
 use serde::Deserialize;
 use serde::Serialize;
+#[cfg(not(feature = "std"))]
+use serde::{
+    de::{self, MapAccess, Visitor},
+    Deserialize,
+};
 
 use crate::introspect;
 
@@ -110,6 +115,154 @@ impl core::fmt::Display for Error<'_> {
 /// Result type for Varlink service methods.
 pub type Result<'a, T> = core::result::Result<T, Error<'a>>;
 
+#[cfg(not(feature = "std"))]
+impl<'de> Deserialize<'de> for Error<'de> {
+    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ErrorVisitor;
+
+        impl<'de> Visitor<'de> for ErrorVisitor {
+            type Value = Error<'de>;
+
+            fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                formatter.write_str("a varlink service error")
+            }
+
+            fn visit_map<M>(self, mut map: M) -> core::result::Result<Self::Value, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                // NOTE: For nostd, we require "error" field to be first.
+                // First, read the error type.
+                let key = map.next_key::<&str>()?;
+                if key != Some("error") {
+                    return Err(de::Error::custom("expected 'error' field first"));
+                }
+                let error_type: &str = map.next_value()?;
+
+                // Helper struct to deserialize parameters
+                struct ParamsMap<'de> {
+                    interface: Option<&'de str>,
+                    method: Option<&'de str>,
+                    parameter: Option<&'de str>,
+                }
+
+                impl<'de> Deserialize<'de> for ParamsMap<'de> {
+                    fn deserialize<D>(deserializer: D) -> core::result::Result<Self, D::Error>
+                    where
+                        D: serde::Deserializer<'de>,
+                    {
+                        struct ParamsMapVisitor;
+
+                        impl<'de> Visitor<'de> for ParamsMapVisitor {
+                            type Value = ParamsMap<'de>;
+
+                            fn expecting(
+                                &self,
+                                formatter: &mut core::fmt::Formatter<'_>,
+                            ) -> core::fmt::Result {
+                                formatter.write_str("parameters object")
+                            }
+
+                            fn visit_map<A>(
+                                self,
+                                mut map: A,
+                            ) -> core::result::Result<Self::Value, A::Error>
+                            where
+                                A: MapAccess<'de>,
+                            {
+                                let mut interface = None;
+                                let mut method = None;
+                                let mut parameter = None;
+
+                                while let Some(key) = map.next_key::<&str>()? {
+                                    match key {
+                                        "interface" => interface = Some(map.next_value()?),
+                                        "method" => method = Some(map.next_value()?),
+                                        "parameter" => parameter = Some(map.next_value()?),
+                                        _ => {
+                                            let _: de::IgnoredAny = map.next_value()?;
+                                        }
+                                    }
+                                }
+
+                                Ok(ParamsMap {
+                                    interface,
+                                    method,
+                                    parameter,
+                                })
+                            }
+                        }
+
+                        deserializer.deserialize_map(ParamsMapVisitor)
+                    }
+                }
+
+                let params_map = loop {
+                    let Some(key) = map.next_key::<&str>()? else {
+                        break ParamsMap {
+                            interface: None,
+                            method: None,
+                            parameter: None,
+                        };
+                    };
+                    if key == "parameters" {
+                        break map.next_value::<ParamsMap<'_>>()?;
+                    }
+                    // Unknown field, skip it.
+                    let _: de::IgnoredAny = map.next_value()?;
+                };
+
+                match error_type {
+                    "org.varlink.service.PermissionDenied" => return Ok(Error::PermissionDenied),
+                    "org.varlink.service.ExpectedMore" => return Ok(Error::ExpectedMore),
+                    "org.varlink.service.InterfaceNotFound" => {
+                        let interface = params_map
+                            .interface
+                            .ok_or_else(|| de::Error::missing_field("interface"))?;
+                        return Ok(Error::InterfaceNotFound { interface });
+                    }
+                    "org.varlink.service.MethodNotFound" => {
+                        let method = params_map
+                            .method
+                            .ok_or_else(|| de::Error::missing_field("method"))?;
+                        return Ok(Error::MethodNotFound { method });
+                    }
+                    "org.varlink.service.MethodNotImplemented" => {
+                        let method = params_map
+                            .method
+                            .ok_or_else(|| de::Error::missing_field("method"))?;
+                        return Ok(Error::MethodNotImplemented { method });
+                    }
+                    "org.varlink.service.InvalidParameter" => {
+                        let parameter = params_map
+                            .parameter
+                            .ok_or_else(|| de::Error::missing_field("parameter"))?;
+                        return Ok(Error::InvalidParameter { parameter });
+                    }
+                    _ => {}
+                }
+
+                Err(de::Error::unknown_variant(
+                    error_type,
+                    &[
+                        "org.varlink.service.InterfaceNotFound",
+                        "org.varlink.service.MethodNotFound",
+                        "org.varlink.service.MethodNotImplemented",
+                        "org.varlink.service.InvalidParameter",
+                        "org.varlink.service.PermissionDenied",
+                        "org.varlink.service.ExpectedMore",
+                    ],
+                ))
+            }
+        }
+
+        deserializer.deserialize_map(ErrorVisitor)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -150,13 +303,11 @@ mod tests {
         assert!(json.contains("org.varlink.service.PermissionDenied"));
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn error_deserialization() {
         // Test error with parameter
         let json = r#"{"error":"org.varlink.service.InterfaceNotFound","parameters":{"interface":"com.example.missing"}}"#;
-
-        let err: Error<'_> = serde_json::from_str(json).unwrap();
+        let err = deserialize_error(json);
         assert_eq!(
             err,
             Error::InterfaceNotFound {
@@ -166,14 +317,12 @@ mod tests {
 
         // Test error without parameters
         let json = r#"{"error":"org.varlink.service.PermissionDenied"}"#;
-
-        let err: Error<'_> = serde_json::from_str(json).unwrap();
+        let err = deserialize_error(json);
         assert_eq!(err, Error::PermissionDenied);
 
         // Test MethodNotFound error
         let json = r#"{"error":"org.varlink.service.MethodNotFound","parameters":{"method":"NonExistentMethod"}}"#;
-
-        let err: Error<'_> = serde_json::from_str(json).unwrap();
+        let err = deserialize_error(json);
         assert_eq!(
             err,
             Error::MethodNotFound {
@@ -183,17 +332,30 @@ mod tests {
 
         // Test InvalidParameter error
         let json = r#"{"error":"org.varlink.service.InvalidParameter","parameters":{"parameter":"invalid_param"}}"#;
-
-        let err: Error<'_> = serde_json::from_str(json).unwrap();
+        let err = deserialize_error(json);
         assert_eq!(
             err,
             Error::InvalidParameter {
                 parameter: "invalid_param"
             }
         );
+
+        // Test MethodNotImplemented error
+        let json = r#"{"error":"org.varlink.service.MethodNotImplemented","parameters":{"method":"UnimplementedMethod"}}"#;
+        let err = deserialize_error(json);
+        assert_eq!(
+            err,
+            Error::MethodNotImplemented {
+                method: "UnimplementedMethod"
+            }
+        );
+
+        // Test ExpectedMore error
+        let json = r#"{"error":"org.varlink.service.ExpectedMore"}"#;
+        let err = deserialize_error(json);
+        assert_eq!(err, Error::ExpectedMore);
     }
 
-    #[cfg(feature = "std")]
     #[test]
     fn error_round_trip_serialization() {
         // Test with error that has parameters
@@ -201,25 +363,43 @@ mod tests {
             interface: "com.example.missing",
         };
 
-        // Serialize to JSON
-        let json = serde_json::to_string(&original).unwrap();
-
-        // Deserialize back from JSON
-        let deserialized: Error<'_> = serde_json::from_str(&json).unwrap();
-
-        // Verify they are equal
-        assert_eq!(original, deserialized);
+        test_round_trip_serialize(&original);
 
         // Test with error that has no parameters
         let original = Error::PermissionDenied;
 
-        // Serialize to JSON
-        let json = serde_json::to_string(&original).unwrap();
+        test_round_trip_serialize(&original);
+    }
 
-        // Deserialize back from JSON
-        let deserialized: Error<'_> = serde_json::from_str(&json).unwrap();
+    // Helper function to deserialize JSON string to Error, abstracting std vs nostd differences
+    fn deserialize_error(json: &str) -> Error<'_> {
+        #[cfg(feature = "std")]
+        {
+            serde_json::from_str(json).unwrap()
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            let (err, _): (Error<'_>, usize) = serde_json_core::from_str(json).unwrap();
+            err
+        }
+    }
 
-        // Verify they are equal
-        assert_eq!(original, deserialized);
+    // Helper function for round-trip serialization test, abstracting std vs nostd differences
+    fn test_round_trip_serialize<'a>(original: &Error<'a>) {
+        #[cfg(feature = "std")]
+        {
+            let json = serde_json::to_string(original).unwrap();
+            let deserialized: Error<'_> = serde_json::from_str(&json).unwrap();
+            assert_eq!(*original, deserialized);
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            let mut buffer = [0u8; 256];
+            let len = serde_json_core::to_slice(original, &mut buffer).unwrap();
+            let json_bytes = &buffer[..len];
+            let (deserialized, _): (Error<'_>, usize) =
+                serde_json_core::from_slice(json_bytes).unwrap();
+            assert_eq!(*original, deserialized);
+        }
     }
 }

--- a/zlink-core/src/varlink_service/api.rs
+++ b/zlink-core/src/varlink_service/api.rs
@@ -96,13 +96,13 @@ impl core::fmt::Display for Error<'_> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Error::InterfaceNotFound { interface } => {
-                write!(f, "Interface not found: {}", interface)
+                write!(f, "Interface not found: {interface}")
             }
             Error::MethodNotFound { method } => {
-                write!(f, "Method not found: {}", method)
+                write!(f, "Method not found: {method}")
             }
             Error::InvalidParameter { parameter } => {
-                write!(f, "Invalid parameter: {}", parameter)
+                write!(f, "Invalid parameter: {parameter}")
             }
             Error::PermissionDenied => {
                 write!(f, "Permission denied")
@@ -111,7 +111,7 @@ impl core::fmt::Display for Error<'_> {
                 write!(f, "Expected more")
             }
             Error::MethodNotImplemented { method } => {
-                write!(f, "Method not implemented: {}", method)
+                write!(f, "Method not implemented: {method}")
             }
         }
     }

--- a/zlink-core/src/varlink_service/api.rs
+++ b/zlink-core/src/varlink_service/api.rs
@@ -51,6 +51,7 @@ pub enum Reply<'a> {
 #[cfg_attr(feature = "introspection", derive(introspect::ReplyError))]
 #[cfg_attr(feature = "introspection", zlink(crate = "crate"))]
 #[cfg_attr(feature = "std", derive(Deserialize))]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 #[serde(tag = "error", content = "parameters")]
 pub enum Error<'a> {
     /// The requested interface was not found.

--- a/zlink-core/src/varlink_service/info.rs
+++ b/zlink-core/src/varlink_service/info.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "introspection")]
 use crate::introspect::Type;
 use mayheap::Vec;
 #[cfg(feature = "std")]
@@ -7,8 +8,9 @@ use serde::Serialize;
 /// Information about a Varlink service implementation.
 ///
 /// This is the return type for the `GetInfo` method of the `org.varlink.service` interface.
-#[derive(Debug, Clone, PartialEq, Serialize, Type)]
-#[zlink(crate = "crate")]
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[cfg_attr(feature = "introspection", derive(Type))]
+#[cfg_attr(feature = "introspection", zlink(crate = "crate"))]
 #[cfg_attr(feature = "std", derive(Deserialize))]
 pub struct Info<'a> {
     /// The vendor of the service.

--- a/zlink-core/src/varlink_service/interface_description.rs
+++ b/zlink-core/src/varlink_service/interface_description.rs
@@ -1,6 +1,8 @@
 use core::fmt::Debug;
 
-use crate::{idl::Interface, introspect::Type};
+use crate::idl::Interface;
+#[cfg(feature = "introspection")]
+use crate::introspect::Type;
 #[cfg(feature = "idl-parse")]
 use serde::Deserialize;
 use serde::Serialize;
@@ -10,8 +12,9 @@ use serde::Serialize;
 /// Use [`InterfaceDescription::parse`] to get the [`Interface`].
 ///
 /// Under the hood, the interface description is either a parsed [`Interface`] or a raw string.
-#[derive(Debug, Serialize, Type, Clone)]
-#[zlink(crate = "crate")]
+#[derive(Debug, Serialize, Clone)]
+#[cfg_attr(feature = "introspection", derive(Type))]
+#[cfg_attr(feature = "introspection", zlink(crate = "crate"))]
 pub struct InterfaceDescription<'a> {
     description: Description<'a>,
 }
@@ -94,6 +97,7 @@ enum Description<'a> {
     Raw(String),
 }
 
+#[cfg(feature = "introspection")]
 impl Type for Description<'_> {
     const TYPE: &'static crate::idl::Type<'static> = &crate::idl::Type::String;
 }

--- a/zlink-core/src/varlink_service/mod.rs
+++ b/zlink-core/src/varlink_service/mod.rs
@@ -13,10 +13,13 @@ mod proxy;
 #[cfg(feature = "idl-parse")]
 pub use proxy::{Chain, Proxy};
 
+#[cfg(feature = "idl")]
 mod interface_description;
+#[cfg(feature = "idl")]
 pub use interface_description::InterfaceDescription;
 
 /// The description of the `org.varlink.service` interface.
+#[cfg(feature = "introspection")]
 pub const DESCRIPTION: &crate::idl::Interface<'static> = &{
     use crate::{
         idl::{Comment, Interface, Method, Parameter},


### PR DESCRIPTION
- **✨ core: impl Deserialize for varlink_service::Error for no_std**
- **♻️  core: Refactor ReadConnection::receive_reply impl**
- **🏗️ core: Impl core::error::Error for varlink_service::Error**
- **🚩 core: varlink_service mod shouldn't require `introspection` feature**
- **⚡️ core: Derive defmt::Format for varlink_service::Error**
- **🎨 core: Use variable directly in format string**
- **✨ core: impl introspect::Type for mayheap::String**
- **📝 TODO: Update**

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
