### PR TITLE
✨ API to fetch peer credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,6 +2142,7 @@ dependencies = [
  "clap",
  "colored 3.0.0",
  "futures-util",
+ "rustix",
  "serde",
  "serde-prefix-all",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2178,6 +2178,7 @@ dependencies = [
  "futures-util",
  "indexmap",
  "itoa",
+ "libc",
  "pin-project-lite",
  "rustix",
  "ryu",

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [features]
 default = ["std", "proxy", "tracing"]
-std = ["dep:rustix", "zlink-macros/std"]
+std = ["dep:rustix", "dep:libc", "zlink-macros/std"]
 proxy = ["zlink-macros/proxy"]
 # IDL and introspection support
 idl = []
@@ -46,6 +46,7 @@ rustix = { version = "1.1.2", default-features = false, features = [
     "std",
     "fs",
 ], optional = true }
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 serde = { version = "1.0.218", default-features = false, features = ["alloc"] }

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -42,7 +42,9 @@ bytes = { version = "1.5", optional = true, default-features = false }
 indexmap = { version = "2.2", optional = true }
 rustix = { version = "1.1.2", default-features = false, features = [
     "net",
+    "process",
     "std",
+    "fs",
 ], optional = true }
 
 [dev-dependencies]

--- a/zlink-core/src/connection/credentials.rs
+++ b/zlink-core/src/connection/credentials.rs
@@ -1,0 +1,58 @@
+//! Connection credentials.
+
+use super::{Pid, Uid};
+
+/// Credentials of a peer connection.
+#[derive(Debug)]
+pub struct Credentials {
+    unix_user_id: Uid,
+    process_id: Pid,
+    #[cfg(target_os = "linux")]
+    process_fd: std::os::fd::OwnedFd,
+}
+
+impl Credentials {
+    /// Create new credentials for a peer connection.
+    ///
+    /// # Arguments
+    /// * `unix_user_id` - The numeric Unix user ID.
+    /// * `process_id` - The numeric process ID.
+    /// * `process_fd` (Linux only) - A file descriptor pinning the process.
+    pub(crate) fn new(
+        unix_user_id: Uid,
+        process_id: Pid,
+        #[cfg(target_os = "linux")] process_fd: std::os::fd::OwnedFd,
+    ) -> Self {
+        Self {
+            unix_user_id,
+            process_id,
+            #[cfg(target_os = "linux")]
+            process_fd,
+        }
+    }
+
+    /// The numeric Unix user ID, as defined by POSIX.
+    pub fn unix_user_id(&self) -> Uid {
+        self.unix_user_id
+    }
+
+    /// The numeric process ID, on platforms that have this concept.
+    ///
+    /// On Unix, this is the process ID defined by POSIX.
+    pub fn process_id(&self) -> Pid {
+        self.process_id
+    }
+
+    /// A file descriptor pinning the process, on platforms that have this concept.
+    ///
+    /// On Linux, the SO_PEERPIDFD socket option is a suitable implementation. This is safer to use
+    /// to identify a process than the ProcessID, as the latter is subject to re-use attacks, while
+    /// the FD cannot be recycled. If the original process no longer exists the FD will no longer
+    /// be resolvable.
+    #[cfg(target_os = "linux")]
+    pub fn process_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+        use std::os::fd::AsFd;
+
+        self.process_fd.as_fd()
+    }
+}

--- a/zlink-core/src/connection/tests/connection_tests.rs
+++ b/zlink-core/src/connection/tests/connection_tests.rs
@@ -1,0 +1,42 @@
+//! Tests for Connection-level functionality.
+
+use crate::{test_utils::mock_socket::MockSocket, Connection};
+
+#[cfg(feature = "std")]
+#[tokio::test]
+async fn peer_credentials_mock_socket() {
+    // Get the expected credentials of the current process.
+    let expected_uid = rustix::process::getuid();
+    let expected_pid = rustix::process::getpid();
+
+    // Create a mock socket with some dummy responses.
+    let socket = MockSocket::with_responses(&[]);
+    let mut connection = Connection::new(socket);
+
+    // Get peer credentials - should return current process credentials.
+    let creds = connection.peer_credentials().await.unwrap();
+
+    // Verify we got the correct credentials.
+    assert_eq!(
+        creds.unix_user_id(),
+        expected_uid,
+        "UID should match current process"
+    );
+
+    // On Linux/Android, mock socket returns actual PID. On other platforms, it returns actual PID
+    // too (unlike real sockets which return 0).
+    assert_eq!(
+        creds.process_id(),
+        expected_pid,
+        "PID should match current process"
+    );
+
+    // Save values for comparison.
+    let uid1 = creds.unix_user_id();
+    let pid1 = creds.process_id();
+
+    // Verify caching works - calling again should return the same values.
+    let creds2 = connection.peer_credentials().await.unwrap();
+    assert_eq!(uid1, creds2.unix_user_id(), "Cached UID should match");
+    assert_eq!(pid1, creds2.process_id(), "Cached PID should match");
+}

--- a/zlink-core/src/connection/tests/mod.rs
+++ b/zlink-core/src/connection/tests/mod.rs
@@ -4,6 +4,8 @@ mod write_connection_tests;
 #[cfg(feature = "std")]
 mod chain_fds_tests;
 #[cfg(feature = "std")]
+mod connection_tests;
+#[cfg(feature = "std")]
 mod read_connection_fds_tests;
 #[cfg(feature = "std")]
 mod write_connection_fds_tests;

--- a/zlink-core/src/test_utils/mock_socket.rs
+++ b/zlink-core/src/test_utils/mock_socket.rs
@@ -4,6 +4,8 @@
 //! used in tests to simulate socket behavior without requiring actual network
 //! connections.
 
+#[cfg(feature = "std")]
+use crate::connection;
 use crate::connection::socket::{ReadHalf, Socket, WriteHalf};
 #[cfg(feature = "std")]
 use alloc::vec;
@@ -157,6 +159,20 @@ impl ReadHalf for MockReadHalf {
         buf[..to_read].copy_from_slice(&self.data[self.pos..self.pos + to_read]);
         self.pos += to_read;
         Ok(to_read)
+    }
+}
+
+#[cfg(feature = "std")]
+impl connection::socket::FetchPeerCredentials for MockReadHalf {
+    async fn fetch_peer_credentials(&self) -> std::io::Result<connection::Credentials> {
+        // For mock sockets, return credentials of the current process.
+        use rustix::process::PidfdFlags;
+
+        let uid = rustix::process::getuid();
+        let pid = rustix::process::getpid();
+        let process_fd = rustix::process::pidfd_open(pid, PidfdFlags::empty())?;
+
+        Ok(connection::Credentials::new(uid, pid, process_fd))
     }
 }
 

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -9,6 +9,8 @@ use std::{
     os::fd::{AsFd, BorrowedFd, OwnedFd},
 };
 
