### PR TITLE
🚸 core: Handle services returning Varlink service interface errors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,13 +2,6 @@
 
 ## Release 0.1.0
 
-* zlink-core
-  * Any method call can return varlink_service::Error
-    * Add `VarlinkService` variant to `zlink_core::Error`
-    * ReadConnection::receive_reply
-      * if error name has `org.varlink.service` prefix,
-        * deserialize to `varlink_service::Error`
-        * return `zlink_core::Error::VarlinkService`
 * zlink-macros
   * Add `Interface` prefix to all intropsection derives
     * The re-exports from zlink-core use alias to keep their name.
@@ -16,11 +9,14 @@
     * Takes enums only
     * Adds
       * `serde::Serialize` derive attribute
-      * `std`: `serde::Deserialize` derive attribute
-      * `no_std`: Manual `serde::Deserialize` impl
-        * Require `error` to be the first field to avoid allocation
+      * Manual `serde::Deserialize` impl
+        * For `no_std`, require `error` to be the first field to avoid allocation
           * See `varlink_service::Error`'s `Deserialize` impl for example.
-    * Update documentation & tests.
+        * Ensure lack or presence of empty `parameters` for unit variants isn't a problem
+          * See https://github.com/serde-rs/serde/issues/2045
+    * Re-export from `zlink_core` root
+    * Update documentation & all tests (use through `zlink_core` re-export only)
+      * Ensure the example code in macro's own docs also uses the `zlink_core` re-export.
   * `proxy` attribute macro
     * check macro code for other cleanups refactors possible
     * chaining/pipelining.

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,17 @@
         * deserialize to `varlink_service::Error`
         * return `zlink_core::Error::VarlinkService`
 * zlink-macros
+  * Add `Interface` prefix to all intropsection derives
+    * The re-exports from zlink-core use alias to keep their name.
+  * Add `ReplyError` derive
+    * Takes enums only
+    * Adds
+      * `serde::Serialize` derive attribute
+      * `std`: `serde::Deserialize` derive attribute
+      * `no_std`: Manual `serde::Deserialize` impl
+        * Require `error` to be the first field to avoid allocation
+          * See `varlink_service::Error`'s `Deserialize` impl for example.
+    * Update documentation & tests.
   * `proxy` attribute macro
     * check macro code for other cleanups refactors possible
     * chaining/pipelining.
@@ -17,10 +28,12 @@
     * Avoid cloning in the macro code, where possible (use references).
 * Replace `println!` with `tracing` logging in tests
   * May need to add a subscriber for tests
+* zlink-core
+  * impl `introspect::Type` for common types
 * zlink-codegen (generates code from IDL)
   * Make use of `zlink_core::idl` module
   * tests
-* mdbook-based tutorial
+* Populate README.md with examples, usage instructions and features documentation
 * More metadata in Cargo.toml files
 
 ## Release 0.2.0
@@ -38,7 +51,7 @@
   * tests
   * Update Service docs: Prefer using `service` macro over a manual implementation.
   * Update connection docs to recommend/show use of `proxy` & `service` macros.
-  * Update Tutorial
+* mdbook-based tutorial
 * zlink-core
   * cargo features to allow use of `idl` only
 

--- a/zlink-core/src/error.rs
+++ b/zlink-core/src/error.rs
@@ -29,6 +29,8 @@ pub enum Error {
     IdlParse(String),
     /// Missing required parameters.
     MissingParameters,
+    /// A general service error.
+    VarlinkService(crate::varlink_service::Error),
 }
 
 /// The Result type for the zlink crate.
@@ -48,6 +50,7 @@ impl core::error::Error for Error {
             Error::InvalidUtf8(e) => Some(e),
             #[cfg(feature = "idl-parse")]
             Error::IdlParse(_) => None,
+            Error::VarlinkService(e) => Some(e),
             _ => None,
         }
     }
@@ -108,6 +111,7 @@ impl core::fmt::Display for Error {
             #[cfg(feature = "idl-parse")]
             Error::IdlParse(e) => write!(f, "IDL parse error: {e}"),
             Error::MissingParameters => write!(f, "Missing required parameters"),
+            Error::VarlinkService(e) => write!(f, "{e}"),
         }
     }
 }
