### PR TITLE
🔥 core: Drop `Debug` constraint on `Service::ReplyStream`

### DIFF
--- a/zlink-core/src/server/service.rs
+++ b/zlink-core/src/server/service.rs
@@ -29,7 +29,7 @@ pub trait Service {
     /// The type of the multi-reply stream.
     ///
     /// If the client asks for multiple replies, this stream will be used to send them.
-    type ReplyStream: Stream<Item = Reply<Self::ReplyStreamParams>> + Unpin + Debug;
+    type ReplyStream: Stream<Item = Reply<Self::ReplyStreamParams>> + Unpin;
     /// The type of the error reply.
     ///
     /// This should be a type that can serialize itself to the whole reply object, containing


### PR DESCRIPTION
This constraint makes it impossible to return a `futures::BoxStream` from the service method handlers and since we don't really need `Debug` impl from the reply streams, we can just drop it.

Note however that we still have the Debug constaint on other types but I think that wouldn't be a (at least major) problem.

Fixes #96.