+use crate::connection::Credentials;
+
 /// Receive a message from a Unix socket, including any file descriptors.
 ///
 /// This is a low-level helper that performs the `recvmsg` syscall.
@@ -55,6 +57,210 @@ pub fn sendmsg(fd: impl AsFd, buf: &[u8], fds: &[BorrowedFd<'_>]) -> io::Result<
 
     let iov = [IoSlice::new(buf)];
     sendmsg(fd.as_fd(), &iov, &mut control, SendFlags::empty()).map_err(io::Error::from)
+}
+
+/// Get the peer credentials from a Unix socket.
+///
+/// This is a low-level helper that fetches credentials using platform-specific APIs.
+///
+/// # Platform Support
+///
+/// - **Linux/Android**: Uses `SO_PEERCRED` to get uid and pid. On Linux, also gets `SO_PEERPIDFD`
+///   for process FD (falls back to `pidfd_open` if not available).
+/// - **macOS/iOS**: Uses `getpeereid()` for uid and `LOCAL_PEERPID` for pid.
+/// - **OpenBSD**: Uses `getpeereid()` for uid and `SO_PEERCRED` for pid.
+/// - **NetBSD**: Uses `getpeereid()` for uid and `LOCAL_PEEREID` for pid.
+/// - **FreeBSD/DragonFly**: Uses `getpeereid()` for uid. PID is 0 (FIXME: use `LOCAL_PEERCRED`).
+pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
+    use std::os::fd::AsRawFd;
+
+    let fd = fd.as_fd();
+
+    #[cfg(any(target_os = "android", target_os = "linux"))]
+    {
+        use std::os::fd::FromRawFd;
+        // Get SO_PEERCRED (uid, gid, pid).
+        let ucred = rustix::net::sockopt::socket_peercred(fd)?;
+        let uid = ucred.uid;
+        let pid = ucred.pid;
+
+        // Get SO_PEERPIDFD if available (Linux-only).
+        #[cfg(target_os = "linux")]
+        let process_fd = {
+            // FIXME: Replace `libc` usage with `rustix` API when it provides SO_PEERPIDFD
+            // sockopt: https://github.com/bytecodealliance/rustix/pull/1474
+            use core::mem::{size_of, MaybeUninit};
+
+            let mut pidfd = MaybeUninit::<libc::c_int>::zeroed();
+            let mut len = size_of::<libc::c_int>() as libc::socklen_t;
+
+            let ret = unsafe {
+                libc::getsockopt(
+                    fd.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_PEERPIDFD,
+                    pidfd.as_mut_ptr().cast(),
+                    &mut len,
+                )
+            };
+
+            // `getsockopt` returns `0` on success or `-1` on error.
+            if ret == 0 {
+                let pidfd = unsafe { pidfd.assume_init() };
+                unsafe { OwnedFd::from_raw_fd(pidfd) }
+            } else {
+                let err = io::Error::last_os_error();
+                // ENOPROTOOPT means the kernel doesn't support this feature.
+                if err.raw_os_error() != Some(libc::ENOPROTOOPT) {
+                    return Err(err);
+                }
+                // If SO_PEERPIDFD is not supported, we fall back to using pidfd_open.
+                rustix::process::pidfd_open(pid, rustix::process::PidfdFlags::empty())?
+            }
+        };
+
+        #[cfg(target_os = "android")]
+        let creds = Credentials::new(uid, pid);
+        #[cfg(target_os = "linux")]
+        let creds = Credentials::new(uid, pid, process_fd);
+
+        Ok(creds)
+    }
+
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))]
+    {
+        // FIXME: Replace with rustix API when it provides the required API:
+        // https://github.com/bytecodealliance/rustix/issues/1533
+        let mut uid: libc::uid_t = 0;
+        let mut gid: libc::gid_t = 0;
+
+        let ret = unsafe { libc::getpeereid(fd.as_raw_fd(), &mut uid, &mut gid) };
+        if ret != 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let uid = rustix::process::Uid::from_raw(uid);
+
+        // Platform-specific PID fetching.
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
+        let pid = {
+            let mut pid: libc::pid_t = 0;
+            let mut len = core::mem::size_of::<libc::pid_t>() as libc::socklen_t;
+
+            let ret = unsafe {
+                libc::getsockopt(
+                    fd.as_raw_fd(),
+                    libc::SOL_LOCAL,
+                    libc::LOCAL_PEERPID,
+                    (&raw mut pid).cast(),
+                    &mut len,
+                )
+            };
+
+            if ret != 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            rustix::process::Pid::from_raw(pid)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid peer PID"))?
+        };
+
+        #[cfg(target_os = "openbsd")]
+        let pid = {
+            // OpenBSD's SO_PEERCRED returns struct sockpeercred { uid, gid, pid }.
+            #[repr(C)]
+            struct sockpeercred {
+                uid: libc::uid_t,
+                gid: libc::gid_t,
+                pid: libc::pid_t,
+            }
+
+            let mut creds = core::mem::MaybeUninit::<sockpeercred>::zeroed();
+            let mut len = core::mem::size_of::<sockpeercred>() as libc::socklen_t;
+
+            let ret = unsafe {
+                libc::getsockopt(
+                    fd.as_raw_fd(),
+                    libc::SOL_SOCKET,
+                    libc::SO_PEERCRED,
+                    creds.as_mut_ptr().cast(),
+                    &mut len,
+                )
+            };
+
+            if ret != 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            let creds = unsafe { creds.assume_init() };
+            rustix::process::Pid::from_raw(creds.pid)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid peer PID"))?
+        };
+
+        #[cfg(target_os = "netbsd")]
+        let pid = {
+            // NetBSD's LOCAL_PEEREID returns struct unpcbid { pid, euid, egid }.
+            #[repr(C)]
+            struct unpcbid {
+                unp_pid: libc::pid_t,
+                unp_euid: libc::uid_t,
+                unp_egid: libc::gid_t,
+            }
+
+            const LOCAL_PEEREID: libc::c_int = 3;
+
+            let mut creds = core::mem::MaybeUninit::<unpcbid>::zeroed();
+            let mut len = core::mem::size_of::<unpcbid>() as libc::socklen_t;
+
+            let ret = unsafe {
+                libc::getsockopt(
+                    fd.as_raw_fd(),
+                    0, // SOL_LOCAL
+                    LOCAL_PEEREID,
+                    creds.as_mut_ptr().cast(),
+                    &mut len,
+                )
+            };
+
+            if ret != 0 {
+                return Err(io::Error::last_os_error());
+            }
+
+            let creds = unsafe { creds.assume_init() };
+            rustix::process::Pid::from_raw(creds.unp_pid)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid peer PID"))?
+        };
+
+        // FIXME: FreeBSD 13+ has cr_pid in xucred, DragonFly status unknown.
+        #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+        let pid = rustix::process::Pid::from_raw(0).unwrap();
+
+        Ok(Credentials::new(uid, pid))
+    }
+
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "freebsd",
+        target_os = "dragonfly",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    )))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "peer credentials not supported on this platform",
+        ))
+    }
 }
 
 /// The maximum number of file descriptors that can be sent in a single message.