@@ -137,6 +141,7 @@ impl defmt::Format for Error {
             #[cfg(feature = "idl-parse")]
             Error::IdlParse(_) => defmt::write!(fmt, "IDL parse error"),
             Error::MissingParameters => defmt::write!(fmt, "Missing required parameters"),
+            Error::VarlinkService(_) => defmt::write!(fmt, "Varlink service error"),
         }
     }
 }

--- a/zlink-core/src/varlink_service/mod.rs
+++ b/zlink-core/src/varlink_service/mod.rs
@@ -18,6 +18,9 @@ mod interface_description;
 #[cfg(feature = "idl")]
 pub use interface_description::InterfaceDescription;
 
+/// The name of the `org.varlink.service` interface.
+pub const INTERFACE_NAME: &str = "org.varlink.service";
+
 /// The description of the `org.varlink.service` interface.
 #[cfg(feature = "introspection")]
 pub const DESCRIPTION: &crate::idl::Interface<'static> = &{
@@ -49,7 +52,7 @@ pub const DESCRIPTION: &crate::idl::Interface<'static> = &{
     ];
 
     Interface::new(
-        "org.varlink.service",
+        INTERFACE_NAME,
         METHODS,
         &[],
         Error::VARIANTS,

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -98,11 +98,11 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
         // Unimplemented interface query should return an error.
         let error = conn
             .get_interface_description("org.varlink.unimplemented")
-            .await?
+            .await
             .unwrap_err();
         assert!(matches!(
             error,
-            varlink_service::Error::InterfaceNotFound { .. }
+            zlink::Error::VarlinkService(varlink_service::Error::InterfaceNotFound { .. })
         ));
 
         // Ask for the drive condition, then set them and then ask again.

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -215,7 +215,7 @@ impl Service for Ftl {
     type ReplyParams<'ser> = Reply<'ser>;
     type ReplyStream = notified::Stream<Self::ReplyStreamParams>;
     type ReplyStreamParams = FtlReply;
-    type ReplyError<'ser> = ReplyError<'ser>;
+    type ReplyError<'ser> = ReplyError;
 
     async fn handle<'ser>(
         &'ser mut self,
@@ -282,7 +282,7 @@ impl Service for Ftl {
                     _ => {
                         return MethodReply::Error(ReplyError::VarlinkSrv(
                             varlink_service::Error::InterfaceNotFound {
-                                interface: "unknown.interface",
+                                interface: "unknown.interface".try_into().unwrap(),
                             },
                         ))
                     }
@@ -360,9 +360,9 @@ enum Reply<'a> {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 #[allow(unused)]
-enum ReplyError<'a> {
+enum ReplyError {
     Ftl(FtlError),
-    VarlinkSrv(varlink_service::Error<'a>),
+    VarlinkSrv(varlink_service::Error),
 }
 
 //

--- a/zlink/tests/machined_proxy_e2e.rs
+++ b/zlink/tests/machined_proxy_e2e.rs
@@ -99,7 +99,6 @@ async fn introspect_machined() {
         let _ = conn
             .get_interface_description("invalid.interface.name")
             .await
-            .expect("Connection should succeed")
             .expect_err("Method should return error");
 
         Ok(())

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -201,7 +201,7 @@ impl Service for MockMachinedService {
     type ReplyParams<'ser> = Reply<'ser>;
     type ReplyStream = futures_util::stream::Empty<zlink::Reply<()>>;
     type ReplyStreamParams = ();
-    type ReplyError<'ser> = MockError<'ser>;
+    type ReplyError<'ser> = MockError;
 
     async fn handle<'ser>(
         &'ser mut self,
@@ -244,7 +244,7 @@ impl Service for MockMachinedService {
                     _ => {
                         return MethodReply::Error(MockError::VarlinkService(
                             Error::InterfaceNotFound {
-                                interface: "unknown.interface",
+                                interface: "unknown.interface".try_into().unwrap(),
                             },
                         ))
                     }
@@ -290,8 +290,8 @@ impl Service for MockMachinedService {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 #[allow(unused)]
-pub enum MockError<'a> {
-    VarlinkService(Error<'a>),
+pub enum MockError {
+    VarlinkService(Error),
     Machined(MachinedError),
 }
 


### PR DESCRIPTION
For the users. Without this change, clients can on deserialize such errors if they use some wrapper enum that combine their interfaces with `varlink_service::Error`.

