### PR TITLE
♻ refactor: Fix clippy warnings in zlink-macros

### DIFF
--- a/zlink-macros/src/proxy/method_impl.rs
+++ b/zlink-macros/src/proxy/method_impl.rs
@@ -5,9 +5,12 @@ use syn::{punctuated::Punctuated, Error, FnArg, Pat, Type};
 
 use super::{
     types::{ArgInfo, MethodAttrs},
-    utils::*,
+    utils::{
+        collect_used_type_params, convert_to_single_lifetime, extract_param_rename_attr,
+        parse_return_type, snake_case_to_pascal_case, type_contains_lifetime,
+    },
 };
-use crate::utils::*;
+use crate::utils::is_option_type;
 
 pub(super) fn generate_method_impl(
     method: &mut syn::TraitItemFn,

--- a/zlink-macros/src/reply_error.rs
+++ b/zlink-macros/src/reply_error.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{parse_quote, Data, DataEnum, DeriveInput, Error, Fields, FieldsNamed};
 
-use crate::utils::*;
+use crate::utils::{convert_type_lifetimes, parse_zlink_string_attr};
 
 /// Main entry point for the ReplyError derive macro that generates serde implementations.
 ///

--- a/zlink-macros/src/reply_error.rs
+++ b/zlink-macros/src/reply_error.rs
@@ -4,7 +4,7 @@ use syn::{parse_quote, Data, DataEnum, DeriveInput, Error, Fields, FieldsNamed};
 
 use crate::utils::{convert_type_lifetimes, parse_zlink_string_attr};
 
-/// Main entry point for the ReplyError derive macro that generates serde implementations.
+/// Main entry point for the `ReplyError` derive macro that generates serde implementations.
 ///
 /// This macro:
 /// 1. Generates manual `serde::Serialize` implementation for qualified error names
@@ -77,7 +77,7 @@ fn parse_interface_from_attrs(attrs: &[syn::Attribute]) -> Result<String, Error>
     ))
 }
 
-/// Validate that enum variants are supported by the ReplyError derive macro.
+/// Validate that enum variants are supported by the `ReplyError` derive macro.
 fn validate_enum_variants(data_enum: &DataEnum) -> Result<(), Error> {
     for variant in &data_enum.variants {
         match &variant.fields {

--- a/zlink-macros/src/utils.rs
+++ b/zlink-macros/src/utils.rs
@@ -173,8 +173,8 @@ pub(crate) fn remove_lifetimes_from_type(ty: &Type) -> Type {
     }
 }
 
-/// Check if a type is Option<T>.
-/// Handles Option, std::option::Option, and core::option::Option.
+/// Check if a type is `Option<T>`.
+/// Handles `Option`, `std::option::Option`, and `core::option::Option`.
 pub(crate) fn is_option_type(ty: &Type) -> bool {
     let Type::Path(type_path) = ty else {
         return false;
@@ -276,7 +276,7 @@ pub(crate) fn convert_type_lifetimes(ty: &Type, target_lifetime: &str) -> Type {
 /// For example, parse `#[zlink(rename = "new_name")]` by calling with key "rename".
 /// Returns None if the attribute or key is not found.
 ///
-/// This is used by both reply_error and proxy modules for parsing rename attributes.
+/// This is used by both `reply_error` and `proxy` modules for parsing rename attributes.
 pub(crate) fn parse_zlink_string_attr(attrs: &[Attribute], key: &str) -> Option<String> {
     for attr in attrs {
         if !attr.path().is_ident("zlink") {


### PR DESCRIPTION
This fixes warnings found by clippy for zlink-macros.