--- a/zlink-smol/src/unix/stream.rs
+++ b/zlink-smol/src/unix/stream.rs
@@ -49,6 +49,14 @@ impl From<Async<StdUnixStream>> for Stream {
     }
 }
 
+impl AsFd for Stream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
+    }
+}
+
+impl socket::UnixSocket for Stream {}
+
 /// The [`ReadHalf`] implementation using Unix Domain Sockets.
 #[derive(Debug)]
 pub struct ReadHalf(Arc<Async<StdUnixStream>>);
@@ -72,6 +80,14 @@ impl socket::ReadHalf for ReadHalf {
         .await
     }
 }
+
+impl AsFd for ReadHalf {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_ref().as_fd()
+    }
+}
+
+impl socket::UnixSocket for ReadHalf {}
 
 /// The [`WriteHalf`] implementation using Unix Domain Sockets.
 #[derive(Debug)]
@@ -109,3 +125,11 @@ impl socket::WriteHalf for WriteHalf {
         Ok(())
     }
 }
+
+impl AsFd for WriteHalf {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_ref().as_fd()
+    }
+}
+
+impl socket::UnixSocket for WriteHalf {}

--- a/zlink-tokio/src/unix/stream.rs
+++ b/zlink-tokio/src/unix/stream.rs
@@ -43,6 +43,14 @@ impl From<UnixStream> for Stream {
     }
 }
 
