### PR TITLE
Fix README typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ An asynchronous no-std-compatible Varlink Rust crate. It consists for the follow
   enabled. This crate also provides high-level macros to each write clients and services.
 * `zlink-tokio`: `tokio`-based transport implementations and runtime integration.
 * `zlink-usb` & `zlink-micro`: Together these enables RPC between a (Linux) host and
-  microcontrollers through USB. The former is targetted for the the host side and latter for the
+  microcontrollers through USB. The former is targeted for the host side and latter for the
   microcontrollers side.


### PR DESCRIPTION
## Summary
- correct README wording

## Testing
- `cargo test` *(fails: could not compile `zlink` due to unresolved imports)*

------
https://chatgpt.com/codex/tasks/task_e_68723f1b11d88333b2c2ee74c2ae8ad5