### PR TITLE
🔖 Ready for 0.1.0 

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,6 +2,7 @@ name: Lint, Build and Test
 
 on:
   push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,6 +1123,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
 ]
 
 [[package]]
@@ -1136,9 +1148,11 @@ dependencies = [
  "once_cell",
  "regex",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1175,6 +1189,12 @@ name = "uuid"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "wasi"
@@ -1415,6 +1435,7 @@ dependencies = [
  "tempfile",
  "test-log",
  "tokio",
+ "tracing-subscriber",
  "zlink-tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,7 +1422,7 @@ dependencies = [
 
 [[package]]
 name = "zlink"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 dependencies = [
  "clap",
  "colored",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-codegen"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1453,7 +1453,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-core"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -1479,7 +1479,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-macros"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 dependencies = [
  "futures-util",
  "proc-macro2",
@@ -1499,7 +1499,7 @@ version = "0.0.1-alpha.1"
 
 [[package]]
 name = "zlink-tokio"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 dependencies = [
  "futures-util",
  "serde",

--- a/README.md
+++ b/README.md
@@ -8,8 +8,13 @@ An asynchronous no-std-compatible Varlink Rust crate. It consists for the follow
   directly. It re-exports API from the appropriate crate(s) depending on the cargo feature(s)
   enabled. This crate also provides high-level macros to each write clients and services.
 * `zlink-tokio`: `tokio`-based transport implementations and runtime integration.
-* `zlink-usb` & `zlink-micro`: Together these enables RPC between a (Linux) host and
-  microcontrollers through USB. The former is targetted for the the host side and latter for the
-  microcontrollers side.
 * `zlink-codegen`: Code generation tool for Varlink interfaces. Generates Rust code from Varlink
   IDL files.
+
+## Future crates
+
+### `zlink-usb` and `zlink-micro`
+
+Together these will enable RPC between a (Linux) host and microcontroller(s) through USB (and
+perhaps other transports as well). You'll use the former on the host side and latter on the
+microcontroller side.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,466 @@
 # zlink
 
-An asynchronous no-std-compatible Varlink Rust crate. It consists for the following subcrates:
+[![CI Pipeline Status](https://github.com/zeenix/zlink/actions/workflows/rust.yml/badge.svg)][cips]
+[![crates.io](https://img.shields.io/crates/v/zlink.svg)][crates.io]
+[![Documentation](https://docs.rs/zlink/badge.svg)][`zlink`]
+[![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)][license]
 
-* `zlink-core`: A no-std and no-alloc crate that provides all the core API. It leaves the actual
-  transport & high-level API to other crates. This crate is not intended to be used directly.
-* `zlink`: The main crate that provides a unified API and will typically be the crate you'd use
-  directly. It re-exports API from the appropriate crate(s) depending on the cargo feature(s)
-  enabled. This crate also provides high-level macros to each write clients and services.
-* `zlink-tokio`: `tokio`-based transport implementations and runtime integration.
-* `zlink-codegen`: Code generation tool for Varlink interfaces. Generates Rust code from Varlink
-  IDL files.
+A Rust implementation of the [Varlink](https://varlink.org/) IPC protocol. zlink provides a safe,
+async API for building Varlink services and clients with support for both standard and embedded
+(no-std) environments.
 
-## Future crates
+## Overview
 
-### `zlink-usb` and `zlink-micro`
+Varlink is a simple, JSON-based IPC protocol that enables communication between system services and
+applications. zlink makes it easy to implement Varlink services in Rust with:
 
-Together these will enable RPC between a (Linux) host and microcontroller(s) through USB (and
-perhaps other transports as well). You'll use the former on the host side and latter on the
-microcontroller side.
+- **Async-first design**: Built on async/await for efficient concurrent operations.
+- **Type safety**: Leverage Rust's type system with derive macros and code generation.
+- **No-std support**: Run on embedded systems without heap allocation.
+- **Multiple transports**: Unix domain sockets and (upcoming) USB support.
+- **Code generation**: Generate Rust code from Varlink IDL files.
+
+## Project Structure
+
+The zlink project consists of several subcrates:
+
+- **[`zlink`]**: The main unified API crate that re-exports functionality based on enabled features.
+  This is the only crate you will want to use directly in your application and services.
+- **[`zlink-core`]**: Core no-std/no-alloc foundation providing essential Varlink types and traits.
+- **[`zlink-macros`]**: Contains the attribute and derive macros.
+- **[`zlink-tokio`]**: `Tokio`-based transport implementations and runtime integration.
+- **[`zlink-codegen`]**: Code generation tool for creating Rust bindings from Varlink IDL files.
+
+## Examples
+
+### Example: Calculator Service and Client
+
+> **Note**: For service implementation, zlink currently only provides a low-level API. A high-level
+> service API with attribute macros (similar to the `proxy` macro for clients) is planned for the
+> near future.
+
+Here's a complete example showing both service implementation and client usage through the `proxy`
+macro:
+
+```rust
+use serde::{Deserialize, Serialize};
+use tokio::{select, sync::oneshot, fs::remove_file};
+use zlink::{
+    proxy,
+    service::{MethodReply, Service},
+    unix, Call, ReplyError, Server,
+};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create a channel to signal when server is ready
+    let (ready_tx, ready_rx) = oneshot::channel();
+
+    // Run server and client concurrently
+    select! {
+        res = run_server(ready_tx) => res?,
+        res = run_client(ready_rx) => res?,
+    }
+
+    Ok(())
+}
+
+async fn run_client(ready_rx: oneshot::Receiver<()>) -> Result<(), Box<dyn std::error::Error>> {
+    // Wait for server to be ready
+    ready_rx.await.map_err(|_| "Server failed to start")?;
+
+    // Connect to the calculator service
+    let mut conn = unix::connect(SOCKET_PATH).await?;
+
+    // Use the proxy-generated methods
+    let result = conn.add(5.0, 3.0).await?.unwrap();
+    assert_eq!(result.result, 8.0);
+
+    let result = conn.multiply(4.0, 7.0).await?.unwrap();
+    assert_eq!(result.result, 28.0);
+
+    // Handle errors properly
+    let Err(CalculatorError::DivisionByZero { message }) = conn.divide(10.0, 0.0).await? else {
+        panic!("Expected DivisionByZero error");
+    };
+    assert_eq!(message, "Cannot divide by zero");
+
+    // Test invalid input error with large dividend
+    let Err(CalculatorError::InvalidInput {
+        field,
+        reason,
+    }) = conn.divide(2000000.0, 2.0).await? else {
+        panic!("Expected InvalidInput error");
+    };
+    println!("Field: {}, Reason: {}", field, reason);
+
+    let stats = conn.get_stats().await?.unwrap();
+    assert_eq!(stats.count, 2);
+    println!("Stats: {:?}", stats);
+
+    Ok(())
+}
+
+// The client proxy - this implements the trait for `Connection<S>`
+#[proxy("org.example.Calculator")]
+trait CalculatorProxy {
+    async fn add(
+        &mut self,
+        a: f64,
+        b: f64,
+    ) -> zlink::Result<Result<CalculationResult, CalculatorError<'_>>>;
+    async fn multiply(
+        &mut self,
+        x: f64,
+        y: f64,
+    ) -> zlink::Result<Result<CalculationResult, CalculatorError<'_>>>;
+    async fn divide(
+        &mut self,
+        dividend: f64,
+        divisor: f64,
+    ) -> zlink::Result<Result<CalculationResult, CalculatorError<'_>>>;
+    async fn get_stats(
+        &mut self,
+    ) -> zlink::Result<Result<Statistics<'_>, CalculatorError<'_>>>;
+}
+
+// Types shared between client and server
+#[derive(Debug, Serialize, Deserialize)]
+struct CalculationResult {
+    result: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Statistics<'a> {
+    count: u64,
+    #[serde(borrow)]
+    operations: Vec<&'a str>,
+}
+
+#[derive(Debug, ReplyError)]
+#[zlink(interface = "org.example.Calculator")]
+enum CalculatorError<'a> {
+    DivisionByZero {
+        message: &'a str
+    },
+    InvalidInput {
+        field: &'a str,
+        reason: &'a str,
+    },
+}
+
+async fn run_server(ready_tx: oneshot::Sender<()>) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = remove_file(SOCKET_PATH).await;
+
+    // Setup the server
+    let listener = unix::bind(SOCKET_PATH)?;
+    let service = Calculator::new();
+    let server = Server::new(listener, service);
+
+    // Signal that server is ready
+    let _ = ready_tx.send(());
+
+    server.run().await.map_err(|e| e.into())
+}
+
+// The calculator service
+struct Calculator {
+    operations: Vec<String>,
+}
+
+impl Calculator {
+    fn new() -> Self {
+        Self {
+            operations: Vec::new(),
+        }
+    }
+}
+
+// Implement the Service trait
+impl Service for Calculator {
+    type MethodCall<'de> = CalculatorMethod;
+    type ReplyParams<'ser> = CalculatorReply<'ser>;
+    type ReplyStreamParams = ();
+    type ReplyStream = futures_util::stream::Empty<zlink::Reply<()>>;
+    type ReplyError<'ser> = CalculatorError<'ser>;
+
+    async fn handle<'ser>(
+        &'ser mut self,
+        call: Call<Self::MethodCall<'_>>,
+    ) -> MethodReply<Self::ReplyParams<'ser>, Self::ReplyStream, Self::ReplyError<'ser>> {
+        match call.method() {
+            CalculatorMethod::Add { a, b } => {
+                self.operations.push(format!("add({}, {})", a, b));
+                MethodReply::Single(Some(CalculatorReply::Result(CalculationResult { result: a + b })))
+            }
+            CalculatorMethod::Multiply { x, y } => {
+                self.operations.push(format!("multiply({}, {})", x, y));
+                MethodReply::Single(Some(CalculatorReply::Result(CalculationResult { result: x * y })))
+            }
+            CalculatorMethod::Divide { dividend, divisor } => {
+                if *divisor == 0.0 {
+                    MethodReply::Error(CalculatorError::DivisionByZero {
+                        message: "Cannot divide by zero",
+                    })
+                } else if dividend < &-1000000.0 || dividend > &1000000.0 {
+                    MethodReply::Error(CalculatorError::InvalidInput {
+                        field: "dividend",
+                        reason: "must be within range",
+                    })
+                } else {
+                    self.operations.push(format!("divide({}, {})", dividend, divisor));
+                    MethodReply::Single(Some(CalculatorReply::Result(CalculationResult {
+                        result: dividend / divisor,
+                    })))
+                }
+            }
+            CalculatorMethod::GetStats => {
+                let ops: Vec<&str> = self.operations.iter().map(|s| s.as_str()).collect();
+                MethodReply::Single(Some(CalculatorReply::Stats(Statistics {
+                    count: self.operations.len() as u64,
+                    operations: ops,
+                })))
+            }
+        }
+    }
+}
+
+// Method calls the service handles
+#[derive(Debug, Deserialize)]
+#[serde(tag = "method", content = "parameters")]
+enum CalculatorMethod {
+    #[serde(rename = "org.example.Calculator.Add")]
+    Add { a: f64, b: f64 },
+    #[serde(rename = "org.example.Calculator.Multiply")]
+    Multiply { x: f64, y: f64 },
+    #[serde(rename = "org.example.Calculator.Divide")]
+    Divide { dividend: f64, divisor: f64 },
+    #[serde(rename = "org.example.Calculator.GetStats")]
+    GetStats,
+}
+
+// Reply types
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+enum CalculatorReply<'a> {
+    Result(CalculationResult),
+    #[serde(borrow)]
+    Stats(Statistics<'a>),
+}
+
+const SOCKET_PATH: &str = "/tmp/calculator_example.varlink";
+```
+
+> **Note**: Typically you would want to spawn the server in a separate task but that's not what we
+> did in the example above. Please refer to [`Server::run` docs] for the reason.
+
+## Code Generation from IDL
+
+zlink-codegen can generate Rust code from Varlink interface description files:
+
+```sh
+# Install the code generator
+cargo install zlink-codegen
+
+# Let's create a file containing Varlink IDL
+cat <<EOF > calculator.varlink
+# Calculator service interface
+interface org.example.Calculator {
+    type CalculationResult (
+        result: float
+    )
+
+    type DivisionByZeroError (
+        message: string
+    )
+
+    method Add(a: float, b: float) -> (result: float)
+    method Multiply(x: float, y: float) -> (result: float)
+    method Divide(dividend: float, divisor: float) -> (result: float)
+    error DivisionByZero(message: string)
+}
+EOF
+
+# Generate Rust code from the IDL
+zlink-codegen calculator.varlink > src/calculator_gen.rs
+```
+
+The generated code includes type definitions and proxy traits ready to use in your application.
+
+### Pipelining
+
+zlink supports method call pipelining for improved throughput and reduced latency. The `proxy` macro
+adds variants for each method named `chain_<method_name>` and a trait named `<TraitName>Chain` that
+allow you to batch multiple requests and send them out at once without waiting for individual
+responses:
+
+```rust,no_run
+use futures_util::{StreamExt, pin_mut};
+use serde::{Deserialize, Serialize};
+use zlink::{proxy, unix, ReplyError};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Connect to a batch processing service
+    let mut conn = unix::connect("/tmp/batch_processor.varlink").await?;
+
+    // Send multiple pipelined requests without waiting for responses
+    let replies = conn
+        .chain_process::<ProcessReply, ProcessError>(1, "first")?
+        .process(2, "second")?
+        .process(3, "third")?
+        .batch_process(vec![
+            ProcessRequest { id: 4, data: "batch1" },
+            ProcessRequest { id: 5, data: "batch2" },
+        ])?
+        .send()
+        .await?;
+
+    // Collect all responses
+    pin_mut!(replies);
+    let mut results = Vec::new();
+    while let Some(reply) = replies.next().await {
+        let reply = reply?;
+        if let Ok(response) = reply {
+            match response.into_parameters() {
+                Some(ProcessReply::Result(result)) => {
+                    results.push(result);
+                }
+                Some(ProcessReply::BatchResult(batch)) => {
+                    results.extend(batch.results);
+                }
+                None => {}
+            }
+        }
+    }
+
+    // Process results
+    for result in results {
+        println!("Processed item {}: {}", result.id, result.processed);
+    }
+
+    Ok(())
+}
+
+#[proxy("org.example.BatchProcessor")]
+trait BatchProcessorProxy {
+    async fn process(
+        &mut self,
+        id: u32,
+        data: &str,
+    ) -> zlink::Result<Result<ProcessReply<'_>, ProcessError>>;
+
+    async fn batch_process(
+        &mut self,
+        requests: Vec<ProcessRequest<'_>>,
+    ) -> zlink::Result<Result<ProcessReply<'_>, ProcessError>>;
+}
+
+#[derive(Debug, Serialize)]
+struct ProcessRequest<'a> {
+    id: u32,
+    #[serde(borrow)]
+    data: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ProcessReply<'a> {
+    #[serde(borrow)]
+    Result(ProcessResult<'a>),
+    #[serde(borrow)]
+    BatchResult(BatchResult<'a>),
+}
+
+#[derive(Debug, Deserialize)]
+struct ProcessResult<'a> {
+    id: u32,
+    #[serde(borrow)]
+    processed: &'a str,
+}
+
+#[derive(Debug, Deserialize)]
+struct BatchResult<'a> {
+    #[serde(borrow)]
+    results: Vec<ProcessResult<'a>>,
+}
+
+#[derive(Debug, ReplyError)]
+#[zlink(interface = "org.example.BatchProcessor")]
+enum ProcessError {
+    InvalidRequest,
+}
+```
+
+## Examples
+
+The repository includes a few examples:
+
+- **[resolved.rs](zlink/examples/resolved.rs)**: DNS resolution using systemd-resolved's Varlink
+  service
+- **[varlink-inspect.rs](zlink/examples/varlink-inspect.rs)**: Service introspection tool
+
+Run examples with:
+
+```bash
+cargo run --example resolved -- example.com systemd.io
+cargo run \
+  --example varlink-inspect \
+  --features idl-parse,introspection -- \
+  /run/systemd/resolve/io.systemd.Resolve
+```
+
+## Features
+
+### Main Features
+
+- `tokio` (default): Enable tokio runtime integration and use of standard library, `serde_json` and
+  `tracing`. This is **currently** the only supported backend and therefore required.
+- `proxy` (default): Enable the `#[proxy]` macro for type-safe client code.
+
+### IDL and Introspection
+
+- `idl`: Support for IDL type representations.
+- `introspection`: Enable runtime introspection of service interfaces.
+- `idl-parse`: Parse Varlink IDL files at runtime (requires `std`).
+
+### Buffer Size Features
+
+Control the I/O buffer size (only one can be enabled at a time):
+
+- `io-buffer-2kb` (default): 2KB buffers for minimal memory usage.
+- `io-buffer-4kb`: 4KB buffers.
+- `io-buffer-16kb`: 16KB buffers for better performance with larger messages.
+- `io-buffer-1mb`: 1MB buffers for high-throughput scenarios.
+
+> **Note**: These feature flags are mainly of interest to embedded systems. With `tokio` enabled,
+> these only represent the initial buffer sizes.
+
+## Upcoming Features & Crates
+
+- `embedded`: No-std support for embedded systems. It will enable use of:
+  - `serde-json-core` for JSON serialization and deserialization.
+  - `embassy-usb` for communication with a host via a USB device.
+  - `defmt` for logging.
+- `usb`: USB transport support for host-side communication.
+
+Behind the scenes, `zlink` will make use of the upcoming `zlink-micro` and `zlink-usb` crates.
+Together these will enable RPC between a (Linux) host and microcontroller(s).
+
+## Contributing
+
+We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
+
+## License
+
+This project is licensed under the [MIT License][license].
+
+[cips]: https://github.com/zeenix/zlink/actions/workflows/rust.yml
+[crates.io]: https://crates.io/crates/zlink
+[license]: ./LICENSE
+[`zlink`]: https://docs.rs/zlink
+[`zlink-core`]: https://docs.rs/zlink-core
+[`zlink-tokio`]: https://docs.rs/zlink-tokio
+[`zlink-codegen`]: https://docs.rs/zlink-codegen
+[`zlink-macros`]: https://docs.rs/zlink-macros
+[`Server::run` docs]: https://docs.rs/zlink/struct.Server.html#method.run

--- a/zlink-codegen/Cargo.toml
+++ b/zlink-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-codegen"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 description = "Utility to generate zlink code from varlink IDL files"
 edition.workspace = true
 rust-version.workspace = true
@@ -14,7 +14,7 @@ name = "zlink-codegen"
 path = "src/main.rs"
 
 [dependencies]
-zlink = { path = "../zlink", version = "0.0.1-alpha.1", features = [
+zlink = { path = "../zlink", version = "0.1.0", features = [
     "idl",
     "idl-parse",
 ] }

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-core"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 description = "The core crate of the zlink project"
 edition.workspace = true
 rust-version.workspace = true
@@ -31,7 +31,7 @@ introspection = ["idl", "zlink-macros/introspection"]
 
 [dependencies]
 serde = { version = "1.0.218", default-features = false, features = ["derive"] }
-zlink-macros = { path = "../zlink-macros", version = "0.0.1-alpha.1" }
+zlink-macros = { path = "../zlink-macros", version = "0.1.0" }
 serde_json = { version = "1.0.139", optional = true }
 serde-json-core = { version = "0.6.0", default-features = false, features = [
     "heapless",

--- a/zlink-core/src/connection/read_connection.rs
+++ b/zlink-core/src/connection/read_connection.rs
@@ -98,7 +98,7 @@ impl<Read: ReadHalf> ReadConnection<Read> {
             None => {
                 // It's a success response.
                 let ret = from_slice::<Reply<ReplyParams>>(buffer).map(Ok);
-                trace!("connection {}: received reply: {:?}", id, ret);
+                debug!("connection {}: received reply: {:?}", id, ret);
 
                 ret
             }
@@ -120,7 +120,7 @@ impl<Read: ReadHalf> ReadConnection<Read> {
         let buffer = self.read_message_bytes().await?;
 
         let call = from_slice::<Call<Method>>(buffer)?;
-        trace!("connection {}: received a call: {:?}", id, call);
+        debug!("connection {}: received a call: {:?}", id, call);
 
         Ok(call)
     }

--- a/zlink-core/src/connection/read_connection.rs
+++ b/zlink-core/src/connection/read_connection.rs
@@ -1,6 +1,6 @@
 //! Contains connection related API.
 
-use core::fmt::Debug;
+use core::{fmt::Debug, str::from_utf8_unchecked};
 
 use crate::{varlink_service, Result};
 
@@ -87,7 +87,13 @@ impl<Read: ReadHalf> ReadConnection<Read> {
         // FIXME: This will mean the document will be parsed twice. We should instead try to
         // quickly check if `error` field is present and then parse to the appropriate type based on
         // that information. Perhaps a simple parser using `winnow`?
-        match extract_error_name(buffer) {
+        let error_name = extract_error_name(buffer);
+        if error_name.is_some() {
+            // SAFETY: If an error name was successfully extracted, it is safe to assume that the
+            // buffer contains valid UTF-8 data.
+            unsafe { log_message(buffer, id) };
+        }
+        match error_name {
             Some(error_name) if error_name.starts_with(varlink_service::INTERFACE_NAME) => {
                 // Varlink service interface error need to be returned as the top-level error.
                 Err(crate::Error::VarlinkService(from_slice::<
@@ -98,6 +104,9 @@ impl<Read: ReadHalf> ReadConnection<Read> {
             None => {
                 // It's a success response.
                 let ret = from_slice::<Reply<ReplyParams>>(buffer).map(Ok);
+                // SAFETY: Since the parsing from JSON already succeeded, we can be sure that the
+                // buffer contains a valid UTF-8 string.
+                unsafe { log_message(buffer, id) };
                 debug!("connection {}: received reply: {:?}", id, ret);
 
                 ret
@@ -120,6 +129,9 @@ impl<Read: ReadHalf> ReadConnection<Read> {
         let buffer = self.read_message_bytes().await?;
 
         let call = from_slice::<Call<Method>>(buffer)?;
+        // SAFETY: Since the parsing from JSON already succeeded, we can be sure that the
+        // buffer contains a valid UTF-8 string.
+        unsafe { log_message(buffer, id) };
         debug!("connection {}: received a call: {:?}", id, call);
 
         Ok(call)
@@ -219,4 +231,18 @@ fn extract_error_name(buffer: &[u8]) -> Option<&str> {
     from_slice::<Error<'_>>(buffer)
         .ok()
         .map(|error| error.error)
+}
+
+/// Logs a message received by the connection.
+///
+/// # Safety
+///
+/// The buffer must be a valid UTF-8 string.
+#[inline(always)]
+unsafe fn log_message(buffer: &[u8], connection_id: usize) {
+    trace!(
+        "connection {}: received a message: {}",
+        connection_id,
+        unsafe { from_utf8_unchecked(buffer) },
+    );
 }

--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -6,7 +6,7 @@
     missing_docs
 )]
 #![warn(unreachable_pub, clippy::std_instead_of_core)]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
 #[cfg(all(not(feature = "std"), not(feature = "embedded")))]
 compile_error!("Either 'std' or 'embedded' feature must be enabled.");

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-macros"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 description = "Macros providing the high-level zlink API"
 edition.workspace = true
 rust-version.workspace = true

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -7,7 +7,6 @@
 #![warn(unreachable_pub)]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
-#[cfg(feature = "introspection")]
 mod utils;
 
 #[cfg(feature = "introspection")]

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -5,7 +5,7 @@
     missing_docs
 )]
 #![warn(unreachable_pub)]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
 #[cfg(feature = "introspection")]
 mod utils;

--- a/zlink-macros/src/proxy/method_impl.rs
+++ b/zlink-macros/src/proxy/method_impl.rs
@@ -5,11 +5,9 @@ use syn::{punctuated::Punctuated, Error, FnArg, Pat, Type};
 
 use super::{
     types::{ArgInfo, MethodAttrs},
-    utils::{
-        collect_used_type_params, convert_to_single_lifetime, extract_param_rename_attr,
-        is_option_type_syn, parse_return_type, snake_case_to_pascal_case, type_contains_lifetime,
-    },
+    utils::*,
 };
+use crate::utils::*;
 
 pub(super) fn generate_method_impl(
     method: &mut syn::TraitItemFn,
@@ -159,7 +157,7 @@ fn parse_method_arguments<'a>(
                 .flatten();
 
             // Check if the type is optional
-            let is_optional = is_option_type_syn(ty);
+            let is_optional = is_option_type(ty);
 
             // Only convert to single lifetime if there are no explicit lifetimes
             let ty_for_params = if has_explicit_lifetimes {

--- a/zlink-macros/src/utils.rs
+++ b/zlink-macros/src/utils.rs
@@ -1,6 +1,11 @@
+#[cfg(feature = "introspection")]
 use proc_macro2::TokenStream as TokenStream2;
+#[cfg(feature = "introspection")]
 use quote::quote;
-use syn::{Attribute, Error, GenericArgument, PathArguments, Type};
+#[cfg(feature = "introspection")]
+use syn::{Attribute, Error, GenericArgument, PathArguments};
+
+use syn::Type;
 
 /// Parse the crate path from attributes, defaulting to `::zlink`.
 ///
@@ -14,6 +19,7 @@ use syn::{Attribute, Error, GenericArgument, PathArguments, Type};
 /// #[zlink(crate = "crate")]
 /// struct MyStruct;
 /// ```
+#[cfg(feature = "introspection")]
 pub(crate) fn parse_crate_path(attrs: &[Attribute]) -> Result<TokenStream2, Error> {
     for attr in attrs {
         if attr.path().is_ident("zlink") {
@@ -44,6 +50,7 @@ pub(crate) fn parse_crate_path(attrs: &[Attribute]) -> Result<TokenStream2, Erro
 /// Extract doc comments from attributes.
 ///
 /// Each `#[doc = "..."]` attribute becomes a single comment string.
+#[cfg(feature = "introspection")]
 pub(crate) fn extract_doc_comments(attrs: &[Attribute]) -> Vec<String> {
     let mut comments = Vec::new();
 
@@ -68,6 +75,7 @@ pub(crate) fn extract_doc_comments(attrs: &[Attribute]) -> Vec<String> {
 }
 
 /// Recursively removes all lifetimes from a type.
+#[cfg(feature = "introspection")]
 pub(crate) fn remove_lifetimes_from_type(ty: &Type) -> Type {
     match ty {
         Type::Reference(type_ref) => Type::Reference(syn::TypeReference {

--- a/zlink-macros/src/utils.rs
+++ b/zlink-macros/src/utils.rs
@@ -173,3 +173,13 @@ pub(crate) fn remove_lifetimes_from_type(ty: &Type) -> Type {
         _ => ty.clone(),
     }
 }
+
+/// Check if a type is Option<T>.
+pub(crate) fn is_option_type(ty: &Type) -> bool {
+    if let Type::Path(type_path) = ty {
+        if let Some(segment) = type_path.path.segments.last() {
+            return segment.ident == "Option";
+        }
+    }
+    false
+}

--- a/zlink-macros/tests/reply-error-derive.rs
+++ b/zlink-macros/tests/reply-error-derive.rs
@@ -5,8 +5,22 @@ use zlink_macros::ReplyError;
 enum TestError<'a> {
     NotFound,
     PermissionDenied,
-    InvalidInput { field: &'a str, reason: &'a str },
-    Timeout { seconds: u32 },
+    InvalidInput {
+        field: &'a str,
+        reason: &'a str,
+    },
+    Timeout {
+        seconds: u32,
+    },
+    // Test variant with renamed fields
+    RenamedFields {
+        #[zlink(rename = "actualName")]
+        _internal_name: &'a str,
+        #[zlink(rename = "errorCode")]
+        _code: i32,
+        #[zlink(rename = "optionalData")]
+        _optional: Option<&'a str>,
+    },
 }
 
 #[cfg(test)]
@@ -46,6 +60,81 @@ mod tests {
         // Test with error that has no parameters
         let original = TestError::NotFound;
         round_trip_serialize(&original);
+    }
+
+    #[test]
+    fn renamed_fields_serialization() {
+        // Test that renamed fields are serialized with their renamed names
+        let error = TestError::RenamedFields {
+            _internal_name: "test_value",
+            _code: 42,
+            _optional: Some("optional_value"),
+        };
+
+        let json = serde_json::to_string(&error).unwrap();
+
+        // Check that the JSON contains the renamed field names, not the original ones
+        assert!(json.contains(r#""actualName":"test_value""#));
+        assert!(json.contains(r#""errorCode":42"#));
+        assert!(json.contains(r#""optionalData":"optional_value""#));
+
+        // Ensure original field names are NOT in the JSON
+        assert!(!json.contains("_internal_name"));
+        assert!(!json.contains("_code"));
+        assert!(!json.contains("_optional"));
+    }
+
+    #[test]
+    fn renamed_fields_deserialization() {
+        // Test deserialization with renamed fields
+        let json = r#"{"error":"com.example.Test.RenamedFields","parameters":{"actualName":"test_value","errorCode":42,"optionalData":"optional_value"}}"#;
+
+        let deserialized: TestError = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            deserialized,
+            TestError::RenamedFields {
+                _internal_name: "test_value",
+                _code: 42,
+                _optional: Some("optional_value"),
+            }
+        );
+
+        // Test with optional field missing (should deserialize as None)
+        let json_no_optional = r#"{"error":"com.example.Test.RenamedFields","parameters":{"actualName":"test_value","errorCode":42}}"#;
+
+        let deserialized: TestError = serde_json::from_str(json_no_optional).unwrap();
+        assert_eq!(
+            deserialized,
+            TestError::RenamedFields {
+                _internal_name: "test_value",
+                _code: 42,
+                _optional: None,
+            }
+        );
+
+        // Test that using original field names fails
+        let json_with_original_names = r#"{"error":"com.example.Test.RenamedFields","parameters":{"_internal_name":"test_value","_code":42}}"#;
+        let result: Result<TestError, _> = serde_json::from_str(json_with_original_names);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn renamed_fields_round_trip() {
+        // Test round-trip with all fields present
+        let original = TestError::RenamedFields {
+            _internal_name: "round_trip_test",
+            _code: 999,
+            _optional: Some("with_optional"),
+        };
+        round_trip_serialize(&original);
+
+        // Test round-trip with optional field as None
+        let original_no_optional = TestError::RenamedFields {
+            _internal_name: "no_optional",
+            _code: 123,
+            _optional: None,
+        };
+        round_trip_serialize(&original_no_optional);
     }
 
     #[test]

--- a/zlink-micro/src/lib.rs
+++ b/zlink-micro/src/lib.rs
@@ -5,7 +5,7 @@
     missing_docs
 )]
 #![warn(unreachable_pub)]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
 /// Add two numbers together.
 pub fn add(left: u64, right: u64) -> u64 {

--- a/zlink-tokio/Cargo.toml
+++ b/zlink-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-tokio"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 description = "zlink library for the Tokio runtime"
 edition.workspace = true
 rust-version.workspace = true
@@ -18,7 +18,7 @@ io-buffer-16kb = ["zlink-core/io-buffer-16kb"]
 io-buffer-1mb = ["zlink-core/io-buffer-1mb"]
 
 [dependencies]
-zlink-core = { path = "../zlink-core", version = "0.0.1-alpha.1" }
+zlink-core = { path = "../zlink-core", version = "0.1.0" }
 tokio = { version = "1.44.0", features = ["net", "io-util", "tracing"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
     "async-await",

--- a/zlink-tokio/src/lib.rs
+++ b/zlink-tokio/src/lib.rs
@@ -5,7 +5,7 @@
     missing_docs
 )]
 #![warn(unreachable_pub)]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
 pub use zlink_core::*;
 pub mod notified;

--- a/zlink-usb/src/lib.rs
+++ b/zlink-usb/src/lib.rs
@@ -5,7 +5,7 @@
     missing_docs
 )]
 #![warn(unreachable_pub)]
-#![doc = include_str!("../README.md")]
+#![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
 /// Add two numbers together.
 pub fn add(left: u64, right: u64) -> u64 {

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -49,4 +49,8 @@ mayheap = { git = "https://github.com/zeenix/mayheap", version = "0.2.0" }
 
 [[example]]
 name = "varlink-inspect"
-required-features = ["introspection", "idl-parse"]
+required-features = ["introspection", "idl-parse", "tokio"]
+
+[[example]]
+name = "resolved"
+required-features = ["proxy", "tokio"]

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink"
-version = "0.0.1-alpha.1"
+version = "0.1.0"
 description = "Async Varlink API"
 edition.workspace = true
 rust-version.workspace = true
@@ -20,7 +20,7 @@ io-buffer-16kb = ["zlink-tokio/io-buffer-16kb"]
 io-buffer-1mb = ["zlink-tokio/io-buffer-1mb"]
 
 [dependencies]
-zlink-tokio = { path = "../zlink-tokio", version = "0.0.1-alpha.1", default-features = false, optional = true }
+zlink-tokio = { path = "../zlink-tokio", version = "0.1.0", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.44.0", features = [

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -46,6 +46,7 @@ colored = "3.0"
 tempfile = "3.8"
 serde_json = "1.0"
 mayheap = { git = "https://github.com/zeenix/mayheap", version = "0.2.0" }
+tracing-subscriber = "0.3.19"
 
 [[example]]
 name = "varlink-inspect"

--- a/zlink/examples/resolved.rs
+++ b/zlink/examples/resolved.rs
@@ -8,6 +8,9 @@ use zlink::{proxy, ReplyError};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Setup tracing subscriber
+    tracing_subscriber::fmt::init();
+
     let mut connection = zlink::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
 
     let args: Vec<_> = args().skip(1).collect();

--- a/zlink/examples/varlink-inspect.rs
+++ b/zlink/examples/varlink-inspect.rs
@@ -24,6 +24,9 @@ struct Cli {
 
 #[tokio::main]
 async fn main() {
+    // Setup tracing subscriber
+    tracing_subscriber::fmt::init();
+
     let cli = Cli::parse();
 
     if let Err(e) = run(&cli).await {


### PR DESCRIPTION
- **📝 README: Split future crates into a separate section**
- **✅ Don't include README docs when building doctests**
- **👷 Run rust workflow only for PRs & pushes to main branch**
- **🎨 Use macros in resolved example**
- **🚩 Correct & complete feature requirements list for examples**
- **➕ Add dev-dep on tracing-subscriber**
- **🔊 Setup tracing in examples**
- **🔊 core: Turn two trace calls to debug**
- **🔊 core: Log raw content of received messages at tracing level**
- **♻️  macros: Minor refactor to prep for new addition to internal utils mod**
- **🚑️ macros: Fix handling of renamed fields in ReplyError**
- **✅ macros: Tests for field renaming in ReplyError enums**
- **♻️  macros: A big refactoring sweep**
- **📝 Populate README**
- **🔖 Cut 0.1.0 for zlink, -core, -macros, -tokio and -codegen**