+impl socket::UnixSocket for Stream {}
+
+impl AsFd for Stream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.0.as_fd()
+    }
+}
+
 /// The [`ReadHalf`] implementation using Unix Domain Sockets.
 #[derive(Debug)]
 pub struct ReadHalf(unix::OwnedReadHalf);
@@ -68,6 +76,15 @@ impl socket::ReadHalf for ReadHalf {
         .await
     }
 }
+
+impl AsFd for ReadHalf {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        let stream: &UnixStream = self.0.as_ref();
+        stream.as_fd()
+    }
+}
+
+impl socket::UnixSocket for ReadHalf {}
 
 /// The [`WriteHalf`] implementation using Unix Domain Sockets.
 #[derive(Debug)]
@@ -108,3 +125,12 @@ impl socket::WriteHalf for WriteHalf {
         Ok(())
     }
 }
+
+impl AsFd for WriteHalf {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        let stream: &UnixStream = self.0.as_ref();
+        stream.as_fd()
+    }
+}
+
+impl socket::UnixSocket for WriteHalf {}

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -46,6 +46,7 @@ colored = "3.0"
 tempfile = "3.8"
 serde_json = "1.0"
 tracing-subscriber = "0.3.19"
+rustix = { version = "1.1.2", features = ["process"] }
 
 [[example]]
 name = "varlink-inspect"

