### PR TITLE
⚡️ core: Start writer buffer at 256 bytes

### DIFF
--- a/zlink-core/src/connection/write_connection.rs
+++ b/zlink-core/src/connection/write_connection.rs
@@ -29,7 +29,7 @@ impl<Write: WriteHalf> WriteConnection<Write> {
         Self {
             socket,
             id,
-            buffer: Vec::new(),
+            buffer: alloc::vec![0; BUFFER_SIZE],
             pos: 0,
         }
     }


### PR DESCRIPTION
If we start at 0, we guarantee that the first serialization pass will
fail and we'll have to allocate anyway, so best just do so from the
beginning. If the JSON messages remain small enough, we could get lucky
and keep the write buffer at 256 bytes.
