### PR TITLE
👷 CI: Run Codspeed bench in walltime mode on Codspeed runner

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   benchmarks:
     name: Run benchmarks
-    runs-on: ubuntu-latest
+    runs-on: codspeed-macro
     steps:
       - uses: actions/checkout@v5
       - name: Setup rust toolchain, cache and cargo-codspeed binary
@@ -22,10 +22,10 @@ jobs:
           cache-target: release
           bins: cargo-codspeed
       - name: Build the benchmark target(s)
-        run: cargo codspeed build
+        run: cargo codspeed build -m walltime
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: instrumentation
+          mode: walltime
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }} # optional for public repos


### PR DESCRIPTION
This is as per the suggestion from Codspeed:
    
> This benchmark contains 13 system calls, totalling 104.9 ms of execution
> time. Since they cannot be consistently instrumented, those calls are
> not included in the measure. Please switch to the Walltime instrument to
> accurately measure system calls
    
We also now run the bench on Codspeed runner as per [the advice in Codspeed docs](https://codspeed.io/docs/features/macro-runners).

