### PR TITLE
codegen rename method params

### DIFF
--- a/zlink-codegen/src/codegen.rs
+++ b/zlink-codegen/src/codegen.rs
@@ -416,7 +416,7 @@ impl CodeGenerator {
 
         // Handle field name if it's a Rust keyword.
         let field_name_attr = if is_rust_keyword(&field_name) || field_name != field.name() {
-            format!("#[serde(rename = \"{}\")]", field.name())
+            format!("#[zlink(rename = \"{}\")]", field.name())
         } else {
             String::new()
         };

--- a/zlink-codegen/src/codegen.rs
+++ b/zlink-codegen/src/codegen.rs
@@ -374,7 +374,14 @@ impl CodeGenerator {
             };
             // Use references for parameters that can be borrowed
             let rust_type = self.type_to_rust_param(param.ty())?;
-            write!(&mut signature, ", {}: {}", safe_param_name, rust_type)?;
+
+            write!(&mut signature, ",")?;
+            // Add parameter with potential rename attribute.
+            if safe_param_name != param.name() {
+                write!(&mut signature, " #[zlink(rename = \"{}\")]", param.name(),)?;
+            }
+
+            write!(&mut signature, " {}: {}", safe_param_name, rust_type)?;
         }
 
         signature.push_str(") -> zlink::Result<Result<");

--- a/zlink-codegen/test-integration/build.rs
+++ b/zlink-codegen/test-integration/build.rs
@@ -5,7 +5,7 @@ fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
 
     // Process all IDL files.
-    let idl_files = ["test.idl", "calc.idl", "storage.idl"];
+    let idl_files = ["test.idl", "calc.idl", "storage.idl", "camelcase.idl"];
 
     // Read all IDL file contents first (they need to stay alive for Interface lifetimes).
     let mut contents = Vec::new();

--- a/zlink-codegen/test-integration/camelcase.idl
+++ b/zlink-codegen/test-integration/camelcase.idl
@@ -1,0 +1,16 @@
+interface test.CamelCase
+
+type UserData (
+    userName: string,
+    emailAddress: ?string
+)
+
+error UserNotFound(userId: int)
+
+method GetUser(
+    userId: int,
+    includeEmail: ?bool
+) -> (
+    userData: UserData,
+    lastLogin: string
+)


### PR DESCRIPTION
- **🐛 codegen: add `zlink` instead of `serde` attribute for ReplyError**
- **🧪 codegen: Add tests for camelCase params/fields**
- **🐛 zlink-codegen: Add `rename` attributes to method parameters**

Fixes #129.
