### PR TITLE
✨ codegen: Introduce generate_files functions

### DIFF
--- a/zlink-codegen/src/cli.rs
+++ b/zlink-codegen/src/cli.rs
@@ -19,6 +19,10 @@ pub struct Args {
     /// Generate separate files for each interface (ignored if --output is specified).
     #[arg(short = 'm', long)]
     pub multiple_files: bool,
+
+    /// Format the generated Rust code using rustfmt.
+    #[arg(short = 'f', long)]
+    pub rustfmt: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -36,5 +40,9 @@ pub enum Command {
         /// Generate separate files for each interface.
         #[arg(short = 'm', long)]
         multiple_files: bool,
+
+        /// Format the generated Rust code using rustfmt.
+        #[arg(short = 'f', long)]
+        rustfmt: bool,
     },
 }

--- a/zlink-codegen/src/error.rs
+++ b/zlink-codegen/src/error.rs
@@ -1,0 +1,55 @@
+/// Error types that can occur during Varlink interface code generation.
+#[derive(Debug)]
+pub enum Error {
+    /// An invalid argument was provided
+    InvalidArgument,
+
+    /// An I/O error occurred during file operations.
+    Io(std::io::Error),
+
+    /// An error from the zlink-core library.
+    Zlink(zlink::Error),
+
+    /// A generic anyhow error.
+    Anyhow(anyhow::Error),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidArgument => write!(f, "Invalid argument provided"),
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Zlink(e) => write!(f, "Zlink error: {e}"),
+            Self::Anyhow(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Zlink(e) => Some(e),
+            Self::Anyhow(e) => Some(e.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<zlink::Error> for Error {
+    fn from(e: zlink::Error) -> Self {
+        Self::Zlink(e)
+    }
+}
+
+impl From<anyhow::Error> for Error {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Anyhow(e)
+    }
+}

--- a/zlink-codegen/src/lib.rs
+++ b/zlink-codegen/src/lib.rs
@@ -4,12 +4,19 @@
 //! Code generation for Varlink interfaces.
 
 use anyhow::{Context, Result};
+use std::{fs, path::PathBuf};
 use zlink::idl::Interface;
 
 mod codegen;
 pub use codegen::CodeGenerator;
+mod error;
+pub use self::error::Error;
 
 /// Generate Rust code from a Varlink interface.
+///
+/// # Errors
+///
+/// Returns an error if code generation fails.
 pub fn generate_interface(interface: &Interface<'_>) -> Result<String> {
     let mut generator = CodeGenerator::new();
     generator.generate_interface(interface, false)?;
@@ -25,7 +32,7 @@ pub fn generate_interfaces(interfaces: &[Interface<'_>]) -> Result<String> {
         generator.write_module_header()?;
     }
 
-    for interface in interfaces.iter() {
+    for interface in interfaces {
         // Skip module header for all interfaces when generating multiple.
         let skip_header = interfaces.len() > 1;
         generator.generate_interface(interface, skip_header)?;
@@ -68,4 +75,191 @@ pub fn format_code(code: &str) -> Result<String> {
     }
 
     String::from_utf8(output.stdout).context("Failed to parse rustfmt output")
+}
+
+/// Configuration options for Varlink code generation.
+///
+/// This struct provides fine-grained control over the code generation process,
+/// allowing customization of output formatting and other generation behaviors.
+///
+/// # Examples
+///
+/// ## Basic usage with default options
+/// ```
+/// use zlink_codegen::CodegenOptions;
+///
+/// let options = CodegenOptions::default();
+/// ```
+///
+/// ## Enable rustfmt formatting
+/// ```
+/// use zlink_codegen::CodegenOptions;
+///
+/// let options = CodegenOptions {
+///     rustfmt: true,
+///     ..Default::default()
+/// };
+/// ```
+#[derive(Default)]
+pub struct CodegenOptions {
+    /// Input Varlink IDL file(s).
+    pub files: Vec<PathBuf>,
+    /// Output file path (defaults to stdout if not specified).
+    pub output: Option<PathBuf>,
+    /// Generate separate files for each interface (ignored if output is specified).
+    pub multiple_files: bool,
+    /// Whether to format the generated Rust code using `rustfmt`.
+    ///
+    /// Default value: false
+    pub rustfmt: bool,
+}
+
+/// Generate Rust source files from Varlink interface files.
+///
+/// This function reads Varlink interface definition files from `config.files`, parses them,
+/// generates corresponding Rust code, and handles output based on the configuration.
+///
+/// # Behavior
+///
+/// - If `config.output` is specified: Generates a single file with all interfaces combined.
+/// - If `config.multiple_files` is true: Generates separate `.rs` files for each interface
+///   in the current working directory. The output filename is derived from the interface name
+///   (dots replaced with underscores and converted to lowercase).
+/// - Otherwise: Writes the generated code to stdout.
+///
+/// # Arguments
+///
+/// * `config` - Code generation options containing input files, output configuration, and formatting options.
+///
+/// # Returns
+///
+/// Returns `Ok(())` on successful code generation and output.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - `Error::InvalidArgument` - No input files specified or paths are invalid.
+/// - `Error::Io` - File I/O operations fail (reading input or writing output).
+/// - `Error::Zlink` - Any Varlink interface definition is malformed or invalid.
+/// - `Error::Anyhow` - Code generation or formatting encounters an error.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::PathBuf;
+/// use zlink_codegen::CodegenOptions;
+///
+/// let config = CodegenOptions {
+///     files: vec![PathBuf::from("interface.varlink")],
+///     output: Some(PathBuf::from("generated.rs")),
+///     rustfmt: true,
+///     ..Default::default()
+/// };
+/// zlink_codegen::generate_files(&config).expect("Failed to generate code");
+/// ```
+pub fn generate_files(config: &CodegenOptions) -> Result<(), Error> {
+    use std::io::Write;
+
+    if config.files.is_empty() {
+        return Err(Error::InvalidArgument);
+    }
+
+    // Read and parse all interface files
+    let mut file_contents = Vec::new();
+    for interface_file in &config.files {
+        let content = fs::read_to_string(interface_file)?;
+        file_contents.push(content);
+    }
+
+    let mut interfaces = Vec::new();
+    for content in &file_contents {
+        let interface = Interface::try_from(content.as_str())?;
+        interfaces.push(interface);
+    }
+
+    // Determine output mode
+    if let Some(output_path) = &config.output {
+        // Single output file mode
+        let code = if interfaces.len() == 1 {
+            generate_interface(&interfaces[0])?
+        } else {
+            generate_interfaces(&interfaces)?
+        };
+
+        let output = if config.rustfmt {
+            format_code(&code)?
+        } else {
+            code
+        };
+
+        fs::write(output_path, output)?;
+    } else if config.multiple_files {
+        // Multiple output files mode - generate separate file for each interface
+        for interface in &interfaces {
+            let code = generate_interface(interface)?;
+
+            let output = if config.rustfmt {
+                format_code(&code)?
+            } else {
+                code
+            };
+
+            // Generate output filename from interface name
+            let filename = interface_to_filename(interface.name());
+            let output_path = PathBuf::from(filename);
+
+            fs::write(&output_path, output)?;
+        }
+    } else {
+        // Stdout mode
+        let code = if interfaces.len() == 1 {
+            generate_interface(&interfaces[0])?
+        } else {
+            generate_interfaces(&interfaces)?
+        };
+
+        let output = if config.rustfmt {
+            format_code(&code)?
+        } else {
+            code
+        };
+
+        std::io::stdout().write_all(output.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+/// Convert an interface name to a filename.
+///
+/// The filename is converted to lowercase to comply with Rust's naming conventions.
+///
+/// For example: `"org.example.Interface"` → `"org_example_interface.rs"`
+fn interface_to_filename(interface_name: &str) -> String {
+    format!("{}.rs", interface_name.replace('.', "_").to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_interface_to_filename() {
+        assert_eq!(
+            interface_to_filename("org.example.Interface"),
+            "org_example_interface.rs"
+        );
+        assert_eq!(
+            interface_to_filename("com.example.MyService"),
+            "com_example_myservice.rs"
+        );
+        assert_eq!(
+            interface_to_filename("SimpleInterface"),
+            "simpleinterface.rs"
+        );
+        assert_eq!(
+            interface_to_filename("org.varlink.service"),
+            "org_varlink_service.rs"
+        );
+    }
 }

--- a/zlink-codegen/src/main.rs
+++ b/zlink-codegen/src/main.rs
@@ -1,12 +1,6 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
-use heck::ToSnakeCase;
-use std::{
-    fs,
-    io::{self, Write},
-};
-use zlink::idl::Interface;
-use zlink_codegen::{format_code, generate_interface, generate_interfaces};
+use zlink_codegen::CodegenOptions;
 
 mod cli;
 use cli::Args;
@@ -15,13 +9,14 @@ fn main() -> Result<()> {
     let args = Args::parse();
 
     // Handle the case where no command is provided (use files directly).
-    let (files, output, multiple_files) = match args.command {
+    let (files, output, multiple_files, rustfmt) = match args.command {
         Some(cli::Command::Generate {
             files,
             output,
             multiple_files,
-        }) => (files, output, multiple_files),
-        None => (args.files, args.output, args.multiple_files),
+            rustfmt,
+        }) => (files, output, multiple_files, rustfmt),
+        None => (args.files, args.output, args.multiple_files, args.rustfmt),
     };
 
     if files.is_empty() {
@@ -30,103 +25,16 @@ fn main() -> Result<()> {
         std::process::exit(1);
     }
 
-    // Parse all interfaces from input files.
-    // We need to keep the file contents alive because Interface borrows from them.
-    let mut file_contents = Vec::new();
-    let mut interfaces = Vec::new();
-    for file_path in &files {
-        let content = fs::read_to_string(file_path)
-            .with_context(|| format!("Failed to read file: {}", file_path.display()))?;
+    // Create configuration from command-line arguments
+    let config = CodegenOptions {
+        files,
+        output,
+        multiple_files,
+        rustfmt,
+    };
 
-        file_contents.push(content);
-    }
-
-    for (i, file_path) in files.iter().enumerate() {
-        let interface = Interface::try_from(file_contents[i].as_str())
-            .with_context(|| format!("Failed to parse interface from: {}", file_path.display()))?;
-
-        interfaces.push(interface);
-    }
-
-    // Generate code based on output options.
-    if let Some(output_path) = output {
-        // Single output file.
-        let output = if interfaces.len() == 1 {
-            generate_interface(&interfaces[0]).with_context(|| {
-                format!(
-                    "Failed to generate code for interface: {}",
-                    interfaces[0].name()
-                )
-            })?
-        } else {
-            generate_interfaces(&interfaces)
-                .with_context(|| "Failed to generate code for interfaces".to_string())?
-        };
-
-        // Format the code.
-        let formatted = format_code(&output)?;
-
-        // Write to file.
-        fs::write(&output_path, formatted)
-            .with_context(|| format!("Failed to write output file: {}", output_path.display()))?;
-
-        println!("Generated code written to {}", output_path.display());
-    } else if multiple_files {
-        // Multiple output files.
-        for interface in &interfaces {
-            let code = generate_interface(interface).with_context(|| {
-                format!(
-                    "Failed to generate code for interface: {}",
-                    interface.name()
-                )
-            })?;
-
-            // Format the code.
-            let formatted = format_code(&code)?;
-
-            // Generate output filename from interface name.
-            let filename = interface_to_filename(interface.name());
-            let output_path = format!("{}.rs", filename);
-
-            // Write to file.
-            fs::write(&output_path, formatted)
-                .with_context(|| format!("Failed to write output file: {}", output_path))?;
-
-            println!(
-                "Generated code for `{}` written to {}",
-                interface.name(),
-                output_path
-            );
-        }
-    } else {
-        // Output to stdout.
-        let output = if interfaces.len() == 1 {
-            generate_interface(&interfaces[0]).with_context(|| {
-                format!(
-                    "Failed to generate code for interface: {}",
-                    interfaces[0].name()
-                )
-            })?
-        } else {
-            generate_interfaces(&interfaces)
-                .with_context(|| "Failed to generate code for interfaces".to_string())?
-        };
-
-        // Format the code.
-        let formatted = format_code(&output)?;
-
-        // Write to stdout.
-        io::stdout().write_all(formatted.as_bytes())?;
-    }
+    // Generate the files
+    zlink_codegen::generate_files(&config)?;
 
     Ok(())
-}
-
-fn interface_to_filename(interface_name: &str) -> String {
-    // Convert interface name like "org.example.Interface" to "interface".
-    interface_name
-        .split('.')
-        .next_back()
-        .unwrap_or(interface_name)
-        .to_snake_case()
 }

--- a/zlink-codegen/test-integration/build.rs
+++ b/zlink-codegen/test-integration/build.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf};
+use std::{env, path::PathBuf};
 
 fn main() {
     // Get the manifest directory.
@@ -7,40 +7,30 @@ fn main() {
     // Process all IDL files.
     let idl_files = ["test.idl", "calc.idl", "storage.idl", "camelcase.idl"];
 
-    // Read all IDL file contents first (they need to stay alive for Interface lifetimes).
-    let mut contents = Vec::new();
-    for idl_file in &idl_files {
-        let idl_path = PathBuf::from(&manifest_dir).join(idl_file);
+    // Build paths to IDL files
+    let idl_paths: Vec<PathBuf> = idl_files
+        .iter()
+        .map(|idl_file| PathBuf::from(&manifest_dir).join(idl_file))
+        .collect();
 
-        // Tell cargo to rerun if the IDL file changes.
+    // Tell cargo to rerun if any IDL file changes.
+    for idl_path in &idl_paths {
         println!("cargo:rerun-if-changed={}", idl_path.display());
-
-        let content = fs::read_to_string(&idl_path)
-            .unwrap_or_else(|_| panic!("Failed to read IDL file: {}", idl_path.display()));
-
-        contents.push(content);
     }
-
-    // Parse all interfaces.
-    let mut interfaces = Vec::new();
-    for content in &contents {
-        let interface: zlink::idl::Interface = content
-            .as_str()
-            .try_into()
-            .expect("Failed to parse IDL file");
-
-        interfaces.push(interface);
-    }
-
-    // Generate code for all interfaces.
-    let generated_code =
-        zlink_codegen::generate_interfaces(&interfaces).expect("Failed to generate code");
-
-    // Format the generated code if rustfmt is available.
-    let formatted_code = zlink_codegen::format_code(&generated_code).unwrap_or(generated_code);
 
     // Write generated code to OUT_DIR.
     let out_dir = env::var("OUT_DIR").unwrap();
-    let out_path = PathBuf::from(&out_dir).join("generated.rs");
-    fs::write(&out_path, formatted_code).expect("Failed to write generated code");
+    let output_file = PathBuf::from(out_dir).join("generated.rs");
+
+    // Generate code from all interface files
+    let idl_path_refs: Vec<&PathBuf> = idl_paths.iter().collect();
+    zlink_codegen::generate_files(
+        &idl_path_refs,
+        &output_file,
+        &zlink_codegen::CodegenOptions {
+            rustfmt: true,
+            ..Default::default()
+        },
+    )
+    .expect("Failed to generate code");
 }


### PR DESCRIPTION
This allows you to use a build.rs file to create the rust source file:

```
extern crate zlink_codegen;

fn main() {
    zlink_codegen::create_source_file(
        "src/io.systemd.UserDatabase.varlink",
        /* rustfmt = */ true,
        &zlink_codegen::CodegenOptions {},
    );
}
```

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
