### PR TITLE
✨ core,smol,tokio: Low-level API for FD-passing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,6 +2178,7 @@ dependencies = [
  "indexmap",
  "itoa",
  "pin-project-lite",
+ "rustix",
  "ryu",
  "serde",
  "serde-prefix-all",

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     pin_mut!(replies);
     let mut results = Vec::new();
     while let Some(reply) = replies.next().await {
-        let reply = reply?;
+        let (reply, _fds) = reply?;
         if let Ok(response) = reply {
             match response.into_parameters() {
                 Some(ProcessReply::Result(result)) => {

--- a/zlink-codegen/test-integration/src/lib.rs
+++ b/zlink-codegen/test-integration/src/lib.rs
@@ -57,7 +57,8 @@ mod tests {
             .to_string(),
         ];
 
-        let socket = MockSocket::new(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+        let socket =
+            MockSocket::with_responses(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
         let mut conn = Connection::new(socket);
 
         // Test successful get_person call.
@@ -111,7 +112,8 @@ mod tests {
             json!({ "parameters": { "result": null } }).to_string(),
         ];
 
-        let socket = MockSocket::new(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+        let socket =
+            MockSocket::with_responses(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
         let mut conn = Connection::new(socket);
 
         // Test add method.
@@ -193,7 +195,8 @@ mod tests {
             json!({ "parameters": { "docs": [] } }).to_string(),
         ];
 
-        let socket = MockSocket::new(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+        let socket =
+            MockSocket::with_responses(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
         let mut conn = Connection::new(socket);
 
         // Test store method with a document that has tags.
@@ -258,7 +261,7 @@ mod tests {
         // Test connection-level errors separately since they each need their own connection.
         // Test connection-level error (invalid JSON response).
         let invalid_json = "this is not valid JSON";
-        let socket = MockSocket::new(&[invalid_json]);
+        let socket = MockSocket::with_responses(&[invalid_json]);
         let mut conn: Connection<MockSocket> = Connection::new(socket);
 
         // This should result in a connection error, not a service error.
@@ -267,7 +270,7 @@ mod tests {
 
         // Test empty response.
         let empty_response = "";
-        let socket = MockSocket::new(&[empty_response]);
+        let socket = MockSocket::with_responses(&[empty_response]);
         let mut conn: Connection<MockSocket> = Connection::new(socket);
 
         let result = conn.get_person("test").await;
@@ -279,7 +282,7 @@ mod tests {
         })
         .to_string();
 
-        let socket = MockSocket::new(&[&weird_response]);
+        let socket = MockSocket::with_responses(&[&weird_response]);
         let mut conn: Connection<MockSocket> = Connection::new(socket);
 
         let result = conn.get_person("test").await;
@@ -331,7 +334,8 @@ mod tests {
             .to_string(),
         ];
 
-        let socket = MockSocket::new(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+        let socket =
+            MockSocket::with_responses(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
         let mut conn = Connection::new(socket);
 
         // Test with Unicode strings.

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [features]
 default = ["std", "proxy", "tracing"]
-std = []
+std = ["dep:rustix", "zlink-macros/std"]
 proxy = ["zlink-macros/proxy"]
 # IDL and introspection support
 idl = []
@@ -40,6 +40,10 @@ time = { version = "0.3", optional = true, default-features = false }
 url = { version = "2.5", optional = true, default-features = false }
 bytes = { version = "1.5", optional = true, default-features = false }
 indexmap = { version = "2.2", optional = true }
+rustix = { version = "1.1.2", default-features = false, features = [
+    "net",
+    "std",
+], optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.218", default-features = false, features = ["alloc"] }

--- a/zlink-core/src/connection/read_connection.rs
+++ b/zlink-core/src/connection/read_connection.rs
@@ -9,9 +9,20 @@ use super::{
     socket::ReadHalf,
     Call, BUFFER_SIZE, MAX_BUFFER_SIZE,
 };
+#[cfg(feature = "std")]
+use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use serde::Deserialize;
 use serde_json::Deserializer;
+
+#[cfg(feature = "std")]
+use std::os::fd::OwnedFd;
+
+// Type alias for receive methods - std returns FDs, no_std doesn't
+#[cfg(feature = "std")]
+type RecvResult<T> = (T, Vec<OwnedFd>);
+#[cfg(not(feature = "std"))]
+type RecvResult<T> = T;
 
 /// A connection that can only be used for reading.
 ///
@@ -26,6 +37,8 @@ pub struct ReadConnection<Read: ReadHalf> {
     msg_pos: usize,
     buffer: Vec<u8>,
     id: usize,
+    #[cfg(feature = "std")]
+    pending_fds: VecDeque<Vec<OwnedFd>>,
 }
 
 impl<Read: ReadHalf> ReadConnection<Read> {
@@ -37,6 +50,8 @@ impl<Read: ReadHalf> ReadConnection<Read> {
             msg_pos: 0,
             id,
             buffer: alloc::vec![0; BUFFER_SIZE],
+            #[cfg(feature = "std")]
+            pending_fds: VecDeque::new(),
         }
     }
 
@@ -71,9 +86,11 @@ impl<Read: ReadHalf> ReadConnection<Read> {
     ///     Charlie { param1: String },
     /// }
     /// ```
+    ///
+    /// Returns the reply and any file descriptors received (std only).
     pub async fn receive_reply<'r, ReplyParams, ReplyError>(
         &'r mut self,
-    ) -> Result<reply::Result<ReplyParams, ReplyError>>
+    ) -> Result<RecvResult<reply::Result<ReplyParams, ReplyError>>>
     where
         ReplyParams: Deserialize<'r> + Debug,
         ReplyError: Deserialize<'r> + Debug,
@@ -86,18 +103,26 @@ impl<Read: ReadHalf> ReadConnection<Read> {
             Reply(Reply<ReplyParams>),
         }
 
-        match self
+        let recv_result = self
             .read_message::<ReplyMsg<ReplyParams, ReplyError>>()
-            .await?
-        {
+            .await?;
+
+        #[cfg(feature = "std")]
+        let (msg, fds) = recv_result;
+        #[cfg(not(feature = "std"))]
+        let msg = recv_result;
+
+        let result = match msg {
             // Varlink service interface error need to be returned as the top-level error.
             ReplyMsg::Varlink(e) => Err(crate::Error::VarlinkService(e)),
             ReplyMsg::Error(e) => Ok(Err(e)),
-            ReplyMsg::Reply(reply) => {
-                // It's a success response.
-                Ok(Ok(reply))
-            }
-        }
+            ReplyMsg::Reply(reply) => Ok(Ok(reply)),
+        };
+
+        #[cfg(feature = "std")]
+        return result.map(|r| (r, fds));
+        #[cfg(not(feature = "std"))]
+        return result;
     }
 
     /// Receive a method call over the socket.
@@ -107,7 +132,9 @@ impl<Read: ReadHalf> ReadConnection<Read> {
     /// containing `method` and `parameter` fields. This can be easily achieved using the
     /// `serde::Deserialize` derive (See the code snippet in [`super::WriteConnection::send_call`]
     /// documentation for an example).
-    pub async fn receive_call<'m, Method>(&'m mut self) -> Result<Call<Method>>
+    ///
+    /// Returns the call and any file descriptors received (std only).
+    pub async fn receive_call<'m, Method>(&'m mut self) -> Result<RecvResult<Call<Method>>>
     where
         Method: Deserialize<'m> + Debug,
     {
@@ -115,7 +142,7 @@ impl<Read: ReadHalf> ReadConnection<Read> {
     }
 
     // Reads at least one full message from the socket and return a single message bytes.
-    async fn read_message<'m, M>(&'m mut self) -> Result<M>
+    async fn read_message<'m, M>(&'m mut self) -> Result<RecvResult<M>>
     where
         M: Deserialize<'m> + Debug,
     {
@@ -140,6 +167,13 @@ impl<Read: ReadHalf> ReadConnection<Read> {
                 trace!("connection {}: received a message: {}", self.id, unsafe {
                     from_utf8_unchecked(buffer)
                 });
+
+                #[cfg(feature = "std")]
+                {
+                    let fds = self.pending_fds.pop_front().unwrap_or_default();
+                    Ok((msg, fds))
+                }
+                #[cfg(not(feature = "std"))]
                 Ok(msg)
             }
             Some(Err(e)) => Err(e.into()),
@@ -155,11 +189,19 @@ impl<Read: ReadHalf> ReadConnection<Read> {
         }
 
         loop {
+            #[cfg(feature = "std")]
+            let (bytes_read, fds) = self.socket.read(&mut self.buffer[self.read_pos..]).await?;
+            #[cfg(not(feature = "std"))]
             let bytes_read = self.socket.read(&mut self.buffer[self.read_pos..]).await?;
+
             if bytes_read == 0 {
                 return Err(crate::Error::UnexpectedEof);
             }
             self.read_pos += bytes_read;
+            #[cfg(feature = "std")]
+            if !fds.is_empty() {
+                self.pending_fds.push_back(fds);
+            }
 
             if self.read_pos == self.buffer.len() {
                 if self.read_pos >= MAX_BUFFER_SIZE {
@@ -186,479 +228,5 @@ impl<Read: ReadHalf> ReadConnection<Read> {
     /// The underlying read half of the socket.
     pub fn read_half(&self) -> &Read {
         &self.socket
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{connection::socket::Socket, test_utils::mock_socket::MockSocket};
-    use serde::{Deserialize, Serialize};
-
-    // Test method and reply types for deserialization testing.
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    #[serde(tag = "method", content = "parameters")]
-    enum TestMethod {
-        #[serde(rename = "org.example.Test")]
-        Test { value: u32 },
-    }
-
-    #[derive(Debug, Serialize, Deserialize, PartialEq)]
-    struct TestReply {
-        result: String,
-    }
-
-    // DOS Attack Protection Tests.
-
-    #[tokio::test]
-    async fn malformed_json_extremely_long_string() {
-        // Create a malicious JSON with a string close to MAX_BUFFER_SIZE.
-        // This tests that the deserializer handles large strings without
-        // panicking and returns proper errors.
-        let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
-        // Create a very long string (10MB worth of 'A's).
-        malicious.push_str(&"A".repeat(10 * 1024 * 1024));
-        malicious.push_str(r#"}}"#);
-
-        let socket = MockSocket::new(&[&malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should fail with JSON deserialization error, not panic.
-        assert!(matches!(result, Err(crate::Error::Json(_))));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_deeply_nested_objects() {
-        // Create deeply nested JSON objects to test for stack overflow or
-        // excessive memory usage in the deserializer.
-        let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
-        // Add 10000 nested objects.
-        for _ in 0..10000 {
-            malicious.push_str(r#"{"a":"#);
-        }
-        malicious.push_str("0");
-        for _ in 0..10000 {
-            malicious.push('}');
-        }
-        malicious.push_str(r#"}}"#);
-
-        let socket = MockSocket::new(&[&malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should fail gracefully, not cause stack overflow.
-        assert!(matches!(result, Err(crate::Error::Json(_))));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_deeply_nested_arrays() {
-        // Similar to nested objects but with arrays.
-        let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
-        // Add 10000 nested arrays.
-        for _ in 0..10000 {
-            malicious.push('[');
-        }
-        malicious.push_str("0");
-        for _ in 0..10000 {
-            malicious.push(']');
-        }
-        malicious.push_str(r#"}}"#);
-
-        let socket = MockSocket::new(&[&malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should fail gracefully.
-        assert!(matches!(result, Err(crate::Error::Json(_))));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_unterminated_string() {
-        // Test unterminated string in JSON.
-        let malicious = r#"{"method":"org.example.Test","parameters":{"value":"#;
-
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should return UnexpectedEof or Json error.
-        assert!(matches!(
-            result,
-            Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
-        ));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_unterminated_object() {
-        // Test unterminated JSON object.
-        let malicious = r#"{"method":"org.example.Test","parameters":{"value":42"#;
-
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(matches!(
-            result,
-            Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
-        ));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_invalid_escape_sequences() {
-        // Test invalid escape sequences that might cause excessive
-        // backtracking.
-        let malicious = r#"{"method":"org.example.Test","parameters":{"value":"\x\x\x\x\x\x"}}"#;
-
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(matches!(result, Err(crate::Error::Json(_))));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_invalid_utf8_sequences() {
-        // Test invalid UTF-8 sequences in JSON string.
-        // Note: JSON requires valid UTF-8, so this should fail.
-        // We use escaped form since MockSocket::new requires &str.
-        // Using invalid escape sequences will trigger JSON parsing errors.
-        let malicious = r#"{"method":"org.example.Test","parameters":{"value":"\xFF\xFE\xFD"}}"#;
-
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should fail with JSON error due to invalid escape sequences.
-        assert!(matches!(result, Err(crate::Error::Json(_))));
-    }
-
-    #[tokio::test]
-    async fn buffer_overflow_near_max_size() {
-        // Test a message with a large payload to verify buffer handling.
-        // Using 10MB to keep test fast while still testing large messages.
-        let size = 10 * 1024 * 1024;
-        let mut large_msg = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
-        large_msg.push_str(&"X".repeat(size));
-        large_msg.push_str(r#"}}"#);
-
-        let socket = MockSocket::new(&[&large_msg]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        // This should fail with Json error due to type mismatch, but
-        // shouldn't panic.
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(result.is_err());
-    }
-
-    #[tokio::test]
-    async fn buffer_overflow_exceeds_max_size() {
-        // Test a message that definitely exceeds MAX_BUFFER_SIZE.
-        // Since MockSocket reads all data at once, we need to simulate
-        // multiple reads that would exceed the limit.
-        let size = 50 * 1024 * 1024; // 50MB chunk.
-        let chunk = "X".repeat(size);
-        let mut large_msg = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
-        large_msg.push_str(&chunk);
-        large_msg.push_str(&chunk);
-        large_msg.push_str(&chunk); // Total > 150MB.
-        large_msg.push_str(r#"}}"#);
-
-        let socket = MockSocket::new(&[&large_msg]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should return BufferOverflow error.
-        assert!(matches!(result, Err(crate::Error::BufferOverflow)));
-    }
-
-    #[tokio::test]
-    async fn missing_null_terminator() {
-        // Test message without proper null byte termination.
-        // MockSocket automatically adds null bytes, so we need to test the
-        // read_from_socket logic indirectly by ensuring empty stream case.
-        let valid_msg = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
-        let socket = MockSocket::new(&[valid_msg]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        // First read should succeed.
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(result.is_ok());
-
-        // Second read should fail with UnexpectedEof.
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(matches!(result, Err(crate::Error::UnexpectedEof)));
-    }
-
-    #[tokio::test]
-    async fn multiple_null_bytes_in_message() {
-        // Test message with embedded null bytes (which shouldn't happen in
-        // valid JSON).
-        let malicious = "{\0\"method\":\"org.example.Test\"\0}";
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should fail due to invalid JSON structure.
-        assert!(matches!(
-            result,
-            Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
-        ));
-    }
-
-    #[tokio::test]
-    async fn stream_deserializer_empty_buffer() {
-        // Test the None case from StreamDeserializer when buffer is
-        // effectively empty. Note: read_from_socket will return UnexpectedEof
-        // before we even get to the deserializer since the socket returns 0
-        // bytes on first read.
-        let malicious = "";
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // MockSocket with empty string results in immediate EOF from socket.
-        // This will trigger UnexpectedEof in read_from_socket, which happens
-        // before deserialization.
-        assert!(result.is_err());
-        // The actual error could be UnexpectedEof from socket or from
-        // deserializer.
-        match result {
-            Err(crate::Error::UnexpectedEof) => {}
-            Err(crate::Error::Json(_)) => {}
-            other => panic!("Expected error, got {:?}", other),
-        }
-    }
-
-    #[tokio::test]
-    async fn stream_deserializer_whitespace_only() {
-        // Test StreamDeserializer with only whitespace.
-        let malicious = "     \n\n\t\t   ";
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should return UnexpectedEof or Json error.
-        assert!(matches!(
-            result,
-            Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
-        ));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_repeated_keys() {
-        // Test JSON with many repeated keys to stress the parser.
-        let mut malicious = r#"{"method":"org.example.Test","parameters":{"#.to_string();
-        for i in 0..10000 {
-            malicious.push_str(&format!(r#""key{i}":"value{i}","#));
-        }
-        malicious.push_str(r#""value":42}}"#);
-
-        let socket = MockSocket::new(&[&malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should either succeed or fail gracefully.
-        // The TestMethod type expects only a "value" field, so this will
-        // likely fail during deserialization to TestMethod.
-        // But it shouldn't panic.
-        if let Err(e) = result {
-            assert!(matches!(e, crate::Error::Json(_)));
-        }
-    }
-
-    #[tokio::test]
-    async fn malformed_json_very_long_array() {
-        // Test very long array in parameters.
-        let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":["#.to_string();
-        for i in 0..100000 {
-            if i > 0 {
-                malicious.push(',');
-            }
-            malicious.push_str(&i.to_string());
-        }
-        malicious.push_str(r#"]}}"#);
-
-        let socket = MockSocket::new(&[&malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should fail with type error but not panic.
-        assert!(matches!(result, Err(crate::Error::Json(_))));
-    }
-
-    #[tokio::test]
-    async fn byte_offset_calculation_with_valid_json() {
-        // Verify that stream.byte_offset() correctly identifies the end of
-        // valid JSON.
-        let valid_msg = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
-        let socket = MockSocket::new(&[valid_msg]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(result.is_ok());
-        let call = result.unwrap();
-        assert_eq!(call.method, TestMethod::Test { value: 42 });
-    }
-
-    #[tokio::test]
-    async fn byte_offset_calculation_with_trailing_data() {
-        // Test that byte_offset correctly handles when there's trailing
-        // data after valid JSON.
-        let valid_msg1 = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
-        let valid_msg2 = r#"{"method":"org.example.Test","parameters":{"value":99}}"#;
-        let socket = MockSocket::new(&[valid_msg1, valid_msg2]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        // First message.
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().method, TestMethod::Test { value: 42 });
-
-        // Second message.
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().method, TestMethod::Test { value: 99 });
-    }
-
-    #[tokio::test]
-    async fn error_propagation_json_to_error() {
-        // Verify JSON deserialization errors are properly converted to
-        // crate::Error::Json.
-        let invalid_json = r#"{"method":"org.example.Test","parameters":{"value":"not_a_number"}}"#;
-        let socket = MockSocket::new(&[invalid_json]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        match result {
-            Err(crate::Error::Json(e)) => {
-                // Verify it's a proper JSON error.
-                assert!(!e.to_string().is_empty());
-            }
-            _ => panic!("Expected Error::Json, got {:?}", result),
-        }
-    }
-
-    #[tokio::test]
-    async fn receive_reply_with_malformed_json() {
-        // Test receive_reply with malformed JSON.
-        let malformed = r#"{"parameters":{"result":"incomplete"#;
-        let socket = MockSocket::new(&[malformed]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_reply::<TestReply, TestReply>().await;
-        assert!(matches!(
-            result,
-            Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
-        ));
-    }
-
-    #[tokio::test]
-    async fn receive_reply_with_large_payload() {
-        // Test receive_reply with very large but valid reply.
-        let large_result = "X".repeat(1024 * 1024); // 1MB string.
-        let reply = format!(r#"{{"parameters":{{"result":"{}"}}}}"#, large_result);
-        let socket = MockSocket::new(&[&reply]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_reply::<TestReply, TestReply>().await;
-        // Should succeed and return the large payload.
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn malformed_json_mixed_control_characters() {
-        // Test JSON with unusual control characters.
-        let malicious = "{\x01\"method\"\x02:\x03\"org.example.Test\"}";
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(matches!(result, Err(crate::Error::Json(_))));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_number_overflow() {
-        // Test with extremely large numbers that might cause overflow.
-        let malicious = r#"{"method":"org.example.Test","parameters":{"value":999999999999999999999999999999999999999999999999999}}"#;
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should fail with JSON deserialization error.
-        assert!(matches!(result, Err(crate::Error::Json(_))));
-    }
-
-    #[tokio::test]
-    async fn malformed_json_duplicate_keys() {
-        // Test JSON with duplicate keys in the same object.
-        let malicious = r#"{"method":"org.example.Test","method":"org.example.Other","parameters":{"value":42}}"#;
-        let socket = MockSocket::new(&[malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // serde_json typically accepts the last duplicate key, so this
-        // might succeed or fail depending on the "Other" method name.
-        // The important part is it doesn't panic.
-        let _ = result;
-    }
-
-    #[tokio::test]
-    async fn malformed_json_unicode_escapes() {
-        // Test excessive unicode escape sequences.
-        let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
-        for _ in 0..10000 {
-            malicious.push_str(r#"\u0041"#); // 'A' in unicode.
-        }
-        malicious.push_str(r#"}}"#);
-
-        let socket = MockSocket::new(&[&malicious]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        let result = conn.receive_call::<TestMethod>().await;
-        // Should handle unicode escapes gracefully.
-        assert!(result.is_err()); // Will fail type checking.
-    }
-
-    #[tokio::test]
-    async fn partial_message_at_buffer_boundary() {
-        // Test handling of partial messages that arrive at buffer
-        // boundaries. MockSocket reads everything at once, so we test the
-        // logic by ensuring the connection properly handles the end of data.
-        let valid_msg = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
-        let socket = MockSocket::new(&[valid_msg]);
-        let (read, _write) = socket.split();
-        let mut conn = ReadConnection::new(read, 0);
-
-        // First read succeeds.
-        assert!(conn.receive_call::<TestMethod>().await.is_ok());
-
-        // Second read should fail with UnexpectedEof.
-        let result = conn.receive_call::<TestMethod>().await;
-        assert!(matches!(result, Err(crate::Error::UnexpectedEof)));
     }
 }

--- a/zlink-core/src/connection/socket.rs
+++ b/zlink-core/src/connection/socket.rs
@@ -2,6 +2,23 @@
 
 use core::future::Future;
 
+#[cfg(feature = "std")]
+use std::os::fd::{AsFd, OwnedFd};
+
+/// Result type for [`ReadHalf::read`] operations.
+///
+/// With `std` feature: returns `(usize, Vec<OwnedFd>)` - bytes read and file descriptors.
+/// Without `std` feature: returns `usize` - just bytes read.
+#[cfg(feature = "std")]
+pub type ReadResult = (usize, alloc::vec::Vec<OwnedFd>);
+
+/// Result type for [`ReadHalf::read`] operations.
+///
+/// With `std` feature: returns `(usize, Vec<OwnedFd>)` - bytes read and file descriptors.
+/// Without `std` feature: returns `usize` - just bytes read.
+#[cfg(not(feature = "std"))]
+pub type ReadResult = usize;
+
 /// The socket trait.
 ///
 /// This is the trait that needs to be implemented for a type to be used as a socket/transport.
@@ -11,6 +28,11 @@ pub trait Socket: core::fmt::Debug {
     /// The write half of the socket.
     type WriteHalf: WriteHalf;
 
+    /// Whether this socket can transfer file descriptors.
+    ///
+    /// This is `true` for Unix domain sockets and `false` for other socket types.
+    const CAN_TRANSFER_FDS: bool = false;
+
     /// Split the socket into read and write halves.
     fn split(self) -> (Self::ReadHalf, Self::WriteHalf);
 }
@@ -19,7 +41,7 @@ pub trait Socket: core::fmt::Debug {
 pub trait ReadHalf: core::fmt::Debug {
     /// Read from a socket.
     ///
-    /// On completion, the number of bytes read is returned.
+    /// On completion, the number of bytes read and any file descriptors received are returned.
     ///
     /// Notes for implementers:
     ///
@@ -29,15 +51,21 @@ pub trait ReadHalf: core::fmt::Debug {
     ///   is not explicitly requied is that it would force boxing (and therefore allocation) on the
     ///   implemention that use `async fn`, which is undesirable for embedded use cases. See [this
     ///   issue](https://github.com/rust-lang/rust/issues/82187) for details.
-    fn read(&mut self, buf: &mut [u8]) -> impl Future<Output = crate::Result<usize>>;
+    fn read(&mut self, buf: &mut [u8]) -> impl Future<Output = crate::Result<ReadResult>>;
 }
 
 /// The write half of a socket.
 pub trait WriteHalf: core::fmt::Debug {
     /// Write to the socket.
     ///
+    /// The `fds` parameter contains file descriptors to send along with the data (std only).
+    ///
     /// The returned future has the same requirements as that of [`ReadHalf::read`].
-    fn write(&mut self, buf: &[u8]) -> impl Future<Output = crate::Result<()>>;
+    fn write(
+        &mut self,
+        buf: &[u8],
+        #[cfg(feature = "std")] fds: &[impl AsFd],
+    ) -> impl Future<Output = crate::Result<()>>;
 }
 
 /// Documentation-only socket implementations for doc tests.
@@ -64,7 +92,7 @@ pub mod impl_for_doc {
     pub struct ReadHalf;
 
     impl super::ReadHalf for ReadHalf {
-        async fn read(&mut self, _buf: &mut [u8]) -> crate::Result<usize> {
+        async fn read(&mut self, _buf: &mut [u8]) -> crate::Result<super::ReadResult> {
             unreachable!("This is only for doc tests")
         }
     }
@@ -74,7 +102,11 @@ pub mod impl_for_doc {
     pub struct WriteHalf;
 
     impl super::WriteHalf for WriteHalf {
-        async fn write(&mut self, _buf: &[u8]) -> crate::Result<()> {
+        async fn write(
+            &mut self,
+            _buf: &[u8],
+            #[cfg(feature = "std")] _fds: &[impl super::AsFd],
+        ) -> crate::Result<()> {
             unreachable!("This is only for doc tests")
         }
     }

--- a/zlink-core/src/connection/tests/chain_fds_tests.rs
+++ b/zlink-core/src/connection/tests/chain_fds_tests.rs
@@ -1,0 +1,448 @@
+//! Unit tests for Chain file descriptor passing.
+
+#![cfg(test)]
+
+use crate::{
+    connection::{
+        socket::{ReadHalf, Socket, WriteHalf},
+        Connection,
+    },
+    test_utils::mock_socket::{MockSocket, MockWriteHalf},
+    Call, Result,
+};
+use alloc::vec::Vec;
+use futures_util::{pin_mut, stream::StreamExt};
+use rustix::{fd::AsFd, io::write};
+use serde::{Deserialize, Serialize};
+use std::os::unix::net::UnixStream;
+
+#[tokio::test]
+async fn chain_replies_with_fds() {
+    let (r1, _w1) = UnixStream::pair().unwrap();
+    let (r2, _w2) = UnixStream::pair().unwrap();
+
+    let reply1 = r#"{"parameters":{"id":1,"name":"Alice"}}"#;
+    let reply2 = r#"{"parameters":{"id":2,"name":"Bob"}}"#;
+
+    // Both replies fit in one read, so all FDs are returned with the first message.
+    let fds = vec![vec![r1.into(), r2.into()]];
+
+    let socket = MockSocket::new(&[reply1, reply2], fds);
+    let mut conn = Connection::new(socket);
+
+    let call1 = Call::new(GetUser { id: 1 });
+    let call2 = Call::new(GetUser { id: 2 });
+
+    let replies = conn
+        .chain_call::<GetUser, User, ApiError>(&call1, vec![])
+        .unwrap()
+        .append(&call2, vec![])
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+
+    pin_mut!(replies);
+
+    let (reply1, fds1) = replies.next().await.unwrap().unwrap();
+    let reply1 = reply1.unwrap();
+    assert_eq!(reply1.parameters().unwrap().id, 1);
+    assert_eq!(fds1.len(), 2); // All FDs from the read operation
+
+    let (reply2, fds2) = replies.next().await.unwrap().unwrap();
+    let reply2 = reply2.unwrap();
+    assert_eq!(reply2.parameters().unwrap().id, 2);
+    assert_eq!(fds2.len(), 0); // No new read, no new FDs
+}
+
+#[tokio::test]
+async fn chain_replies_with_no_fds() {
+    let reply1 = r#"{"parameters":{"id":1,"name":"Alice"}}"#;
+    let reply2 = r#"{"parameters":{"id":2,"name":"Bob"}}"#;
+
+    let fds = vec![vec![]];
+
+    let socket = MockSocket::new(&[reply1, reply2], fds);
+    let mut conn = Connection::new(socket);
+
+    let call1 = Call::new(GetUser { id: 1 });
+    let call2 = Call::new(GetUser { id: 2 });
+
+    let replies = conn
+        .chain_call::<GetUser, User, ApiError>(&call1, vec![])
+        .unwrap()
+        .append(&call2, vec![])
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+
+    pin_mut!(replies);
+
+    let (reply1, fds1) = replies.next().await.unwrap().unwrap();
+    let reply1 = reply1.unwrap();
+    assert_eq!(reply1.parameters().unwrap().id, 1);
+    assert!(fds1.is_empty());
+
+    let (reply2, fds2) = replies.next().await.unwrap().unwrap();
+    let reply2 = reply2.unwrap();
+    assert_eq!(reply2.parameters().unwrap().id, 2);
+    assert!(fds2.is_empty());
+}
+
+#[tokio::test]
+async fn chain_send_with_fds() {
+    let (r1, w1) = UnixStream::pair().unwrap();
+    let (r2, w2) = UnixStream::pair().unwrap();
+
+    // Write test data to write ends so we can verify FDs were transmitted.
+    write(w1.as_fd(), b"data1").unwrap();
+    write(w2.as_fd(), b"data2").unwrap();
+
+    let reply1 = r#"{"parameters":{"id":1,"name":"Alice"}}"#;
+    let reply2 = r#"{"parameters":{"id":2,"name":"Bob"}}"#;
+
+    let socket = MockSocket::new(&[reply1, reply2], vec![vec![]]);
+    let (read_half, write_half) = socket.split();
+    let tracking_write = TrackingWriteHalf { mock: write_half };
+    let mut conn = Connection::new(TrackingSocket {
+        read: read_half,
+        write: tracking_write,
+    });
+
+    let call1 = Call::new(GetUser { id: 1 });
+    let call2 = Call::new(GetUser { id: 2 });
+
+    // Send FDs with the calls.
+    let chain = conn
+        .chain_call::<GetUser, User, ApiError>(&call1, vec![r1.into()])
+        .unwrap()
+        .append(&call2, vec![r2.into()])
+        .unwrap();
+
+    let replies = chain.send().await.unwrap();
+
+    // Collect replies first to release the borrow on conn.
+    let reply_results: Vec<_> = {
+        pin_mut!(replies);
+        replies.collect().await
+    }; // `replies` dropped here, releasing the borrow.
+
+    // Now we can access the FDs captured by the mock.
+    let fds_written = conn.write_mut().socket.mock.fds_written();
+    assert_eq!(fds_written.len(), 2, "Should have written FDs twice");
+    assert_eq!(fds_written[0].len(), 1, "First call should send 1 FD");
+    assert_eq!(fds_written[1].len(), 1, "Second call should send 1 FD");
+
+    // Verify we can read data from the received FDs.
+    let mut buf1 = [0u8; 5];
+    rustix::io::read(fds_written[0][0].as_fd(), &mut buf1).unwrap();
+    assert_eq!(&buf1, b"data1");
+
+    let mut buf2 = [0u8; 5];
+    rustix::io::read(fds_written[1][0].as_fd(), &mut buf2).unwrap();
+    assert_eq!(&buf2, b"data2");
+
+    // Verify the replies.
+    assert_eq!(reply_results.len(), 2);
+
+    let (reply1, _fds) = reply_results[0].as_ref().unwrap();
+    let reply1 = reply1.as_ref().unwrap();
+    assert_eq!(reply1.parameters().unwrap().id, 1);
+
+    let (reply2, _fds) = reply_results[1].as_ref().unwrap();
+    let reply2 = reply2.as_ref().unwrap();
+    assert_eq!(reply2.parameters().unwrap().id, 2);
+}
+
+#[tokio::test]
+async fn chain_oneway_call_with_fds() {
+    let reply1 = r#"{"parameters":{"id":1,"name":"Alice"}}"#;
+
+    let socket = MockSocket::new(&[reply1], vec![vec![]]);
+    let mut conn = Connection::new(socket);
+
+    let call1 = Call::new(GetUser { id: 1 });
+    let oneway_call = Call::new(GetUser { id: 2 }).set_oneway(true);
+
+    let replies = conn
+        .chain_call::<GetUser, User, ApiError>(&call1, vec![])
+        .unwrap()
+        .append(&oneway_call, vec![])
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+
+    pin_mut!(replies);
+
+    // Only expect one reply since the second call is oneway.
+    let (reply1, _fds) = replies.next().await.unwrap().unwrap();
+    let reply1 = reply1.unwrap();
+    assert_eq!(reply1.parameters().unwrap().id, 1);
+
+    // No more replies.
+    assert!(replies.next().await.is_none());
+}
+
+#[tokio::test]
+async fn chain_error_reply_with_fds() {
+    use crate::ReplyError;
+
+    #[derive(Debug, ReplyError)]
+    #[zlink(interface = "org.example")]
+    enum TestError {
+        NotFound { code: i32 },
+    }
+
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let error_reply = r#"{"error":"org.example.NotFound","parameters":{"code":404}}"#;
+    let fds = vec![vec![r_fd.into()]];
+
+    let socket = MockSocket::new(&[error_reply], fds);
+    let mut conn = Connection::new(socket);
+
+    let call1 = Call::new(GetUser { id: 1 });
+
+    let replies = conn
+        .chain_call::<GetUser, User, TestError>(&call1, vec![])
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+
+    pin_mut!(replies);
+
+    let (reply, fds) = replies.next().await.unwrap().unwrap();
+    assert!(reply.is_err());
+    assert_eq!(fds.len(), 1);
+}
+
+/// Test FD distribution when server sends FDs back.
+///
+/// This tests the receiving side: when the server sends FDs with replies,
+/// they arrive with the first read operation. MockSocket simulates all messages
+/// arriving in one read, so all FDs come with the first message.
+#[tokio::test]
+async fn chain_receive_fds_from_server() {
+    let (r1, _w1) = UnixStream::pair().unwrap();
+    let (r2, _w2) = UnixStream::pair().unwrap();
+    let (r3, _w3) = UnixStream::pair().unwrap();
+
+    let reply1 = r#"{"parameters":{"id":1,"name":"Alice"}}"#;
+    let reply2 = r#"{"parameters":{"id":2,"name":"Bob"}}"#;
+    let reply3 = r#"{"parameters":{"id":3,"name":"Charlie"}}"#;
+
+    // Server sends FDs with replies. MockSocket delivers them all in one read,
+    // so all FDs arrive with the first message's first byte.
+    let fds = vec![vec![r1.into(), r2.into(), r3.into()]];
+
+    let socket = MockSocket::new(&[reply1, reply2, reply3], fds);
+    let mut conn = Connection::new(socket);
+
+    let call1 = Call::new(GetUser { id: 1 });
+    let call2 = Call::new(GetUser { id: 2 });
+    let call3 = Call::new(GetUser { id: 3 });
+
+    let replies = conn
+        .chain_call::<GetUser, User, ApiError>(&call1, vec![])
+        .unwrap()
+        .append(&call2, vec![])
+        .unwrap()
+        .append(&call3, vec![])
+        .unwrap()
+        .send()
+        .await
+        .unwrap();
+
+    pin_mut!(replies);
+    let results: Vec<_> = replies.collect().await;
+
+    assert_eq!(results.len(), 3);
+
+    // First result gets all the FDs from the single read operation.
+    let (reply, fds) = results[0].as_ref().unwrap();
+    let user = reply.as_ref().unwrap();
+    assert_eq!(user.parameters().unwrap().id, 1);
+    assert_eq!(fds.len(), 3);
+
+    // Remaining results have no FDs (no new read operations).
+    for i in 1..3 {
+        let (reply, fds) = results[i].as_ref().unwrap();
+        let user = reply.as_ref().unwrap();
+        assert_eq!(user.parameters().unwrap().id, (i + 1) as u32);
+        assert_eq!(fds.len(), 0);
+    }
+}
+
+/// Test that FDs are sent only with their specific message bytes.
+///
+/// This tests the critical flush behavior: when a message has FDs, we must flush pending messages
+/// first, then write the FD message separately. This ensures that:
+/// 1. FDs are sent in a separate write operation
+/// 2. The FD write contains ONLY the bytes of the message with FDs
+/// 3. Previous and subsequent messages are sent in their own writes
+#[tokio::test]
+async fn chain_fds_sent_only_with_their_message() {
+    let (r_fd, w_fd) = UnixStream::pair().unwrap();
+    write(w_fd.as_fd(), b"test").unwrap();
+
+    let reply1 = r#"{"parameters":{"id":1,"name":"Alice"}}"#;
+    let reply2 = r#"{"parameters":{"id":2,"name":"Bob"}}"#;
+    let reply3 = r#"{"parameters":{"id":3,"name":"Charlie"}}"#;
+
+    let socket = MockSocket::new(&[reply1, reply2, reply3], vec![vec![]]);
+    let (read_half, write_half) = socket.split();
+
+    // Wrap the write half to track each write operation.
+    let tracking_write = WriteOperationTracker {
+        mock: write_half,
+        operations: Vec::new(),
+    };
+
+    let mut conn = Connection::new(TrackingSocket {
+        read: read_half,
+        write: tracking_write,
+    });
+
+    let call1 = Call::new(GetUser { id: 1 });
+    let call2 = Call::new(GetUser { id: 2 });
+    let call3 = Call::new(GetUser { id: 3 });
+
+    // Build chain: call1 (no FDs), call2 (with FD), call3 (no FDs).
+    let chain = conn
+        .chain_call::<GetUser, User, ApiError>(&call1, vec![])
+        .unwrap()
+        .append(&call2, vec![r_fd.into()])
+        .unwrap()
+        .append(&call3, vec![])
+        .unwrap();
+
+    // Flush to send all messages.
+    chain.connection.write_mut().flush().await.unwrap();
+
+    // Verify write operations.
+    let ops = &mut conn.write_mut().socket.operations;
+
+    // Should have exactly 3 write operations.
+    assert_eq!(ops.len(), 3, "Expected 3 write operations");
+
+    // First write: call1 without FDs.
+    assert_eq!(ops[0].fd_count, 0, "call1 should have no FDs");
+    let call1_str = core::str::from_utf8(&ops[0].data[..ops[0].data.len() - 1]).unwrap();
+    assert!(
+        call1_str.contains("\"id\":1"),
+        "call1 write should contain id:1"
+    );
+    assert!(
+        ops[0].data.ends_with(b"\0"),
+        "call1 should be null-terminated"
+    );
+
+    // Second write: call2 with FD - critically, this should ONLY contain call2's bytes.
+    assert_eq!(ops[1].fd_count, 1, "call2 should have 1 FD");
+    let call2_str = core::str::from_utf8(&ops[1].data[..ops[1].data.len() - 1]).unwrap();
+    assert!(
+        call2_str.contains("\"id\":2"),
+        "call2 write should contain id:2"
+    );
+    assert!(
+        ops[1].data.ends_with(b"\0"),
+        "call2 should be null-terminated"
+    );
+
+    // CRITICAL: Verify call2 write doesn't contain call1 or call3 data.
+    // This ensures FDs are sent ONLY with their specific message bytes.
+    assert!(
+        !call2_str.contains("\"id\":1"),
+        "call2 write should NOT contain id:1 from call1"
+    );
+    assert!(
+        !call2_str.contains("\"id\":3"),
+        "call2 write should NOT contain id:3 from call3"
+    );
+
+    // Third write: call3 without FDs.
+    assert_eq!(ops[2].fd_count, 0, "call3 should have no FDs");
+    let call3_str = core::str::from_utf8(&ops[2].data[..ops[2].data.len() - 1]).unwrap();
+    assert!(
+        call3_str.contains("\"id\":3"),
+        "call3 write should contain id:3"
+    );
+    assert!(
+        ops[2].data.ends_with(b"\0"),
+        "call3 should be null-terminated"
+    );
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct GetUser {
+    id: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct User {
+    id: u32,
+    name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct ApiError {
+    code: i32,
+}
+
+/// Socket wrapper that provides access to the write half after use.
+#[derive(Debug)]
+struct TrackingSocket<R, W> {
+    read: R,
+    write: W,
+}
+
+impl<R: ReadHalf, W: WriteHalf> Socket for TrackingSocket<R, W> {
+    type ReadHalf = R;
+    type WriteHalf = W;
+
+    fn split(self) -> (Self::ReadHalf, Self::WriteHalf) {
+        (self.read, self.write)
+    }
+}
+
+/// Write half wrapper for testing that provides access to MockWriteHalf.
+#[derive(Debug)]
+struct TrackingWriteHalf {
+    mock: MockWriteHalf,
+}
+
+impl WriteHalf for TrackingWriteHalf {
+    async fn write(&mut self, buf: &[u8], fds: &[impl AsFd]) -> Result<()> {
+        self.mock.write(buf, fds).await
+    }
+}
+
+/// Tracks individual write operations with their data and FD counts.
+#[derive(Debug)]
+struct WriteOperation {
+    data: Vec<u8>,
+    fd_count: usize,
+}
+
+/// Write half wrapper that tracks each write operation separately.
+#[derive(Debug)]
+struct WriteOperationTracker {
+    mock: MockWriteHalf,
+    operations: Vec<WriteOperation>,
+}
+
+impl WriteHalf for WriteOperationTracker {
+    async fn write(&mut self, buf: &[u8], fds: &[impl AsFd]) -> Result<()> {
+        // Record this write operation.
+        self.operations.push(WriteOperation {
+            data: buf.to_vec(),
+            fd_count: fds.len(),
+        });
+
+        // Also write to the mock for actual functionality.
+        self.mock.write(buf, fds).await
+    }
+}

--- a/zlink-core/src/connection/tests/mod.rs
+++ b/zlink-core/src/connection/tests/mod.rs
@@ -1,0 +1,9 @@
+mod read_connection_tests;
+mod write_connection_tests;
+
+#[cfg(feature = "std")]
+mod chain_fds_tests;
+#[cfg(feature = "std")]
+mod read_connection_fds_tests;
+#[cfg(feature = "std")]
+mod write_connection_fds_tests;

--- a/zlink-core/src/connection/tests/read_connection_fds_tests.rs
+++ b/zlink-core/src/connection/tests/read_connection_fds_tests.rs
@@ -1,0 +1,302 @@
+//! Unit tests for ReadConnection file descriptor passing.
+
+#![cfg(test)]
+
+use crate::{
+    connection::{read_connection::ReadConnection, socket::Socket},
+    test_utils::mock_socket::MockSocket,
+};
+use alloc::vec::Vec;
+use rustix::fd::AsFd;
+use serde::{Deserialize, Serialize};
+use std::os::unix::net::UnixStream;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "method", content = "parameters")]
+enum TestMethod {
+    #[serde(rename = "org.example.Test")]
+    Test { value: u32 },
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct TestReply {
+    result: String,
+}
+
+#[tokio::test]
+async fn receive_call_with_single_fd() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let call_json = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let fds = vec![vec![r_fd.into()]];
+
+    let socket = MockSocket::new(&[call_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (call, received_fds) = conn.receive_call::<TestMethod>().await.unwrap();
+
+    assert_eq!(call.method(), &TestMethod::Test { value: 42 });
+    assert_eq!(received_fds.len(), 1);
+}
+
+#[tokio::test]
+async fn receive_call_with_multiple_fds() {
+    let (r1, _w1) = UnixStream::pair().unwrap();
+    let (r2, _w2) = UnixStream::pair().unwrap();
+    let (r3, _w3) = UnixStream::pair().unwrap();
+
+    let call_json = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let fds = vec![vec![r1.into(), r2.into(), r3.into()]];
+
+    let socket = MockSocket::new(&[call_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (call, received_fds) = conn.receive_call::<TestMethod>().await.unwrap();
+
+    assert_eq!(call.method(), &TestMethod::Test { value: 42 });
+    assert_eq!(received_fds.len(), 3);
+}
+
+#[tokio::test]
+async fn receive_call_with_no_fds() {
+    let call_json = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let fds = vec![vec![]];
+
+    let socket = MockSocket::new(&[call_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (call, received_fds) = conn.receive_call::<TestMethod>().await.unwrap();
+
+    assert_eq!(call.method(), &TestMethod::Test { value: 42 });
+    assert!(received_fds.is_empty());
+}
+
+#[tokio::test]
+async fn receive_multiple_calls_with_mixed_fds() {
+    let (r1, _w1) = UnixStream::pair().unwrap();
+    let (r2, _w2) = UnixStream::pair().unwrap();
+
+    let call1 = r#"{"method":"org.example.Test","parameters":{"value":1}}"#;
+    let call2 = r#"{"method":"org.example.Test","parameters":{"value":2}}"#;
+    let call3 = r#"{"method":"org.example.Test","parameters":{"value":3}}"#;
+
+    let fds = vec![vec![r1.into(), r2.into()]];
+
+    let socket = MockSocket::new(&[call1, call2, call3], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (call, fds) = conn.receive_call::<TestMethod>().await.unwrap();
+    assert_eq!(call.method(), &TestMethod::Test { value: 1 });
+    assert_eq!(fds.len(), 2); // All FDs from the batch
+
+    let (call, fds) = conn.receive_call::<TestMethod>().await.unwrap();
+    assert_eq!(call.method(), &TestMethod::Test { value: 2 });
+    assert!(fds.is_empty()); // No new read, so no new FDs
+
+    let (call, fds) = conn.receive_call::<TestMethod>().await.unwrap();
+    assert_eq!(call.method(), &TestMethod::Test { value: 3 });
+    assert!(fds.is_empty()); // No new read, so no new FDs
+}
+
+#[tokio::test]
+async fn receive_reply_with_single_fd() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let reply_json = r#"{"parameters":{"result":"success"}}"#;
+    let fds = vec![vec![r_fd.into()]];
+
+    let socket = MockSocket::new(&[reply_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (reply, received_fds) = conn.receive_reply::<TestReply, TestReply>().await.unwrap();
+
+    let reply = reply.unwrap();
+    assert_eq!(reply.parameters().unwrap().result, "success");
+
+    assert_eq!(received_fds.len(), 1);
+}
+
+#[tokio::test]
+async fn receive_reply_with_multiple_fds() {
+    let (r1, _w1) = UnixStream::pair().unwrap();
+    let (r2, _w2) = UnixStream::pair().unwrap();
+
+    let reply_json = r#"{"parameters":{"result":"success"}}"#;
+    let fds = vec![vec![r1.into(), r2.into()]];
+
+    let socket = MockSocket::new(&[reply_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (reply, received_fds) = conn.receive_reply::<TestReply, TestReply>().await.unwrap();
+
+    let reply = reply.unwrap();
+    assert_eq!(reply.parameters().unwrap().result, "success");
+    assert_eq!(received_fds.len(), 2);
+}
+
+#[tokio::test]
+async fn receive_reply_with_no_fds() {
+    let reply_json = r#"{"parameters":{"result":"success"}}"#;
+    let fds = vec![vec![]];
+
+    let socket = MockSocket::new(&[reply_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (reply, received_fds) = conn.receive_reply::<TestReply, TestReply>().await.unwrap();
+
+    let reply = reply.unwrap();
+    assert_eq!(reply.parameters().unwrap().result, "success");
+    assert!(received_fds.is_empty());
+}
+
+#[tokio::test]
+async fn receive_call_malformed_json() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let malformed = r#"{"method":"org.example.Test","parameters":"#;
+    let fds = vec![vec![r_fd.into()]];
+
+    let socket = MockSocket::new(&[malformed], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(matches!(result, Err(crate::Error::Json(_))));
+}
+
+#[tokio::test]
+async fn receive_call_large_message() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let large_value = 1000000u32;
+    let call_json = format!(
+        r#"{{"method":"org.example.Test","parameters":{{"value":{}}}}}"#,
+        large_value
+    );
+
+    let fds = vec![vec![r_fd.into()]];
+
+    let socket = MockSocket::new(&[&call_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (call, received_fds) = conn.receive_call::<TestMethod>().await.unwrap();
+
+    assert_eq!(call.method(), &TestMethod::Test { value: large_value });
+    assert_eq!(received_fds.len(), 1);
+}
+
+#[tokio::test]
+async fn fd_validity_after_receive() {
+    use rustix::io::{read, write};
+
+    let (r_fd, w_fd) = UnixStream::pair().unwrap();
+
+    write(w_fd.as_fd(), b"test data").unwrap();
+
+    let call_json = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let fds = vec![vec![r_fd.into()]];
+
+    let socket = MockSocket::new(&[call_json], fds);
+    let (read_half, _write) = socket.split();
+    let mut conn = ReadConnection::new(read_half, 0);
+
+    let (_call, received_fds) = conn.receive_call::<TestMethod>().await.unwrap();
+
+    let mut buf = [0u8; 9];
+    let n = read(received_fds[0].as_fd(), &mut buf).unwrap();
+    assert_eq!(n, 9);
+    assert_eq!(&buf[..n], b"test data");
+}
+
+#[tokio::test]
+async fn receive_call_with_max_fds() {
+    let mut fds_vec = Vec::new();
+    for _ in 0..10 {
+        let (r, _w) = UnixStream::pair().unwrap();
+        fds_vec.push(r.into());
+    }
+
+    let call_json = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let fds = vec![fds_vec];
+
+    let socket = MockSocket::new(&[call_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (_call, received_fds) = conn.receive_call::<TestMethod>().await.unwrap();
+    assert_eq!(received_fds.len(), 10);
+}
+
+#[tokio::test]
+async fn receive_call_backward_compat_regular_receive() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let call_json = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let fds = vec![vec![r_fd.into()]];
+
+    let socket = MockSocket::new(&[call_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (call, _fds) = conn.receive_call::<TestMethod>().await.unwrap();
+
+    assert_eq!(call.method(), &TestMethod::Test { value: 42 });
+}
+
+#[tokio::test]
+async fn mixed_receive_call_and_receive_call() {
+    let (r1, _w1) = UnixStream::pair().unwrap();
+
+    let call1 = r#"{"method":"org.example.Test","parameters":{"value":1}}"#;
+    let call2 = r#"{"method":"org.example.Test","parameters":{"value":2}}"#;
+
+    let fds = vec![vec![r1.into()], vec![]];
+
+    let socket = MockSocket::new(&[call1, call2], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (call, fds) = conn.receive_call::<TestMethod>().await.unwrap();
+    assert_eq!(call.method(), &TestMethod::Test { value: 1 });
+    assert_eq!(fds.len(), 1);
+
+    let (call, _fds) = conn.receive_call::<TestMethod>().await.unwrap();
+    assert_eq!(call.method(), &TestMethod::Test { value: 2 });
+}
+
+#[tokio::test]
+async fn receive_reply_error_with_fds() {
+    use crate::ReplyError;
+
+    #[derive(Debug, ReplyError)]
+    #[zlink(interface = "org.example")]
+    enum TestError {
+        NotFound { code: i32 },
+    }
+
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let error_json = r#"{"error":"org.example.NotFound","parameters":{"code":404}}"#;
+    let fds = vec![vec![r_fd.into()]];
+
+    let socket = MockSocket::new(&[error_json], fds);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let (reply, received_fds) = conn.receive_reply::<TestReply, TestError>().await.unwrap();
+
+    assert!(reply.is_err());
+    assert!(matches!(
+        reply.unwrap_err(),
+        TestError::NotFound { code: 404 }
+    ));
+    assert_eq!(received_fds.len(), 1);
+}

--- a/zlink-core/src/connection/tests/read_connection_tests.rs
+++ b/zlink-core/src/connection/tests/read_connection_tests.rs
@@ -1,0 +1,477 @@
+#![cfg(test)]
+
+use crate::{
+    connection::{read_connection::ReadConnection, socket::Socket},
+    test_utils::mock_socket::MockSocket,
+};
+use serde::{Deserialize, Serialize};
+
+// Test method and reply types for deserialization testing.
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "method", content = "parameters")]
+enum TestMethod {
+    #[serde(rename = "org.example.Test")]
+    Test { value: u32 },
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+struct TestReply {
+    result: String,
+}
+
+// DOS Attack Protection Tests.
+
+#[tokio::test]
+async fn malformed_json_extremely_long_string() {
+    // Create a malicious JSON with a string close to MAX_BUFFER_SIZE.
+    // This tests that the deserializer handles large strings without panicking and returns proper
+    // errors.
+    let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
+    // Create a very long string (10MB worth of 'A's).
+    malicious.push_str(&"A".repeat(10 * 1024 * 1024));
+    malicious.push_str(r#"}}"#);
+
+    let socket = MockSocket::with_responses(&[&malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should fail with JSON deserialization error, not panic.
+    assert!(matches!(result, Err(crate::Error::Json(_))));
+}
+
+#[tokio::test]
+async fn malformed_json_deeply_nested_objects() {
+    // Create deeply nested JSON objects to test for stack overflow or excessive memory usage in
+    // the deserializer.
+    let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
+    // Add 10000 nested objects.
+    for _ in 0..10000 {
+        malicious.push_str(r#"{"a":"#);
+    }
+    malicious.push_str("0");
+    for _ in 0..10000 {
+        malicious.push('}');
+    }
+    malicious.push_str(r#"}}"#);
+
+    let socket = MockSocket::with_responses(&[&malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should fail gracefully, not cause stack overflow.
+    assert!(matches!(result, Err(crate::Error::Json(_))));
+}
+
+#[tokio::test]
+async fn malformed_json_deeply_nested_arrays() {
+    // Similar to nested objects but with arrays.
+    let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
+    // Add 10000 nested arrays.
+    for _ in 0..10000 {
+        malicious.push('[');
+    }
+    malicious.push_str("0");
+    for _ in 0..10000 {
+        malicious.push(']');
+    }
+    malicious.push_str(r#"}}"#);
+
+    let socket = MockSocket::with_responses(&[&malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should fail gracefully.
+    assert!(matches!(result, Err(crate::Error::Json(_))));
+}
+
+#[tokio::test]
+async fn malformed_json_unterminated_string() {
+    // Test unterminated string in JSON.
+    let malicious = r#"{"method":"org.example.Test","parameters":{"value":"#;
+
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should return UnexpectedEof or Json error.
+    assert!(matches!(
+        result,
+        Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
+    ));
+}
+
+#[tokio::test]
+async fn malformed_json_unterminated_object() {
+    // Test unterminated JSON object.
+    let malicious = r#"{"method":"org.example.Test","parameters":{"value":42"#;
+
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(matches!(
+        result,
+        Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
+    ));
+}
+
+#[tokio::test]
+async fn malformed_json_invalid_escape_sequences() {
+    // Test invalid escape sequences that might cause excessive backtracking.
+    let malicious = r#"{"method":"org.example.Test","parameters":{"value":"\x\x\x\x\x\x"}}"#;
+
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(matches!(result, Err(crate::Error::Json(_))));
+}
+
+#[tokio::test]
+async fn malformed_json_invalid_utf8_sequences() {
+    // Test invalid UTF-8 sequences in JSON string.
+    // Note: JSON requires valid UTF-8, so this should fail.
+    // We use escaped form since MockSocket::new requires &str.
+    // Using invalid escape sequences will trigger JSON parsing errors.
+    let malicious = r#"{"method":"org.example.Test","parameters":{"value":"\xFF\xFE\xFD"}}"#;
+
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should fail with JSON error due to invalid escape sequences.
+    assert!(matches!(result, Err(crate::Error::Json(_))));
+}
+
+#[tokio::test]
+async fn buffer_overflow_near_max_size() {
+    // Test a message with a large payload to verify buffer handling.
+    // Using 10MB to keep test fast while still testing large messages.
+    let size = 10 * 1024 * 1024;
+    let mut large_msg = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
+    large_msg.push_str(&"X".repeat(size));
+    large_msg.push_str(r#"}}"#);
+
+    let socket = MockSocket::with_responses(&[&large_msg]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    // This should fail with Json error due to type mismatch, but shouldn't panic.
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn buffer_overflow_exceeds_max_size() {
+    // Test a message that definitely exceeds MAX_BUFFER_SIZE.
+    // Since MockSocket reads all data at once, we need to simulate multiple reads that would
+    // exceed the limit.
+    let size = 50 * 1024 * 1024; // 50MB chunk.
+    let chunk = "X".repeat(size);
+    let mut large_msg = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
+    large_msg.push_str(&chunk);
+    large_msg.push_str(&chunk);
+    large_msg.push_str(&chunk); // Total > 150MB.
+    large_msg.push_str(r#"}}"#);
+
+    let socket = MockSocket::with_responses(&[&large_msg]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should return BufferOverflow error.
+    assert!(matches!(result, Err(crate::Error::BufferOverflow)));
+}
+
+#[tokio::test]
+async fn missing_null_terminator() {
+    // Test message without proper null byte termination.
+    // MockSocket automatically adds null bytes, so we need to test the read_from_socket logic
+    // indirectly by ensuring empty stream case.
+    let valid_msg = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let socket = MockSocket::with_responses(&[valid_msg]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    // First read should succeed.
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(result.is_ok());
+
+    // Second read should fail with UnexpectedEof.
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(matches!(result, Err(crate::Error::UnexpectedEof)));
+}
+
+#[tokio::test]
+async fn multiple_null_bytes_in_message() {
+    // Test message with embedded null bytes (which shouldn't happen in valid JSON).
+    let malicious = "{\0\"method\":\"org.example.Test\"\0}";
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should fail due to invalid JSON structure.
+    assert!(matches!(
+        result,
+        Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
+    ));
+}
+
+#[tokio::test]
+async fn stream_deserializer_empty_buffer() {
+    // Test the None case from StreamDeserializer when buffer is effectively empty.
+    // Note: read_from_socket will return UnexpectedEof before we even get to the deserializer
+    // since the socket returns 0 bytes on first read.
+    let malicious = "";
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // MockSocket with empty string results in immediate EOF from socket.
+    // This will trigger UnexpectedEof in read_from_socket, which happens before deserialization.
+    assert!(result.is_err());
+    // The actual error could be UnexpectedEof from socket or from deserializer.
+    match result {
+        Err(crate::Error::UnexpectedEof) => {}
+        Err(crate::Error::Json(_)) => {}
+        other => panic!("Expected error, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn stream_deserializer_whitespace_only() {
+    // Test StreamDeserializer with only whitespace.
+    let malicious = "     \n\n\t\t   ";
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should return UnexpectedEof or Json error.
+    assert!(matches!(
+        result,
+        Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
+    ));
+}
+
+#[tokio::test]
+async fn malformed_json_repeated_keys() {
+    // Test JSON with many repeated keys to stress the parser.
+    let mut malicious = r#"{"method":"org.example.Test","parameters":{"#.to_string();
+    for i in 0..10000 {
+        malicious.push_str(&format!(r#""key{i}":"value{i}","#));
+    }
+    malicious.push_str(r#""value":42}}"#);
+
+    let socket = MockSocket::with_responses(&[&malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should either succeed or fail gracefully.
+    // The TestMethod type expects only a "value" field, so this will likely fail during
+    // deserialization to TestMethod.
+    // But it shouldn't panic.
+    if let Err(e) = result {
+        assert!(matches!(e, crate::Error::Json(_)));
+    }
+}
+
+#[tokio::test]
+async fn malformed_json_very_long_array() {
+    // Test very long array in parameters.
+    let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":["#.to_string();
+    for i in 0..100000 {
+        if i > 0 {
+            malicious.push(',');
+        }
+        malicious.push_str(&i.to_string());
+    }
+    malicious.push_str(r#"]}}"#);
+
+    let socket = MockSocket::with_responses(&[&malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should fail with type error but not panic.
+    assert!(matches!(result, Err(crate::Error::Json(_))));
+}
+
+#[tokio::test]
+async fn byte_offset_calculation_with_valid_json() {
+    // Verify that stream.byte_offset() correctly identifies the end of valid JSON.
+    let valid_msg = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let socket = MockSocket::with_responses(&[valid_msg]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(result.is_ok());
+    #[cfg(feature = "std")]
+    let (call, _fds) = result.unwrap();
+    #[cfg(not(feature = "std"))]
+    let call = result.unwrap();
+    assert_eq!(call.method, TestMethod::Test { value: 42 });
+}
+
+#[tokio::test]
+async fn byte_offset_calculation_with_trailing_data() {
+    // Test that byte_offset correctly handles when there's trailing data after valid JSON.
+    let valid_msg1 = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let valid_msg2 = r#"{"method":"org.example.Test","parameters":{"value":99}}"#;
+    let socket = MockSocket::with_responses(&[valid_msg1, valid_msg2]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    // First message.
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(result.is_ok());
+    #[cfg(feature = "std")]
+    let (call, _fds) = result.unwrap();
+    #[cfg(not(feature = "std"))]
+    let call = result.unwrap();
+    assert_eq!(call.method, TestMethod::Test { value: 42 });
+
+    // Second message.
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(result.is_ok());
+    #[cfg(feature = "std")]
+    let (call, _fds) = result.unwrap();
+    #[cfg(not(feature = "std"))]
+    let call = result.unwrap();
+    assert_eq!(call.method, TestMethod::Test { value: 99 });
+}
+
+#[tokio::test]
+async fn error_propagation_json_to_error() {
+    // Verify JSON deserialization errors are properly converted to crate::Error::Json.
+    let invalid_json = r#"{"method":"org.example.Test","parameters":{"value":"not_a_number"}}"#;
+    let socket = MockSocket::with_responses(&[invalid_json]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    match result {
+        Err(crate::Error::Json(e)) => {
+            // Verify it's a proper JSON error.
+            assert!(!e.to_string().is_empty());
+        }
+        _ => panic!("Expected Error::Json, got {:?}", result),
+    }
+}
+
+#[tokio::test]
+async fn receive_reply_with_malformed_json() {
+    // Test receive_reply with malformed JSON.
+    let malformed = r#"{"parameters":{"result":"incomplete"#;
+    let socket = MockSocket::with_responses(&[malformed]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_reply::<TestReply, TestReply>().await;
+    assert!(matches!(
+        result,
+        Err(crate::Error::Json(_)) | Err(crate::Error::UnexpectedEof)
+    ));
+}
+
+#[tokio::test]
+async fn receive_reply_with_large_payload() {
+    // Test receive_reply with very large but valid reply.
+    let large_result = "X".repeat(1024 * 1024); // 1MB string.
+    let reply = format!(r#"{{"parameters":{{"result":"{}"}}}}"#, large_result);
+    let socket = MockSocket::with_responses(&[&reply]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_reply::<TestReply, TestReply>().await;
+    // Should succeed and return the large payload.
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn malformed_json_mixed_control_characters() {
+    // Test JSON with unusual control characters.
+    let malicious = "{\x01\"method\"\x02:\x03\"org.example.Test\"}";
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(matches!(result, Err(crate::Error::Json(_))));
+}
+
+#[tokio::test]
+async fn malformed_json_number_overflow() {
+    // Test with extremely large numbers that might cause overflow.
+    let malicious = r#"{"method":"org.example.Test","parameters":{"value":999999999999999999999999999999999999999999999999999}}"#;
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should fail with JSON deserialization error.
+    assert!(matches!(result, Err(crate::Error::Json(_))));
+}
+
+#[tokio::test]
+async fn malformed_json_duplicate_keys() {
+    // Test JSON with duplicate keys in the same object.
+    let malicious =
+        r#"{"method":"org.example.Test","method":"org.example.Other","parameters":{"value":42}}"#;
+    let socket = MockSocket::with_responses(&[malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // serde_json typically accepts the last duplicate key, so this might succeed or fail
+    // depending on the "Other" method name.
+    // The important part is it doesn't panic.
+    let _ = result;
+}
+
+#[tokio::test]
+async fn malformed_json_unicode_escapes() {
+    // Test excessive unicode escape sequences.
+    let mut malicious = r#"{"method":"org.example.Test","parameters":{"value":"#.to_string();
+    for _ in 0..10000 {
+        malicious.push_str(r#"\u0041"#); // 'A' in unicode.
+    }
+    malicious.push_str(r#"}}"#);
+
+    let socket = MockSocket::with_responses(&[&malicious]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    let result = conn.receive_call::<TestMethod>().await;
+    // Should handle unicode escapes gracefully.
+    assert!(result.is_err()); // Will fail type checking.
+}
+
+#[tokio::test]
+async fn partial_message_at_buffer_boundary() {
+    // Test handling of partial messages that arrive at buffer boundaries.
+    // MockSocket reads everything at once, so we test the logic by ensuring the connection
+    // properly handles the end of data.
+    let valid_msg = r#"{"method":"org.example.Test","parameters":{"value":42}}"#;
+    let socket = MockSocket::with_responses(&[valid_msg]);
+    let (read, _write) = socket.split();
+    let mut conn = ReadConnection::new(read, 0);
+
+    // First read succeeds.
+    assert!(conn.receive_call::<TestMethod>().await.is_ok());
+
+    // Second read should fail with UnexpectedEof.
+    let result = conn.receive_call::<TestMethod>().await;
+    assert!(matches!(result, Err(crate::Error::UnexpectedEof)));
+}

--- a/zlink-core/src/connection/tests/write_connection_fds_tests.rs
+++ b/zlink-core/src/connection/tests/write_connection_fds_tests.rs
@@ -1,0 +1,325 @@
+//! Unit tests for WriteConnection file descriptor passing.
+
+#![cfg(test)]
+
+use crate::{
+    connection::write_connection::WriteConnection,
+    test_utils::mock_socket::{MockWriteHalf, TestWriteHalf},
+    Call, Reply,
+};
+use serde::{Deserialize, Serialize};
+use std::os::unix::net::UnixStream;
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "method", content = "parameters")]
+enum TestMethod {
+    #[serde(rename = "org.example.Test")]
+    Test { value: u32 },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct TestReply {
+    result: String,
+}
+
+#[tokio::test]
+async fn send_call_with_single_fd() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call = Call::new(TestMethod::Test { value: 42 });
+
+    write_conn
+        .send_call(&call, vec![r_fd.into()])
+        .await
+        .unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 1);
+    assert_eq!(write_conn.write_half().fds_written().len(), 1);
+}
+
+#[tokio::test]
+async fn send_call_with_multiple_fds() {
+    let (r1, _w1) = UnixStream::pair().unwrap();
+    let (r2, _w2) = UnixStream::pair().unwrap();
+    let (r3, _w3) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call = Call::new(TestMethod::Test { value: 42 });
+
+    write_conn
+        .send_call(&call, vec![r1.into(), r2.into(), r3.into()])
+        .await
+        .unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 1);
+    let fds_written = write_conn.write_half().fds_written();
+    assert_eq!(fds_written.len(), 1);
+    assert_eq!(fds_written[0].len(), 3);
+}
+
+#[tokio::test]
+async fn send_call_with_no_fds() {
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call = Call::new(TestMethod::Test { value: 42 });
+
+    write_conn.send_call(&call, vec![]).await.unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 0);
+}
+
+#[tokio::test]
+async fn send_call_with_empty_fd_vec() {
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call = Call::new(TestMethod::Test { value: 42 });
+
+    write_conn.send_call(&call, vec![]).await.unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 0);
+}
+
+#[tokio::test]
+async fn send_reply() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let reply = Reply::new(Some(TestReply {
+        result: "success".to_string(),
+    }));
+
+    write_conn
+        .send_reply(&reply, vec![r_fd.into()])
+        .await
+        .unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 1);
+}
+
+#[tokio::test]
+async fn enqueue_call_with_fds_succeeds() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call = Call::new(TestMethod::Test { value: 42 });
+
+    write_conn.enqueue_call(&call, vec![r_fd.into()]).unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 0);
+}
+
+#[tokio::test]
+async fn enqueue_call_without_fds_succeeds() {
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call = Call::new(TestMethod::Test { value: 42 });
+
+    write_conn.enqueue_call(&call, vec![]).unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 0);
+}
+
+#[tokio::test]
+async fn multiple_sequential_fd_sends() {
+    let (r1, _w1) = UnixStream::pair().unwrap();
+    let (r2, _w2) = UnixStream::pair().unwrap();
+    let (r3, _w3) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call1 = Call::new(TestMethod::Test { value: 1 });
+    write_conn.send_call(&call1, vec![r1.into()]).await.unwrap();
+
+    let call2 = Call::new(TestMethod::Test { value: 2 });
+    write_conn.send_call(&call2, vec![r2.into()]).await.unwrap();
+
+    let call3 = Call::new(TestMethod::Test { value: 3 });
+    write_conn.send_call(&call3, vec![r3.into()]).await.unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 3);
+}
+
+#[tokio::test]
+async fn send_call_validates_data_length() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let call = Call::new(TestMethod::Test { value: 42 });
+    let serialized_len = serde_json::to_vec(&call).unwrap().len() + 1; // +1 for null terminator.
+
+    let mut write_conn = WriteConnection::new(TestWriteHalf::new_with_fds(serialized_len, 1), 0);
+
+    write_conn
+        .send_call(&call, vec![r_fd.into()])
+        .await
+        .unwrap();
+
+    assert_eq!(write_conn.write_half().write_count(), 1);
+}
+
+#[tokio::test]
+async fn send_call_preserves_call_flags() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call = Call::new(TestMethod::Test { value: 42 })
+        .set_oneway(true)
+        .set_more(true);
+
+    write_conn
+        .send_call(&call, vec![r_fd.into()])
+        .await
+        .unwrap();
+
+    let written = write_conn.write_half().written_data();
+    let written_str = core::str::from_utf8(written).unwrap();
+
+    assert!(written_str.contains("\"oneway\":true"));
+    assert!(written_str.contains("\"more\":true"));
+}
+
+#[tokio::test]
+async fn backward_compat_send_call_works() {
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call = Call::new(TestMethod::Test { value: 42 });
+
+    write_conn.send_call(&call, vec![]).await.unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 0);
+}
+
+#[tokio::test]
+async fn mixed_send_call_and_send_call() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call1 = Call::new(TestMethod::Test { value: 1 });
+    write_conn.send_call(&call1, vec![]).await.unwrap();
+
+    let call2 = Call::new(TestMethod::Test { value: 2 });
+    write_conn
+        .send_call(&call2, vec![r_fd.into()])
+        .await
+        .unwrap();
+
+    let call3 = Call::new(TestMethod::Test { value: 3 });
+    write_conn.send_call(&call3, vec![]).await.unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 1);
+}
+
+#[tokio::test]
+async fn send_call_buffer_growth() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let _large_data = vec![0u8; 10000];
+    let call = Call::new(TestMethod::Test { value: 42 });
+
+    write_conn
+        .send_call(&call, vec![r_fd.into()])
+        .await
+        .unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 1);
+}
+
+#[tokio::test]
+async fn send_reply_with_multiple_fds() {
+    let (r1, _w1) = UnixStream::pair().unwrap();
+    let (r2, _w2) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let reply = Reply::new(Some(TestReply {
+        result: "success".to_string(),
+    }));
+
+    write_conn
+        .send_reply(&reply, vec![r1.into(), r2.into()])
+        .await
+        .unwrap();
+
+    let fds_written = write_conn.write_half().fds_written();
+    assert_eq!(fds_written.len(), 1);
+    assert_eq!(fds_written[0].len(), 2);
+}
+
+#[tokio::test]
+async fn send_reply_with_no_fds() {
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let reply = Reply::new(Some(TestReply {
+        result: "success".to_string(),
+    }));
+
+    write_conn.send_reply(&reply, vec![]).await.unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 0);
+}
+
+#[tokio::test]
+async fn send_error() {
+    use crate::ReplyError;
+
+    #[derive(Debug, ReplyError)]
+    #[zlink(interface = "org.example")]
+    enum TestError {
+        NotFound { code: i32 },
+    }
+
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let error = TestError::NotFound { code: 404 };
+
+    write_conn
+        .send_error(&error, vec![r_fd.into()])
+        .await
+        .unwrap();
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 1);
+}
+
+#[tokio::test]
+async fn enqueue_normal_then_send_with_fds_clears_queue() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call1 = Call::new(TestMethod::Test { value: 1 });
+    write_conn.enqueue_call(&call1, vec![]).unwrap();
+
+    let call2 = Call::new(TestMethod::Test { value: 2 });
+
+    let result = write_conn.send_call(&call2, vec![r_fd.into()]).await;
+
+    assert!(result.is_ok() || result.is_err());
+}
+
+#[tokio::test]
+async fn fd_ownership_with_borrowed_fd() {
+    let (r_fd, _w_fd) = UnixStream::pair().unwrap();
+
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+
+    let call = Call::new(TestMethod::Test { value: 42 });
+
+    {
+        write_conn
+            .send_call(&call, vec![r_fd.into()])
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(write_conn.write_half().fd_write_count(), 1);
+}

--- a/zlink-core/src/connection/tests/write_connection_tests.rs
+++ b/zlink-core/src/connection/tests/write_connection_tests.rs
@@ -1,0 +1,267 @@
+#![cfg(test)]
+
+use crate::{
+    connection::{write_connection::WriteConnection, BUFFER_SIZE},
+    test_utils::mock_socket::TestWriteHalf,
+};
+
+#[tokio::test]
+async fn write() {
+    const WRITE_LEN: usize =
+        // Every `0u8` is one byte.
+        BUFFER_SIZE +
+        // `,` separators.
+        (BUFFER_SIZE - 1) +
+        // `[` and `]`.
+        2 +
+        // null byte from enqueue.
+        1;
+    let mut write_conn = WriteConnection::new(TestWriteHalf::new(WRITE_LEN), 1);
+    // An item that serializes into `> BUFFER_SIZE * 2` bytes.
+    let item: Vec<u8> = vec![0u8; BUFFER_SIZE];
+    #[cfg(feature = "std")]
+    write_conn.write(&item, vec![]).await.unwrap();
+    #[cfg(not(feature = "std"))]
+    write_conn.write(&item).await.unwrap();
+    assert_eq!(write_conn.buffer.len(), BUFFER_SIZE * 3);
+    assert_eq!(write_conn.pos, 0); // Reset after flush.
+}
+
+#[tokio::test]
+async fn enqueue_and_flush() {
+    // Test enqueuing multiple small items.
+    let mut write_conn = WriteConnection::new(TestWriteHalf::new(5), 1); // "42\03\0"
+
+    #[cfg(feature = "std")]
+    {
+        write_conn.enqueue(&42u32, vec![]).unwrap();
+        write_conn.enqueue(&3u32, vec![]).unwrap();
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        write_conn.enqueue(&42u32).unwrap();
+        write_conn.enqueue(&3u32).unwrap();
+    }
+    assert_eq!(write_conn.pos, 5); // "42\03\0"
+
+    write_conn.flush().await.unwrap();
+    assert_eq!(write_conn.pos, 0); // Reset after flush.
+}
+
+#[tokio::test]
+async fn enqueue_null_terminators() {
+    // Test that null terminators are properly placed.
+    let mut write_conn = WriteConnection::new(TestWriteHalf::new(4), 1); // "1\02\0"
+
+    #[cfg(feature = "std")]
+    {
+        write_conn.enqueue(&1u32, vec![]).unwrap();
+        assert_eq!(write_conn.buffer[write_conn.pos - 1], b'\0');
+
+        write_conn.enqueue(&2u32, vec![]).unwrap();
+        assert_eq!(write_conn.buffer[write_conn.pos - 1], b'\0');
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        write_conn.enqueue(&1u32).unwrap();
+        assert_eq!(write_conn.buffer[write_conn.pos - 1], b'\0');
+
+        write_conn.enqueue(&2u32).unwrap();
+        assert_eq!(write_conn.buffer[write_conn.pos - 1], b'\0');
+    }
+
+    write_conn.flush().await.unwrap();
+}
+
+#[tokio::test]
+async fn enqueue_buffer_extension() {
+    // Test buffer extension when enqueuing large items.
+    let mut write_conn = WriteConnection::new(TestWriteHalf::new(0), 1);
+    let initial_len = write_conn.buffer.len();
+
+    // Fill up the buffer.
+    let large_item: Vec<u8> = vec![0u8; BUFFER_SIZE];
+    #[cfg(feature = "std")]
+    write_conn.enqueue(&large_item, vec![]).unwrap();
+    #[cfg(not(feature = "std"))]
+    write_conn.enqueue(&large_item).unwrap();
+
+    assert!(write_conn.buffer.len() > initial_len);
+}
+
+#[tokio::test]
+async fn flush_empty_buffer() {
+    // Test that flushing an empty buffer is a no-op.
+    let mut write_conn = WriteConnection::new(TestWriteHalf::new(0), 1);
+
+    // Should not call write since buffer is empty.
+    write_conn.flush().await.unwrap();
+    assert_eq!(write_conn.pos, 0);
+}
+
+#[tokio::test]
+async fn multiple_flushes() {
+    // Test multiple flushes in a row.
+    let mut write_conn = WriteConnection::new(TestWriteHalf::new(2), 1); // "1\0"
+
+    #[cfg(feature = "std")]
+    write_conn.enqueue(&1u32, vec![]).unwrap();
+    #[cfg(not(feature = "std"))]
+    write_conn.enqueue(&1u32).unwrap();
+    write_conn.flush().await.unwrap();
+    assert_eq!(write_conn.pos, 0);
+
+    // Second flush should be a no-op.
+    write_conn.flush().await.unwrap();
+    assert_eq!(write_conn.pos, 0);
+}
+
+#[tokio::test]
+async fn enqueue_after_flush() {
+    // Test that enqueuing works properly after a flush.
+    let mut write_conn = WriteConnection::new(TestWriteHalf::new(2), 1); // "2\0"
+
+    #[cfg(feature = "std")]
+    write_conn.enqueue(&1u32, vec![]).unwrap();
+    #[cfg(not(feature = "std"))]
+    write_conn.enqueue(&1u32).unwrap();
+    write_conn.flush().await.unwrap();
+
+    // Should be able to enqueue again after flush.
+    #[cfg(feature = "std")]
+    write_conn.enqueue(&2u32, vec![]).unwrap();
+    #[cfg(not(feature = "std"))]
+    write_conn.enqueue(&2u32).unwrap();
+    assert_eq!(write_conn.pos, 2); // "2\0"
+
+    write_conn.flush().await.unwrap();
+    assert_eq!(write_conn.pos, 0);
+}
+
+#[tokio::test]
+async fn call_pipelining() {
+    use super::super::super::Call;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct TestMethod {
+        name: &'static str,
+        value: u32,
+    }
+
+    let mut write_conn = WriteConnection::new(TestWriteHalf::new(0), 1);
+
+    // Test pipelining multiple method calls.
+    let call1 = Call::new(TestMethod {
+        name: "method1",
+        value: 1,
+    });
+    #[cfg(feature = "std")]
+    write_conn.enqueue_call(&call1, vec![]).unwrap();
+    #[cfg(not(feature = "std"))]
+    write_conn.enqueue_call(&call1).unwrap();
+
+    let call2 = Call::new(TestMethod {
+        name: "method2",
+        value: 2,
+    });
+    #[cfg(feature = "std")]
+    write_conn.enqueue_call(&call2, vec![]).unwrap();
+    #[cfg(not(feature = "std"))]
+    write_conn.enqueue_call(&call2).unwrap();
+
+    let call3 = Call::new(TestMethod {
+        name: "method3",
+        value: 3,
+    });
+    #[cfg(feature = "std")]
+    write_conn.enqueue_call(&call3, vec![]).unwrap();
+    #[cfg(not(feature = "std"))]
+    write_conn.enqueue_call(&call3).unwrap();
+
+    assert!(write_conn.pos > 0);
+
+    // Verify that all calls are properly queued with null terminators.
+    let buffer = &write_conn.buffer[..write_conn.pos];
+    let mut null_positions = [0usize; 3];
+    let mut null_count = 0;
+
+    for (i, &byte) in buffer.iter().enumerate() {
+        if byte == b'\0' {
+            assert!(null_count < 3, "Found more than 3 null terminators");
+            null_positions[null_count] = i;
+            null_count += 1;
+        }
+    }
+
+    // Should have exactly 3 null terminators for 3 calls.
+    assert_eq!(null_count, 3);
+
+    // Verify each null terminator is at the end of a complete JSON object.
+    for i in 0..null_count {
+        let pos = null_positions[i];
+        assert!(
+            pos > 0,
+            "Null terminator at position {pos} should not be at start"
+        );
+        let preceding_byte = buffer[pos - 1];
+        assert!(
+            preceding_byte == b'}' || preceding_byte == b'"' || preceding_byte.is_ascii_digit(),
+            "Null terminator at position {pos} should be after valid JSON ending, found byte: {preceding_byte}"
+        );
+    }
+
+    // Verify the last null terminator is at the very end.
+    assert_eq!(null_positions[2], write_conn.pos - 1);
+}
+
+#[tokio::test]
+async fn pipelining_vs_individual_sends() {
+    use super::super::super::Call;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct TestMethod {
+        operation: &'static str,
+        id: u32,
+    }
+
+    // Use consolidated counting write half from test_utils.
+    use crate::test_utils::mock_socket::CountingWriteHalf;
+
+    // Test individual sends (3 write calls expected).
+    let counting_write = CountingWriteHalf::new();
+    let mut write_conn_individual = WriteConnection::new(counting_write, 1);
+
+    for i in 1..=3 {
+        let call = Call::new(TestMethod {
+            operation: "fetch",
+            id: i,
+        });
+        #[cfg(feature = "std")]
+        write_conn_individual
+            .send_call(&call, vec![])
+            .await
+            .unwrap();
+        #[cfg(not(feature = "std"))]
+        write_conn_individual.send_call(&call).await.unwrap();
+    }
+    assert_eq!(write_conn_individual.socket.count(), 3);
+
+    // Test pipelined sends (1 write call expected).
+    let counting_write = CountingWriteHalf::new();
+    let mut write_conn_pipelined = WriteConnection::new(counting_write, 2);
+
+    for i in 1..=3 {
+        let call = Call::new(TestMethod {
+            operation: "fetch",
+            id: i,
+        });
+        #[cfg(feature = "std")]
+        write_conn_pipelined.enqueue_call(&call, vec![]).unwrap();
+        #[cfg(not(feature = "std"))]
+        write_conn_pipelined.enqueue_call(&call).unwrap();
+    }
+    write_conn_pipelined.flush().await.unwrap();
+    assert_eq!(write_conn_pipelined.socket.count(), 1);
+}

--- a/zlink-core/src/introspect/type/wrappers.rs
+++ b/zlink-core/src/introspect/type/wrappers.rs
@@ -34,11 +34,11 @@ impl<T: Type + ?Sized> Type for std::sync::Arc<T> {
 // Cell types - transparent wrappers
 // ============================================================================
 
-impl<T: Type + ?Sized> Type for std::cell::Cell<T> {
+impl<T: Type + ?Sized> Type for core::cell::Cell<T> {
     const TYPE: &'static idl::Type<'static> = T::TYPE;
 }
 
-impl<T: Type + ?Sized> Type for std::cell::RefCell<T> {
+impl<T: Type + ?Sized> Type for core::cell::RefCell<T> {
     const TYPE: &'static idl::Type<'static> = T::TYPE;
 }
 

--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -26,7 +26,9 @@ pub mod connection;
 pub use connection::Connection;
 mod error;
 pub use error::{Error, Result};
+#[cfg(feature = "std")]
 mod server;
+#[cfg(feature = "std")]
 pub use server::{
     listener::Listener,
     service::{self, Service},
@@ -46,6 +48,10 @@ pub mod varlink_service;
 pub use zlink_macros::proxy;
 
 pub use zlink_macros::ReplyError;
+
+#[cfg(feature = "std")]
+#[doc(hidden)]
+pub mod unix_utils;
 
 #[doc(hidden)]
 pub mod test_utils;

--- a/zlink-core/src/test_utils/mock_socket.rs
+++ b/zlink-core/src/test_utils/mock_socket.rs
@@ -5,18 +5,30 @@
 //! connections.
 
 use crate::connection::socket::{ReadHalf, Socket, WriteHalf};
+#[cfg(feature = "std")]
+use alloc::vec;
 use alloc::vec::Vec;
+#[cfg(feature = "std")]
+use core::cell::RefCell;
+#[cfg(feature = "std")]
+use rustix::fd::{BorrowedFd, OwnedFd};
 
 /// Mock socket implementation for testing.
 ///
 /// This socket pre-loads response data and allows tests to verify what was written.
 /// Responses should be provided as individual strings, and the mock will automatically
 /// add null byte separators between them.
+///
+/// In std mode, also supports file descriptor passing for testing FD-based IPC.
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct MockSocket {
     read_data: Vec<u8>,
     read_pos: usize,
+    #[cfg(feature = "std")]
+    fds: Vec<Vec<OwnedFd>>,
+    #[cfg(feature = "std")]
+    fd_index: usize,
 }
 
 impl MockSocket {
@@ -24,20 +36,39 @@ impl MockSocket {
     ///
     /// Each response string will be automatically null-terminated.
     /// An additional null byte is added at the end to mark the end of all messages.
-    pub fn new(responses: &[&str]) -> Self {
+    ///
+    /// In std mode, the `fds` parameter specifies which FDs to return for each read operation.
+    /// Use an empty vec for reads that should not return FDs.
+    pub fn new(responses: &[&str], #[cfg(feature = "std")] fds: Vec<Vec<OwnedFd>>) -> Self {
         let mut data = Vec::new();
 
         for response in responses {
             data.extend_from_slice(response.as_bytes());
             data.push(b'\0');
         }
-        // Add an extra null byte to mark end of all messages
+        // Add an extra null byte to mark end of all messages.
         data.push(b'\0');
 
         Self {
             read_data: data,
             read_pos: 0,
+            #[cfg(feature = "std")]
+            fds,
+            #[cfg(feature = "std")]
+            fd_index: 0,
         }
+    }
+
+    /// Create a mock socket with responses and no file descriptors.
+    ///
+    /// This is a convenience method for tests that don't use FDs, working
+    /// uniformly in both std and no_std modes.
+    pub fn with_responses(responses: &[&str]) -> Self {
+        Self::new(
+            responses,
+            #[cfg(feature = "std")]
+            vec![],
+        )
     }
 }
 
@@ -50,9 +81,15 @@ impl Socket for MockSocket {
             MockReadHalf {
                 data: self.read_data,
                 pos: self.read_pos,
+                #[cfg(feature = "std")]
+                fds: self.fds,
+                #[cfg(feature = "std")]
+                fd_index: self.fd_index,
             },
             MockWriteHalf {
                 written: Vec::new(),
+                #[cfg(feature = "std")]
+                fds_written: RefCell::new(Vec::new()),
             },
         )
     }
@@ -64,6 +101,10 @@ impl Socket for MockSocket {
 pub struct MockReadHalf {
     data: Vec<u8>,
     pos: usize,
+    #[cfg(feature = "std")]
+    fds: Vec<Vec<OwnedFd>>,
+    #[cfg(feature = "std")]
+    fd_index: usize,
 }
 
 impl MockReadHalf {
@@ -71,9 +112,41 @@ impl MockReadHalf {
     pub fn remaining_data(&self) -> &[u8] {
         &self.data[self.pos..]
     }
+
+    /// Get the number of FD sets that have been consumed (std only).
+    #[cfg(feature = "std")]
+    pub fn fds_consumed(&self) -> usize {
+        self.fd_index
+    }
 }
 
 impl ReadHalf for MockReadHalf {
+    #[cfg(feature = "std")]
+    async fn read(
+        &mut self,
+        buf: &mut [u8],
+    ) -> crate::Result<(usize, alloc::vec::Vec<std::os::fd::OwnedFd>)> {
+        let remaining = self.data.len().saturating_sub(self.pos);
+        if remaining == 0 {
+            return Ok((0, vec![]));
+        }
+
+        let to_read = remaining.min(buf.len());
+        buf[..to_read].copy_from_slice(&self.data[self.pos..self.pos + to_read]);
+        self.pos += to_read;
+
+        let fds = if self.fd_index < self.fds.len() {
+            let fds = core::mem::take(&mut self.fds[self.fd_index]);
+            self.fd_index += 1;
+            fds
+        } else {
+            vec![]
+        };
+
+        Ok((to_read, fds))
+    }
+
+    #[cfg(not(feature = "std"))]
     async fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
         let remaining = self.data.len().saturating_sub(self.pos);
         if remaining == 0 {
@@ -92,18 +165,71 @@ impl ReadHalf for MockReadHalf {
 #[doc(hidden)]
 pub struct MockWriteHalf {
     written: Vec<u8>,
+    #[cfg(feature = "std")]
+    fds_written: RefCell<Vec<Vec<OwnedFd>>>,
 }
 
 impl MockWriteHalf {
+    /// Create a new mock write half.
+    #[cfg(feature = "std")]
+    pub fn new() -> Self {
+        Self {
+            written: Vec::new(),
+            fds_written: RefCell::new(Vec::new()),
+        }
+    }
+
     /// Get all data that has been written to this mock.
     pub fn written_data(&self) -> &[u8] {
         &self.written
     }
+
+    /// Get all file descriptors that have been written (std only).
+    #[cfg(feature = "std")]
+    pub fn fds_written(&self) -> core::cell::Ref<'_, Vec<Vec<OwnedFd>>> {
+        self.fds_written.borrow()
+    }
+
+    /// Get the number of times FDs were written (std only).
+    #[cfg(feature = "std")]
+    pub fn fd_write_count(&self) -> usize {
+        self.fds_written.borrow().len()
+    }
+}
+
+#[cfg(feature = "std")]
+impl Default for MockWriteHalf {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl WriteHalf for MockWriteHalf {
-    async fn write(&mut self, buf: &[u8]) -> crate::Result<()> {
+    async fn write(
+        &mut self,
+        buf: &[u8],
+        #[cfg(feature = "std")] fds: &[impl std::os::fd::AsFd],
+    ) -> crate::Result<()> {
         self.written.extend_from_slice(buf);
+
+        #[cfg(feature = "std")]
+        {
+            let borrowed_fds: Vec<BorrowedFd<'_>> = fds.iter().map(|f| f.as_fd()).collect();
+
+            if !borrowed_fds.is_empty() {
+                // For testing, we duplicate the FDs to take ownership.
+                // In real implementation, the OS would transfer them.
+                let owned_fds: Vec<OwnedFd> = borrowed_fds
+                    .iter()
+                    .map(|fd| {
+                        rustix::io::fcntl_dupfd_cloexec(fd, 0)
+                            .map_err(|e| crate::Error::Io(e.into()))
+                    })
+                    .collect::<crate::Result<Vec<_>>>()?;
+                self.fds_written.borrow_mut().push(owned_fds);
+            }
+        }
+
         Ok(())
     }
 }
@@ -111,22 +237,71 @@ impl WriteHalf for MockWriteHalf {
 /// Mock write half that asserts the expected write length.
 ///
 /// This is useful for testing that writes are exactly the expected size.
+/// In std mode, can also validate expected FD count.
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct TestWriteHalf {
     expected_len: usize,
+    #[cfg(feature = "std")]
+    expected_fd_count: Option<usize>,
+    #[cfg(feature = "std")]
+    write_count: usize,
 }
 
 impl TestWriteHalf {
     /// Create a new test write half that expects writes of the given length.
+    #[cfg(not(feature = "std"))]
     pub fn new(expected_len: usize) -> Self {
         Self { expected_len }
+    }
+
+    /// Create a new test write half that expects writes of the given length (std version).
+    #[cfg(feature = "std")]
+    pub fn new(expected_len: usize) -> Self {
+        Self {
+            expected_len,
+            expected_fd_count: None,
+            write_count: 0,
+        }
+    }
+
+    /// Create a new test write half expecting specific write length and FD count (std only).
+    #[cfg(feature = "std")]
+    pub fn new_with_fds(expected_len: usize, expected_fd_count: usize) -> Self {
+        Self {
+            expected_len,
+            expected_fd_count: Some(expected_fd_count),
+            write_count: 0,
+        }
+    }
+
+    /// Get the number of writes performed (std only).
+    #[cfg(feature = "std")]
+    pub fn write_count(&self) -> usize {
+        self.write_count
     }
 }
 
 impl WriteHalf for TestWriteHalf {
-    async fn write(&mut self, buf: &[u8]) -> crate::Result<()> {
+    async fn write(
+        &mut self,
+        buf: &[u8],
+        #[cfg(feature = "std")] fds: &[impl std::os::fd::AsFd],
+    ) -> crate::Result<()> {
         assert_eq!(buf.len(), self.expected_len);
+
+        #[cfg(feature = "std")]
+        {
+            let fd_count = fds.len();
+            if let Some(expected_count) = self.expected_fd_count {
+                assert_eq!(fd_count, expected_count);
+            } else {
+                assert_eq!(fd_count, 0, "Expected no FDs to be passed");
+            }
+
+            self.write_count += 1;
+        }
+
         Ok(())
     }
 }
@@ -159,8 +334,127 @@ impl CountingWriteHalf {
 }
 
 impl WriteHalf for CountingWriteHalf {
-    async fn write(&mut self, _buf: &[u8]) -> crate::Result<()> {
+    async fn write(
+        &mut self,
+        _buf: &[u8],
+        #[cfg(feature = "std")] _fds: &[impl std::os::fd::AsFd],
+    ) -> crate::Result<()> {
         self.count += 1;
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+    use std::os::fd::AsFd;
+
+    #[tokio::test]
+    async fn mock_socket_with_fds_basic() {
+        use std::os::unix::net::UnixStream;
+
+        let (r1, _w1) = UnixStream::pair().unwrap();
+        let (r2, _w2) = UnixStream::pair().unwrap();
+
+        let fds = vec![vec![r1.into()], vec![r2.into()]];
+        let socket = MockSocket::new(&["test1", "test2"], fds);
+
+        let (mut read, _write) = socket.split();
+
+        let mut buf = [0u8; 10]; // Small buffer to force multiple reads
+        let (bytes, fds1) = read.read(&mut buf).await.unwrap();
+        assert!(bytes > 0);
+        assert_eq!(fds1.len(), 1);
+
+        let (bytes, fds2) = read.read(&mut buf).await.unwrap();
+        assert!(bytes > 0);
+        assert_eq!(fds2.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn mock_write_half_captures_fds() {
+        use std::os::unix::net::UnixStream;
+
+        let mut write = MockWriteHalf::new();
+
+        let (r1, _w1) = UnixStream::pair().unwrap();
+        let borrowed = r1.as_fd();
+
+        write.write(b"test", &[borrowed]).await.unwrap();
+
+        assert_eq!(write.written_data(), b"test");
+        assert_eq!(write.fd_write_count(), 1);
+        assert_eq!(write.fds_written().len(), 1);
+        assert_eq!(write.fds_written()[0].len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_write_half_validates_fd_count() {
+        use std::os::unix::net::UnixStream;
+
+        let mut write = TestWriteHalf::new_with_fds(4, 2);
+
+        let (r1, _w1) = UnixStream::pair().unwrap();
+        let (r2, _w2) = UnixStream::pair().unwrap();
+        let borrowed = [r1.as_fd(), r2.as_fd()];
+
+        write.write(b"test", &borrowed).await.unwrap();
+
+        assert_eq!(write.write_count(), 1);
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "assertion `left == right` failed")]
+    async fn test_write_half_panics_on_wrong_fd_count() {
+        use std::os::unix::net::UnixStream;
+
+        let mut write = TestWriteHalf::new_with_fds(4, 2);
+
+        let (r1, _w1) = UnixStream::pair().unwrap();
+        let borrowed = [r1.as_fd()];
+
+        // This should panic because we expect 2 FDs but provide 1.
+        write.write(b"test", &borrowed).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn mock_read_half_multiple_fds_per_read() {
+        use std::os::unix::net::UnixStream;
+
+        let (r1, _w1) = UnixStream::pair().unwrap();
+        let (r2, _w2) = UnixStream::pair().unwrap();
+        let (r3, _w3) = UnixStream::pair().unwrap();
+
+        let fds = vec![vec![r1.into(), r2.into(), r3.into()]];
+        let socket = MockSocket::new(&["test"], fds);
+
+        let (mut read, _write) = socket.split();
+
+        let mut buf = [0u8; 1024];
+        let (bytes, fds) = read.read(&mut buf).await.unwrap();
+        assert!(bytes > 0);
+        assert_eq!(fds.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn mock_read_half_mixed_fd_and_no_fd_reads() {
+        use std::os::unix::net::UnixStream;
+
+        let (r1, _w1) = UnixStream::pair().unwrap();
+
+        let fds = vec![vec![r1.into()], vec![]];
+        let socket = MockSocket::new(&["test1", "test2"], fds);
+
+        let (mut read, _write) = socket.split();
+
+        let mut buf = [0u8; 10]; // Small buffer to force multiple reads
+
+        let (bytes, fds1) = read.read(&mut buf).await.unwrap();
+        assert!(bytes > 0);
+        assert!(!fds1.is_empty());
+
+        let (bytes, fds2) = read.read(&mut buf).await.unwrap();
+        assert!(bytes > 0);
+        assert!(fds2.is_empty());
     }
 }

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -1,0 +1,63 @@
+//! Helper functions for Unix socket FD passing.
+//!
+//! These are public but hidden from documentation as they're implementation details shared between
+//! runtime-specific socket implementations.
+
+use core::mem::MaybeUninit;
+use std::{
+    io,
+    os::fd::{AsFd, BorrowedFd, OwnedFd},
+};
+
+/// Receive a message from a Unix socket, including any file descriptors.
+///
+/// This is a low-level helper that performs the `recvmsg` syscall.
+#[doc(hidden)]
+pub fn recvmsg(fd: impl AsFd, buf: &mut [u8]) -> io::Result<(usize, alloc::vec::Vec<OwnedFd>)> {
+    use rustix::net::{recvmsg, RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags};
+    use std::io::IoSliceMut;
+
+    let mut cmsg_buf = [MaybeUninit::<u8>::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS))];
+    let mut control = RecvAncillaryBuffer::new(&mut cmsg_buf);
+
+    let mut iov = [IoSliceMut::new(buf)];
+    recvmsg(fd.as_fd(), &mut iov, &mut control, RecvFlags::empty())
+        .map(|msg| {
+            // Extract file descriptors from ancillary data.
+            let mut fds = alloc::vec::Vec::new();
+            for m in control.drain() {
+                if let RecvAncillaryMessage::ScmRights(rights) = m {
+                    fds.extend(rights);
+                }
+            }
+            (msg.bytes, fds)
+        })
+        .map_err(io::Error::from)
+}
+
+/// Send a message to a Unix socket, including any file descriptors.
+///
+/// This is a low-level helper that performs the `sendmsg` syscall.
+#[doc(hidden)]
+pub fn sendmsg(fd: impl AsFd, buf: &[u8], fds: &[BorrowedFd<'_>]) -> io::Result<usize> {
+    use rustix::net::{sendmsg, SendAncillaryBuffer, SendAncillaryMessage, SendFlags};
+    use std::io::IoSlice;
+
+    let mut cmsg_buf = [MaybeUninit::<u8>::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS))];
+    let mut control = SendAncillaryBuffer::new(&mut cmsg_buf);
+
+    if !fds.is_empty() && !control.push(SendAncillaryMessage::ScmRights(fds)) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "too many file descriptors to send",
+        ));
+    }
+
+    let iov = [IoSlice::new(buf)];
+    sendmsg(fd.as_fd(), &iov, &mut control, SendFlags::empty()).map_err(io::Error::from)
+}
+
+/// The maximum number of file descriptors that can be sent in a single message.
+///
+/// The value is based on what is used in `zbus`, which comes from sdbus.
+const MAX_FDS: usize = 1024;

--- a/zlink-core/src/varlink_service/mod.rs
+++ b/zlink-core/src/varlink_service/mod.rs
@@ -8,9 +8,9 @@ pub use info::Info;
 mod api;
 pub use api::{Error, Method, Reply, Result};
 
-#[cfg(feature = "idl-parse")]
+#[cfg(all(feature = "idl-parse", feature = "std"))]
 mod proxy;
-#[cfg(feature = "idl-parse")]
+#[cfg(all(feature = "idl-parse", feature = "std"))]
 pub use proxy::{Chain, Proxy};
 
 #[cfg(feature = "idl")]

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -12,6 +12,7 @@ proc-macro = true
 
 [features]
 default = ["proxy"]
+std = []
 proxy = ["syn/full", "syn/clone-impls"]
 idl-parse = ["zlink/idl-parse"]
 introspection = ["zlink/introspection"]

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -411,7 +411,7 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// # let responses = vec![
 /// #     r#"{"parameters":{"active":true,"message":"System running"}}"#,
 /// # ];
-/// # let socket = MockSocket::new(&responses);
+/// # let socket = MockSocket::with_responses(&responses);
 /// # let mut conn = zlink::Connection::new(socket);
 /// let result = conn.get_status().await?.unwrap();
 /// assert_eq!(result.active, true);
@@ -484,7 +484,7 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// #     r#"{"parameters":[{"id":1,"user_id":1,"content":"My first post!"}]}"#,
 /// #     r#"{"parameters":{"id":1,"name":"Alice"}}"#,
 /// # ];
-/// # let socket = MockSocket::new(&responses);
+/// # let socket = MockSocket::with_responses(&responses);
 /// # let mut conn = zlink::Connection::new(socket);
 /// // Chain calls across both interfaces in a single batch
 /// let chain = conn
@@ -499,14 +499,15 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///
 /// // Process replies in order
 /// let mut reply_count = 0;
-/// while let Some(reply) = replies.try_next().await? {
-///     let reply = reply?;
+/// while let Some((reply, _fds)) = replies.try_next().await? {
 ///     reply_count += 1;
-///     match reply.parameters() {
-///         Some(BlogReply::User(user)) => assert_eq!(user.name, "Alice"),
-///         Some(BlogReply::Post(post)) => assert_eq!(post.content, "My first post!"),
-///         Some(BlogReply::Posts(posts)) => assert_eq!(posts.len(), 1),
-///         None => {} // set_value returns empty response
+///     if let Ok(response) = reply {
+///         match response.parameters() {
+///             Some(BlogReply::User(user)) => assert_eq!(user.name, "Alice"),
+///             Some(BlogReply::Post(post)) => assert_eq!(post.content, "My first post!"),
+///             Some(BlogReply::Posts(posts)) => assert_eq!(posts.len(), 1),
+///             None => {} // set_value returns empty response
+///         }
 ///     }
 /// }
 /// assert_eq!(reply_count, 4); // We made 4 calls
@@ -563,7 +564,7 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// #     r#"{"parameters":{"active":true,"message":"Running"}}"#,
 /// #     r#"{"parameters":{"description":"interface com.example.MyService\n..."}}"#,
 /// # ];
-/// # let socket = MockSocket::new(&responses);
+/// # let socket = MockSocket::with_responses(&responses);
 /// # let mut conn = zlink::Connection::new(socket);
 /// use varlink_service::Proxy;
 /// use zlink::varlink_service::Chain;
@@ -665,7 +666,7 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// # let responses = vec![
 /// #     r#"{"parameters":null}"#, // store returns empty Ok
 /// # ];
-/// # let socket = MockSocket::new(&responses);
+/// # let socket = MockSocket::with_responses(&responses);
 /// # let mut conn = zlink::Connection::new(socket);
 /// // Store a value with generic type
 /// let result = conn.store("my-key", 42i32).await?;

--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -166,6 +166,11 @@ fn generate_no_params_method(
         >;
     };
 
+    #[cfg(feature = "std")]
+    let append_call = quote! { self.append(&call, vec![]) };
+    #[cfg(not(feature = "std"))]
+    let append_call = quote! { self.append(&call) };
+
     let impl_method = quote! {
         fn #method_name(
             self,
@@ -181,7 +186,7 @@ fn generate_no_params_method(
                 }
                 MethodWrapper::Method
             });
-            self.append(&call)
+            #append_call
         }
     };
 
@@ -239,6 +244,11 @@ fn generate_with_params_method(
     // Build struct where clause adding Serialize and Debug bounds for generic parameters
     let struct_where = build_struct_where_clause(method_generic_params, method_where_clause);
 
+    #[cfg(feature = "std")]
+    let append_call = quote! { self.append(&call, vec![]) };
+    #[cfg(not(feature = "std"))]
+    let append_call = quote! { self.append(&call) };
+
     let impl_method = quote! {
         fn #method_name #generics(
             self,
@@ -269,7 +279,7 @@ fn generate_with_params_method(
                     #(#arg_names,)*
                 })
             });
-            self.append(&call)
+            #append_call
         }
     };
 

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -94,6 +94,11 @@ pub(super) fn generate_chain_method(
     );
 
     // Generate the implementation method
+    #[cfg(feature = "std")]
+    let chain_call = quote! { self.chain_call(&call, vec![]) };
+    #[cfg(not(feature = "std"))]
+    let chain_call = quote! { self.chain_call(&call) };
+
     let impl_method = quote! {
         fn #chain_method_name<#all_generics>(
             &'c mut self,
@@ -104,7 +109,7 @@ pub(super) fn generate_chain_method(
         #chain_where
         {
             #method_call_creation
-            self.chain_call(&call)
+            #chain_call
         }
     };
 

--- a/zlink-macros/tests/proxy/basic.rs
+++ b/zlink-macros/tests/proxy/basic.rs
@@ -17,7 +17,7 @@ async fn proxy_no_in_or_out_params() {
 
     // Test that methods returning `()` should accept empty {} response and empty parameters.
     let responses = [r#"{}"#, r#"{parameters: {}}"#];
-    let socket = MockSocket::new(&responses);
+    let socket = MockSocket::with_responses(&responses);
 
     let mut conn = Connection::new(socket);
 
@@ -36,7 +36,7 @@ async fn proxy_oneway_method() {
 
     // Oneway methods don't expect a response, so we provide an empty response list
     let responses: &[&str] = &[];
-    let socket = MockSocket::new(responses);
+    let socket = MockSocket::with_responses(responses);
 
     let mut conn = Connection::new(socket);
 
@@ -73,7 +73,7 @@ async fn proxy_parameter_rename() {
 
     // Mock response with the expected parameter names in the request
     let responses = json!({"parameters": {"id": 123}}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
 
     let mut conn = Connection::new(socket);
 

--- a/zlink-macros/tests/proxy/complex_lifetimes.rs
+++ b/zlink-macros/tests/proxy/complex_lifetimes.rs
@@ -71,7 +71,7 @@ async fn complex_lifetimes_test() {
         }]
     })
     .to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let items = vec!["item1".to_string()];
@@ -86,7 +86,7 @@ async fn complex_lifetimes_test() {
         }
     })
     .to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let mut data = HashMap::new();
@@ -109,7 +109,7 @@ async fn complex_lifetimes_test() {
         }
     })
     .to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let pairs = vec![("key1".to_string(), 100), ("key2".to_string(), 200)];
@@ -125,7 +125,7 @@ async fn complex_lifetimes_test() {
         }
     })
     .to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn.generic_result("test input").await.unwrap().unwrap();

--- a/zlink-macros/tests/proxy/generics.rs
+++ b/zlink-macros/tests/proxy/generics.rs
@@ -29,7 +29,7 @@ async fn generic_test() {
 
     // Test process with String type parameter
     let responses = json!({"parameters": {"result": "success"}}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn
@@ -41,7 +41,7 @@ async fn generic_test() {
 
     // Test process2 with i32 type parameter
     let responses = json!({"parameters": {"result": "process2 result"}}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn.process2(123).await.unwrap().unwrap();
@@ -71,7 +71,7 @@ async fn where_clause_test() {
 
     // Test get with i32 type parameter
     let responses = json!({"parameters": {"value": "42"}}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn.get(42).await.unwrap().unwrap();
@@ -79,7 +79,7 @@ async fn where_clause_test() {
 
     // Test get2 with bool type parameter
     let responses = json!({"parameters": {"value": "true"}}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn.get2(true).await.unwrap().unwrap();

--- a/zlink-macros/tests/proxy/lifetimes.rs
+++ b/zlink-macros/tests/proxy/lifetimes.rs
@@ -40,7 +40,7 @@ async fn lifetimes_test() {
         }
     })
     .to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn.process("test input").await.unwrap().unwrap();
@@ -54,7 +54,7 @@ async fn lifetimes_test() {
         }
     })
     .to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn.with_lifetime("test", 3).await.unwrap().unwrap();

--- a/zlink-macros/tests/proxy/optional_params.rs
+++ b/zlink-macros/tests/proxy/optional_params.rs
@@ -36,7 +36,7 @@ async fn optional_params_test() {
 
     // Test with_optionals
     let responses = json!({"parameters": {"message": "success with optionals"}}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn
@@ -48,7 +48,7 @@ async fn optional_params_test() {
 
     // Test mixed_optionals
     let responses = json!({}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     conn.mixed_optionals("first", None, 100, Some(true), "third", None)

--- a/zlink-macros/tests/proxy/rename.rs
+++ b/zlink-macros/tests/proxy/rename.rs
@@ -27,7 +27,7 @@ async fn rename_test() {
 
     // Test get_data with renamed method
     let responses = json!({"parameters": {"data": "test data"}}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn.get_data().await.unwrap().unwrap();
@@ -41,14 +41,14 @@ async fn rename_test() {
 
     // Test update_value
     let responses = json!({}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     conn.update_value(42).await.unwrap().unwrap();
 
     // Test snake_case_method (should be converted to PascalCase)
     let responses = json!({}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     conn.snake_case_method().await.unwrap().unwrap();

--- a/zlink-macros/tests/proxy/streaming.rs
+++ b/zlink-macros/tests/proxy/streaming.rs
@@ -46,7 +46,7 @@ async fn streaming_test() {
 
     // Test get_single
     let responses = json!({"parameters": {"result": "single result"}}).to_string();
-    let socket = MockSocket::new(&[&responses]);
+    let socket = MockSocket::with_responses(&[&responses]);
     let mut conn = Connection::new(socket);
 
     let result = conn.get_single().await.unwrap().unwrap();
@@ -58,7 +58,8 @@ async fn streaming_test() {
         json!({"continues": true, "parameters": {"result": "stream item 2"}}).to_string(),
         json!({"continues": false, "parameters": {"result": "stream item 3"}}).to_string(),
     ];
-    let socket = MockSocket::new(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+    let socket =
+        MockSocket::with_responses(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
     let mut conn = Connection::new(socket);
 
     let stream = conn.get_stream().await.unwrap();
@@ -78,7 +79,8 @@ async fn streaming_test() {
         json!({"continues": true, "parameters": {"id": 2, "name": "Item 2"}}).to_string(),
         json!({"continues": false, "parameters": {"id": 3, "name": "Item 3"}}).to_string(),
     ];
-    let socket = MockSocket::new(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
+    let socket =
+        MockSocket::with_responses(&responses.iter().map(|s| s.as_str()).collect::<Vec<_>>());
     let mut conn = Connection::new(socket);
 
     let stream = conn.custom_stream(3).await.unwrap();

--- a/zlink-tokio/src/unix/stream.rs
+++ b/zlink-tokio/src/unix/stream.rs
@@ -2,10 +2,8 @@ use crate::{
     connection::socket::{self, Socket},
     Result,
 };
-use tokio::{
-    io::{AsyncReadExt, AsyncWriteExt},
-    net::{unix, UnixStream},
-};
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use tokio::net::{unix, UnixStream};
 
 /// The connection type that uses Unix Domain Sockets for transport.
 pub type Connection = crate::Connection<Stream>;
@@ -30,6 +28,8 @@ impl Socket for Stream {
     type ReadHalf = ReadHalf;
     type WriteHalf = WriteHalf;
 
+    const CAN_TRANSFER_FDS: bool = true;
+
     fn split(self) -> (Self::ReadHalf, Self::WriteHalf) {
         let (read, write) = self.0.into_split();
 
@@ -48,8 +48,24 @@ impl From<UnixStream> for Stream {
 pub struct ReadHalf(unix::OwnedReadHalf);
 
 impl socket::ReadHalf for ReadHalf {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
-        self.0.read(buf).await.map_err(Into::into)
+    async fn read(&mut self, buf: &mut [u8]) -> Result<(usize, Vec<OwnedFd>)> {
+        use std::{future::poll_fn, task::Poll};
+
+        poll_fn(|cx| loop {
+            let stream: &UnixStream = self.0.as_ref();
+            match stream.try_io(tokio::io::Interest::READABLE, || {
+                crate::unix_utils::recvmsg(stream, buf)
+            }) {
+                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    match stream.poll_read_ready(cx) {
+                        Poll::Pending => return Poll::Pending,
+                        Poll::Ready(res) => res?,
+                    }
+                }
+                v => return Poll::Ready(v.map_err(Into::into)),
+            }
+        })
+        .await
     }
 }
 
@@ -58,11 +74,34 @@ impl socket::ReadHalf for ReadHalf {
 pub struct WriteHalf(unix::OwnedWriteHalf);
 
 impl socket::WriteHalf for WriteHalf {
-    async fn write(&mut self, buf: &[u8]) -> Result<()> {
-        let mut pos = 0;
+    async fn write(&mut self, buf: &[u8], fds: &[impl AsFd]) -> Result<()> {
+        use std::{future::poll_fn, task::Poll};
 
+        // Convert to BorrowedFd for rustix.
+        let borrowed_fds: Vec<BorrowedFd<'_>> = fds.iter().map(|f| f.as_fd()).collect();
+
+        let mut pos = 0;
         while pos < buf.len() {
-            let n = self.0.write(&buf[pos..]).await?;
+            // Use FDs on first write, empty slice on subsequent writes.
+            let fds_to_send = if pos == 0 { &borrowed_fds[..] } else { &[] };
+
+            let n: usize = poll_fn(|cx| loop {
+                let stream: &UnixStream = self.0.as_ref();
+                match stream.try_io(tokio::io::Interest::WRITABLE, || {
+                    crate::unix_utils::sendmsg(stream, &buf[pos..], fds_to_send)
+                }) {
+                    Ok(bytes_sent) => return Poll::Ready(Ok::<_, crate::Error>(bytes_sent)),
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        match stream.poll_write_ready(cx) {
+                            Poll::Pending => return Poll::Pending,
+                            Poll::Ready(res) => res?,
+                        }
+                    }
+                    Err(e) => return Poll::Ready(Err(e.into())),
+                }
+            })
+            .await?;
+
             pos += n;
         }
 

--- a/zlink/examples/resolved.rs
+++ b/zlink/examples/resolved.rs
@@ -36,10 +36,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let name = &args[i];
         i += 1;
 
-        match reply? {
-            Ok(result) => {
+        let (result, _fds) = reply?;
+        match result {
+            Ok(reply) => {
                 println!("Results for '{name}':");
-                for address in result.into_parameters().unwrap().addresses {
+                for address in reply.into_parameters().unwrap().addresses {
                     println!("\t{address}");
                 }
             }


### PR DESCRIPTION
This commit lays down the foundation for FD-passing and receiving in the
core/low-level API. Support for FD-passing in `proxy` will be added in a
follow-up PR.

Partially fixes issue #82.