--- a/zlink/tests/peer_credentials.rs
+++ b/zlink/tests/peer_credentials.rs
@@ -1,0 +1,117 @@
+//! Integration test for peer credentials functionality.
+
+use std::os::fd::{AsFd, AsRawFd};
+use tempfile::TempDir;
+use zlink::Listener;
+
+#[tokio::test]
+async fn peer_credentials_unix_socket() {
+    // Get the expected credentials of the current process.
+    let expected_uid = rustix::process::getuid();
+    let expected_pid = rustix::process::getpid();
+
+    // Create a temporary directory for the socket.
+    let temp_dir = TempDir::new().unwrap();
+    let socket_path = temp_dir.path().join("test_creds.sock");
+
+    // Create a listener.
+    let mut listener = zlink::unix::bind(&socket_path).unwrap();
+
+    // Connect from a client.
+    let socket_path_clone = socket_path.clone();
+    let connect_task = tokio::spawn(async move {
+        tokio::net::UnixStream::connect(&socket_path_clone)
+            .await
+            .unwrap()
+    });
+
+    let mut connection = listener.accept().await.unwrap();
+
+    // Get peer credentials.
+    let creds = connection.peer_credentials().await.unwrap();
+
+    // Verify we got the correct credentials.
+    assert_eq!(
+        creds.unix_user_id(),
+        expected_uid,
+        "UID should match current process"
+    );
+
+    // On most platforms, we can get the actual PID.
+    // Exception: FreeBSD < 13 and DragonFly BSD (where it's 0).
+    #[cfg(any(
+        target_os = "linux",
+        target_os = "android",
+        target_os = "macos",
+        target_os = "ios",
+        target_os = "openbsd",
+        target_os = "netbsd"
+    ))]
+    assert_eq!(
+        creds.process_id(),
+        expected_pid,
+        "PID should match current process"
+    );
+
+    #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    {
+        // FreeBSD 13+ has PID support, older versions return 0.
+        // DragonFly BSD currently returns 0 (PID support TBD).
+        let pid = creds.process_id();
+        assert!(
+            pid == expected_pid || pid == rustix::process::Pid::from_raw(0).unwrap(),
+            "PID should be either the actual PID or 0 on older FreeBSD/DragonFly"
+        );
+    }
+
+    // On Linux, we expect a valid process FD (pidfd) on recent kernels.
+    #[cfg(target_os = "linux")]
+    {
+        let pidfd = creds.process_fd();
+
+        // Verify the pidfd is valid by checking if we can use it.
+        let fd_num = pidfd.as_fd().as_raw_fd();
+        assert!(fd_num >= 0, "Process FD should be valid");
+
+        // Verify the pidfd refers to the correct process by reading /proc/self/fdinfo.
+        let fdinfo_path = format!("/proc/self/fdinfo/{}", fd_num);
+        let fdinfo = std::fs::read_to_string(&fdinfo_path).unwrap();
+        // The fdinfo should contain "Pid:" followed by our PID.
+
+        use rustix::process::Pid;
+        let pid_line = fdinfo
+            .lines()
+            .find(|line| line.starts_with("Pid:"))
+            .expect("fdinfo should contain Pid field");
+        let pid = pid_line
+            .strip_prefix("Pid:")
+            .unwrap()
+            .trim()
+            .parse::<i32>()
+            .expect("Pid field should be a valid number");
+        let pid = Pid::from_raw(pid).unwrap();
+        assert_eq!(
+            pid, expected_pid,
+            "pidfd should refer to the correct process"
+        );
+    }
+
+    // Save values for comparison.
+    let uid1 = creds.unix_user_id();
+    let pid1 = creds.process_id();
+    #[cfg(target_os = "linux")]
+    let pidfd1 = creds.process_fd().as_raw_fd();
+
+    // Verify caching works - calling again should return the same values.
+    let creds2 = connection.peer_credentials().await.unwrap();
+    assert_eq!(uid1, creds2.unix_user_id(), "Cached UID should match");
+    assert_eq!(pid1, creds2.process_id(), "Cached PID should match");
+    #[cfg(target_os = "linux")]
+    assert_eq!(
+        pidfd1,
+        creds2.process_fd().as_raw_fd(),
+        "Cached pidfd should match"
+    );
+
+    let _stream = connect_task.await.unwrap();
+}


### PR DESCRIPTION
This includes PID, UID and PIDFD (on Linux). The credentials are cached for you so don't have to.
    
This API requires `std` feature, which is currently always enabled for both supported async runtime backends (smol and tokio).
    
Fixes #120.

