### PR TITLE
🔥 core: varlink_service::Proxy now makes use of `proxy` macro

### DIFF
--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -36,4 +36,9 @@ serde-json-core = { version = "0.6.0", default-features = false, features = [
 ] }
 serde-prefix-all = "0.1.0"
 futures-util = { version = "0.3.31", default-features = false }
-tokio = { version = "1.42.0", features = ["macros", "rt", "test-util"] }
+tokio = { version = "1.42.0", features = [
+    "macros",
+    "rt",
+    "test-util",
+    "rt-multi-thread",
+] }

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -344,6 +344,15 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// The macro also generates a chain extension trait that allows you to chain multiple method
 /// calls together for efficient batching across multiple interfaces.
 ///
+/// # Supported Attributes
+///
+/// The following attributes can be used to customize the behavior of this macro:
+///
+/// * `interface` (required) - The Varlink interface name (e.g., `"org.varlink.service"`).
+/// * `crate` - Specifies the crate path to use for zlink types. Defaults to `::zlink`.
+/// * `chain_name` - Custom name for the generated chain extension trait. Defaults to
+///   `{TraitName}Chain`.
+///
 /// # Example
 ///
 /// ```rust

--- a/zlink-macros/src/proxy.rs
+++ b/zlink-macros/src/proxy.rs
@@ -117,18 +117,14 @@ fn parse_proxy_attributes(
     if attr.is_empty() {
         return Err(Error::new_spanned(
             trait_def,
-            "proxy macro requires interface name, e.g. #[proxy(\"org.example.Interface\")] or #[proxy(interface = \"org.example.Interface\")]",
+            "proxy macro requires interface name, e.g. #[proxy(\"org.example.Interface\")] \
+             or #[proxy(interface = \"org.example.Interface\")]",
         ));
     }
 
     // Try parsing as a simple string literal first (backward compatibility)
-    if let Ok(interface_lit) = parse2::<Lit>(attr.clone()) {
-        match interface_lit {
-            Lit::Str(lit_str) => {
-                return Ok((lit_str.value(), quote! { ::zlink }, None));
-            }
-            _ => {}
-        }
+    if let Ok(Lit::Str(lit_str)) = parse2::<Lit>(attr.clone()) {
+        return Ok((lit_str.value(), quote! { ::zlink }, None));
     }
 
     // Parse as name-value pairs
@@ -158,7 +154,8 @@ fn parse_proxy_attributes(
     let interface_name = interface_name.ok_or_else(|| {
         Error::new_spanned(
             trait_def,
-            "proxy macro requires 'interface' parameter, e.g. #[proxy(interface = \"org.example.Interface\")]",
+            "proxy macro requires 'interface' parameter, \
+             e.g. #[proxy(interface = \"org.example.Interface\")]",
         )
     })?;
 

--- a/zlink-macros/src/proxy.rs
+++ b/zlink-macros/src/proxy.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse2, Error, ItemTrait, Lit, TraitItem};
+use syn::{parse::Parser, parse2, Error, ItemTrait, Lit, TraitItem};
 
 mod chain_extension;
 mod chain_method;
@@ -24,8 +24,8 @@ pub(crate) fn proxy(attr: TokenStream, input: TokenStream) -> TokenStream {
 fn proxy_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Error> {
     let mut trait_def = parse2::<ItemTrait>(input)?;
 
-    // Parse the interface name from the attribute
-    let interface_name = parse_interface_name(&attr, &trait_def)?;
+    // Parse the interface name and crate path from the attribute
+    let (interface_name, crate_path) = parse_proxy_attributes(&attr, &trait_def)?;
 
     // Validate trait definition
     validate_trait(&trait_def)?;
@@ -49,6 +49,7 @@ fn proxy_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Erro
                 &interface_name,
                 &trait_def.generics,
                 &method_attrs,
+                &crate_path,
             )?;
             if !extension_method.is_empty() {
                 chain_extension_methods.push(extension_method);
@@ -58,13 +59,23 @@ fn proxy_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Erro
             }
 
             // Generate regular method implementation
-            let method_impl =
-                generate_method_impl(method, &interface_name, &trait_def.generics, &method_attrs)?;
+            let method_impl = generate_method_impl(
+                method,
+                &interface_name,
+                &trait_def.generics,
+                &method_attrs,
+                &crate_path,
+            )?;
             methods.push(method_impl);
 
             // Generate chain method
-            let (chain_trait, chain_impl) =
-                generate_chain_method(method, &interface_name, &trait_def.generics, &method_attrs)?;
+            let (chain_trait, chain_impl) = generate_chain_method(
+                method,
+                &interface_name,
+                &trait_def.generics,
+                &method_attrs,
+                &crate_path,
+            )?;
             if !chain_trait.is_empty() {
                 chain_method_traits.push(chain_trait);
             }
@@ -75,18 +86,20 @@ fn proxy_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Erro
     }
 
     // Build the output components
-    let trait_output = build_trait_output(&mut trait_def, &chain_method_traits)?;
+    let trait_output = build_trait_output(&mut trait_def, &chain_method_traits, &crate_path)?;
     let impl_output = build_impl_output(
         &trait_def.ident,
         &trait_def.generics,
         &trait_def.generics.where_clause,
         &methods,
         &chain_method_impls,
+        &crate_path,
     );
     let chain_extension_trait_output = build_chain_extension_trait(
         &trait_def.ident,
         &chain_extension_methods,
         &chain_extension_impls,
+        &crate_path,
     );
 
     Ok(quote! {
@@ -96,22 +109,57 @@ fn proxy_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Erro
     })
 }
 
-fn parse_interface_name(attr: &TokenStream, trait_def: &ItemTrait) -> Result<String, Error> {
+fn parse_proxy_attributes(
+    attr: &TokenStream,
+    trait_def: &ItemTrait,
+) -> Result<(String, TokenStream), Error> {
     if attr.is_empty() {
         return Err(Error::new_spanned(
             trait_def,
-            "proxy macro requires interface name, e.g. #[proxy(\"org.example.Interface\")]",
+            "proxy macro requires interface name, e.g. #[proxy(\"org.example.Interface\")] or #[proxy(interface = \"org.example.Interface\")]",
         ));
     }
 
-    let interface_lit: Lit = parse2(attr.clone())?;
-    match interface_lit {
-        Lit::Str(lit_str) => Ok(lit_str.value()),
-        _ => Err(Error::new_spanned(
-            &interface_lit,
-            "interface name must be a string literal",
-        )),
+    // Try parsing as a simple string literal first (backward compatibility)
+    if let Ok(interface_lit) = parse2::<Lit>(attr.clone()) {
+        match interface_lit {
+            Lit::Str(lit_str) => {
+                return Ok((lit_str.value(), quote! { ::zlink }));
+            }
+            _ => {}
+        }
     }
+
+    // Parse as name-value pairs
+    let mut interface_name = None;
+    let mut crate_path = None;
+
+    let parser = syn::meta::parser(|meta| {
+        if meta.path.is_ident("interface") {
+            let value: syn::LitStr = meta.value()?.parse()?;
+            interface_name = Some(value.value());
+        } else if meta.path.is_ident("crate") {
+            let value: syn::LitStr = meta.value()?.parse()?;
+            let path_str = value.value();
+            crate_path = Some(syn::parse_str(&path_str)?);
+        } else {
+            return Err(meta.error("unsupported attribute"));
+        }
+        Ok(())
+    });
+
+    parser.parse2(attr.clone())?;
+
+    let interface_name = interface_name.ok_or_else(|| {
+        Error::new_spanned(
+            trait_def,
+            "proxy macro requires 'interface' parameter, e.g. #[proxy(interface = \"org.example.Interface\")]",
+        )
+    })?;
+
+    let crate_path = crate_path.unwrap_or_else(|| quote! { ::zlink });
+
+    Ok((interface_name, crate_path))
 }
 
 fn validate_trait(trait_def: &ItemTrait) -> Result<(), Error> {
@@ -132,11 +180,12 @@ fn validate_trait(trait_def: &ItemTrait) -> Result<(), Error> {
 fn build_trait_output(
     trait_def: &mut ItemTrait,
     chain_method_traits: &[TokenStream],
+    crate_path: &TokenStream,
 ) -> Result<TokenStream, Error> {
     // Add the Socket associated type to the trait
     trait_def.items.push(syn::parse2(quote! {
         /// The socket type used for the connection.
-        type Socket: ::zlink::connection::socket::Socket;
+        type Socket: #crate_path::connection::socket::Socket;
     })?);
 
     // Add chain method signatures to the trait definition
@@ -156,6 +205,7 @@ fn build_impl_output(
     where_clause: &Option<syn::WhereClause>,
     methods: &[TokenStream],
     chain_method_impls: &[TokenStream],
+    crate_path: &TokenStream,
 ) -> TokenStream {
     // Build impl generics combining trait generics with socket generic
     let mut impl_generics = generics.clone();
@@ -172,12 +222,12 @@ fn build_impl_output(
     // Build where clause combining existing constraints with socket constraint and trait bounds
     let combined_where_clause = Some(build_combined_where_clause(
         where_clause.clone(),
-        syn::parse_quote!(S: ::zlink::connection::socket::Socket),
+        syn::parse_quote!(S: #crate_path::connection::socket::Socket),
         generics,
     ));
 
     quote! {
-        impl #impl_generics #trait_name #trait_generics_no_bounds for ::zlink::Connection<S>
+        impl #impl_generics #trait_name #trait_generics_no_bounds for #crate_path::Connection<S>
         #combined_where_clause
         {
             type Socket = S;
@@ -192,6 +242,7 @@ fn build_chain_extension_trait(
     trait_name: &syn::Ident,
     chain_extension_methods: &[TokenStream],
     chain_extension_impls: &[TokenStream],
+    crate_path: &TokenStream,
 ) -> TokenStream {
     if chain_extension_methods.is_empty() {
         return quote! {};
@@ -205,7 +256,7 @@ fn build_chain_extension_trait(
         /// This trait provides methods to add proxy calls to a chain of method calls.
         pub trait #chain_trait_name<'c, S, ReplyParams, ReplyError>
         where
-            S: ::zlink::connection::socket::Socket,
+            S: #crate_path::connection::socket::Socket,
             ReplyParams: ::serde::Deserialize<'c> + ::core::fmt::Debug,
             ReplyError: ::serde::Deserialize<'c> + ::core::fmt::Debug,
         {
@@ -213,9 +264,9 @@ fn build_chain_extension_trait(
         }
 
         impl<'c, S, ReplyParams, ReplyError> #chain_trait_name<'c, S, ReplyParams, ReplyError>
-            for ::zlink::connection::chain::Chain<'c, S, ReplyParams, ReplyError>
+            for #crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>
         where
-            S: ::zlink::connection::socket::Socket,
+            S: #crate_path::connection::socket::Socket,
             ReplyParams: ::serde::Deserialize<'c> + ::core::fmt::Debug,
             ReplyError: ::serde::Deserialize<'c> + ::core::fmt::Debug,
         {

--- a/zlink-macros/src/proxy.rs
+++ b/zlink-macros/src/proxy.rs
@@ -135,6 +135,7 @@ fn build_trait_output(
 ) -> Result<TokenStream, Error> {
     // Add the Socket associated type to the trait
     trait_def.items.push(syn::parse2(quote! {
+        /// The socket type used for the connection.
         type Socket: ::zlink::connection::socket::Socket;
     })?);
 

--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -12,6 +12,7 @@ pub(super) fn generate_chain_extension_method(
     interface_name: &str,
     _trait_generics: &syn::Generics,
     method_attrs: &MethodAttrs,
+    crate_path: &TokenStream,
 ) -> Result<(TokenStream, TokenStream), Error> {
     let method_name_str = method.sig.ident.to_string();
     let method_ident = method.sig.ident.clone();
@@ -58,7 +59,7 @@ pub(super) fn generate_chain_extension_method(
         .collect();
 
     if arg_infos.is_empty() {
-        generate_no_params_method(&method_ident, &method_path)
+        generate_no_params_method(&method_ident, &method_path, crate_path)
     } else {
         generate_with_params_method(
             &method_ident,
@@ -71,6 +72,7 @@ pub(super) fn generate_chain_extension_method(
             &method_where_clause,
             has_any_lifetime,
             has_explicit_lifetimes,
+            crate_path,
         )
     }
 }
@@ -153,19 +155,20 @@ fn build_combined_where_clause(method_where_clause: &Option<syn::WhereClause>) -
 fn generate_no_params_method(
     method_name: &syn::Ident,
     method_path: &str,
+    crate_path: &TokenStream,
 ) -> Result<(TokenStream, TokenStream), Error> {
     let trait_method = quote! {
         /// Add a #method_name call to this chain.
         fn #method_name(
             self,
-        ) -> ::zlink::Result<::zlink::connection::chain::Chain<'c, S, ReplyParams, ReplyError>>;
+        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>>;
     };
 
     let impl_method = quote! {
         fn #method_name(
             self,
-        ) -> ::zlink::Result<::zlink::connection::chain::Chain<'c, S, ReplyParams, ReplyError>> {
-            let call = ::zlink::Call::new({
+        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>> {
+            let call = #crate_path::Call::new({
                 #[derive(::serde::Serialize, ::core::fmt::Debug)]
                 #[serde(tag = "method")]
                 enum MethodWrapper {
@@ -193,13 +196,14 @@ fn generate_with_params_method(
     method_where_clause: &Option<syn::WhereClause>,
     has_any_lifetime: bool,
     has_explicit_lifetimes: bool,
+    crate_path: &TokenStream,
 ) -> Result<(TokenStream, TokenStream), Error> {
     let trait_method = quote! {
         /// Add a #method_name call to this chain.
         fn #method_name #generics(
             self,
             #(#param_fields,)*
-        ) -> ::zlink::Result<::zlink::connection::chain::Chain<'c, S, ReplyParams, ReplyError>>
+        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>>
         #combined_where_clause;
     };
 
@@ -233,10 +237,10 @@ fn generate_with_params_method(
         fn #method_name #generics(
             self,
             #(#param_fields,)*
-        ) -> ::zlink::Result<::zlink::connection::chain::Chain<'c, S, ReplyParams, ReplyError>>
+        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>>
         #combined_where_clause
         {
-            let call = ::zlink::Call::new({
+            let call = #crate_path::Call::new({
                 #[derive(::serde::Serialize, ::core::fmt::Debug)]
                 struct #params_struct_name #generics
                 #struct_where

--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -161,13 +161,17 @@ fn generate_no_params_method(
         /// Add a #method_name call to this chain.
         fn #method_name(
             self,
-        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>>;
+        ) -> #crate_path::Result<
+            #crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>
+        >;
     };
 
     let impl_method = quote! {
         fn #method_name(
             self,
-        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>> {
+        ) -> #crate_path::Result<
+            #crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>
+        > {
             let call = #crate_path::Call::new({
                 #[derive(::serde::Serialize, ::core::fmt::Debug)]
                 #[serde(tag = "method")]
@@ -203,7 +207,9 @@ fn generate_with_params_method(
         fn #method_name #generics(
             self,
             #(#param_fields,)*
-        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>>
+        ) -> #crate_path::Result<
+            #crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>
+        >
         #combined_where_clause;
     };
 
@@ -237,7 +243,9 @@ fn generate_with_params_method(
         fn #method_name #generics(
             self,
             #(#param_fields,)*
-        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>>
+        ) -> #crate_path::Result<
+            #crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>
+        >
         #combined_where_clause
         {
             let call = #crate_path::Call::new({

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -12,6 +12,7 @@ pub(super) fn generate_chain_method(
     interface_name: &str,
     _trait_generics: &syn::Generics,
     method_attrs: &MethodAttrs,
+    crate_path: &TokenStream,
 ) -> Result<(TokenStream, TokenStream), Error> {
     let method_name_str = method.sig.ident.to_string();
     let method_ident = method.sig.ident.clone();
@@ -73,7 +74,7 @@ pub(super) fn generate_chain_method(
         fn #chain_method_name<#all_generics>(
             &'c mut self,
             #(#args_with_types),*
-        ) -> ::zlink::Result<::zlink::connection::chain::Chain<'c, Self::Socket, ReplyParams, ReplyError>>
+        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, Self::Socket, ReplyParams, ReplyError>>
         #chain_where;
     };
 
@@ -87,6 +88,7 @@ pub(super) fn generate_chain_method(
         &method_where_clause,
         has_any_lifetime,
         has_explicit_lifetimes,
+        crate_path,
     );
 
     // Generate the implementation method
@@ -94,7 +96,7 @@ pub(super) fn generate_chain_method(
         fn #chain_method_name<#all_generics>(
             &'c mut self,
             #(#args_with_types),*
-        ) -> ::zlink::Result<::zlink::connection::chain::Chain<'c, Self::Socket, ReplyParams, ReplyError>>
+        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, Self::Socket, ReplyParams, ReplyError>>
         #chain_where
         {
             #method_call_creation
@@ -178,6 +180,7 @@ fn generate_method_call_creation(
     method_where_clause: &Option<syn::WhereClause>,
     has_any_lifetime: bool,
     has_explicit_lifetimes: bool,
+    crate_path: &TokenStream,
 ) -> TokenStream {
     if !arg_names.is_empty() {
         let param_fields: Vec<_> = arg_infos
@@ -242,7 +245,7 @@ fn generate_method_call_creation(
             let method_call = #wrapper_enum_name::Method(#params_struct_name {
                 #(#arg_names,)*
             });
-            let call = ::zlink::Call::new(method_call);
+            let call = #crate_path::Call::new(method_call);
         }
     } else {
         // Create unique enum name for this method to avoid conflicts
@@ -263,7 +266,7 @@ fn generate_method_call_creation(
             }
 
             let method_call = #wrapper_enum_name::Method;
-            let call = ::zlink::Call::new(method_call);
+            let call = #crate_path::Call::new(method_call);
         }
     }
 }

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -74,7 +74,9 @@ pub(super) fn generate_chain_method(
         fn #chain_method_name<#all_generics>(
             &'c mut self,
             #(#args_with_types),*
-        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, Self::Socket, ReplyParams, ReplyError>>
+        ) -> #crate_path::Result<
+            #crate_path::connection::chain::Chain<'c, Self::Socket, ReplyParams, ReplyError>
+        >
         #chain_where;
     };
 
@@ -96,7 +98,9 @@ pub(super) fn generate_chain_method(
         fn #chain_method_name<#all_generics>(
             &'c mut self,
             #(#args_with_types),*
-        ) -> #crate_path::Result<#crate_path::connection::chain::Chain<'c, Self::Socket, ReplyParams, ReplyError>>
+        ) -> #crate_path::Result<
+            #crate_path::connection::chain::Chain<'c, Self::Socket, ReplyParams, ReplyError>
+        >
         #chain_where
         {
             #method_call_creation

--- a/zlink-macros/tests/proxy_crate_attr.rs
+++ b/zlink-macros/tests/proxy_crate_attr.rs
@@ -1,0 +1,31 @@
+//! Test that proxy macro works with both old and new attribute formats
+
+use zlink::proxy;
+
+// Test old format (backward compatibility)
+#[proxy("org.example.old")]
+pub trait OldFormat {
+    async fn test(&mut self) -> zlink::Result<Result<(), TestError>>;
+}
+
+// Test new format with interface only
+#[proxy(interface = "org.example.new")]
+pub trait NewFormat {
+    async fn test(&mut self) -> zlink::Result<Result<(), TestError>>;
+}
+
+// Test new format with interface and crate
+#[proxy(interface = "org.example.full", crate = "::zlink")]
+pub trait FullFormat {
+    async fn test(&mut self) -> ::zlink::Result<Result<(), TestError>>;
+}
+
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError)]
+#[zlink(interface = "org.example.test")]
+pub enum TestError {}
+
+#[test]
+fn test_compilation() {
+    // This test just verifies that the code compiles
+    // which means the proxy macro correctly handles all formats
+}


### PR DESCRIPTION
- **📝 macros: Document the associated `Socket` type added to `proxy` trait**
- **✨ macros: `proxy` now supports `crate` attribute**
- **✨ macros: `proxy` now allows specifying name of generated chain trait**
- **🔥 core: varlink_service::Proxy now makes use of `proxy` macro**
- **🚩 macros: Enable `rt-multi-thread` feature of tokio in dev**
- **♻️  macros: Break long lines**
- **📝 macros: Document `proxy` attributes**
