### PR TITLE
🚸 core: Service::handle now receives the `Connection` ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ use tokio::{select, sync::oneshot, fs::remove_file};
 use zlink::{
     proxy,
     service::{MethodReply, Service},
+    connection::{Connection, Socket},
     unix, Call, ReplyError, Server,
 };
 
@@ -195,9 +196,10 @@ impl Service for Calculator {
     type ReplyStream = futures_util::stream::Empty<zlink::Reply<()>>;
     type ReplyError<'ser> = CalculatorError<'ser>;
 
-    async fn handle(
+    async fn handle<Sock: Socket>(
         &mut self,
         call: Call<Self::MethodCall<'_>>,
+        conn: &mut Connection<Sock>,
     ) -> MethodReply<Self::ReplyParams<'_>, Self::ReplyStream, Self::ReplyError<'_>> {
         match call.method() {
             CalculatorMethod::Add { a, b } => {

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -167,7 +167,7 @@ where
         conn: &mut Connection<Listener::Socket>,
     ) -> crate::Result<Option<Service::ReplyStream>> {
         let mut stream = None;
-        match self.service.handle(call).await {
+        match self.service.handle(call, conn).await {
             MethodReply::Single(params) => {
                 let reply = Reply::new(params).set_continues(Some(false));
                 conn.send_reply(&reply, vec![]).await?

--- a/zlink-core/src/server/service.rs
+++ b/zlink-core/src/server/service.rs
@@ -5,7 +5,7 @@ use core::{fmt::Debug, future::Future};
 use futures_util::Stream;
 use serde::{Deserialize, Serialize};
 
-use crate::{Call, Reply};
+use crate::{connection::Socket, Call, Connection, Reply};
 
 /// Service trait for handling method calls.
 pub trait Service {
@@ -41,9 +41,10 @@ pub trait Service {
         Self: 'ser;
 
     /// Handle a method call.
-    fn handle<'ser>(
+    fn handle<'ser, Sock: Socket>(
         &'ser mut self,
         method: Call<Self::MethodCall<'_>>,
+        conn: &mut Connection<Sock>,
     ) -> impl Future<
         Output = MethodReply<Self::ReplyParams<'ser>, Self::ReplyStream, Self::ReplyError<'ser>>,
     >;

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -7,6 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_prefix_all::prefix_all;
 use tokio::{select, time::sleep};
 use zlink::{
+    connection::Socket,
     idl::Interface,
     introspect::{self, CustomType, ReplyError as _, Type},
     notified,
@@ -16,7 +17,7 @@ use zlink::{
         self, Info, InterfaceDescription, Method as VarlinkSrvMethod, Proxy as _,
         Reply as VarlinkSrvReply,
     },
-    Call, Service,
+    Call, Connection, Service,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
@@ -233,9 +234,10 @@ impl Service for Ftl {
     type ReplyStreamParams = FtlReply;
     type ReplyError<'ser> = ReplyError;
 
-    async fn handle<'ser>(
+    async fn handle<'ser, Sock: Socket>(
         &'ser mut self,
         call: Call<Self::MethodCall<'_>>,
+        _conn: &mut Connection<Sock>,
     ) -> MethodReply<Self::ReplyParams<'ser>, Self::ReplyStream, Self::ReplyError<'ser>> {
         match call.method() {
             Method::Ftl(FtlMethod::GetDriveCondition) if call.more() => {

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -8,11 +8,12 @@ use serde::{Deserialize, Serialize};
 use serde_prefix_all::prefix_all;
 use std::vec::Vec;
 use zlink::{
+    connection::Socket,
     idl::{self, Comment, Interface, Parameter},
     introspect::{self, CustomType, ReplyError as _, Type},
     service::MethodReply,
     varlink_service::{self, Error, Info, InterfaceDescription},
-    Call, ReplyError, Service,
+    Call, Connection, ReplyError, Service,
 };
 
 /// Mock systemd-machined service that serves hardcoded responses.
@@ -203,9 +204,10 @@ impl Service for MockMachinedService {
     type ReplyStreamParams = ();
     type ReplyError<'ser> = MockError;
 
-    async fn handle<'ser>(
+    async fn handle<'ser, Sock: Socket>(
         &'ser mut self,
         call: Call<Self::MethodCall<'_>>,
+        _conn: &mut Connection<Sock>,
     ) -> MethodReply<Self::ReplyParams<'ser>, Self::ReplyStream, Self::ReplyError<'ser>> {
         match call.method() {
             Method::VarlinkService(varlink_service::Method::GetInfo) => {


### PR DESCRIPTION
This is the connection that the method call in question arrived on. In the future, we'll add API to `Connection` that service implementation will likely be interested in, like peer credentials fetching (#120) for example.
