### PR TITLE
🐛 macros: Fix `rename` attributes on chained method

### DIFF
--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -88,7 +88,15 @@ pub(super) fn generate_chain_extension_method(
         .map(|info| {
             let name = info.name;
             let ty = &info.ty_for_params;
-            quote! { #name: #ty }
+            let serde_attrs = if let Some(ref renamed) = info.serialized_name {
+                quote! { #[serde(rename = #renamed)] }
+            } else {
+                quote! {}
+            };
+            quote! {
+                #serde_attrs
+                #name: #ty
+            }
         })
         .collect();
 

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -238,7 +238,15 @@ fn generate_method_call_creation(
             .map(|info| {
                 let name = info.name;
                 let ty = &info.ty_for_params;
-                quote! { pub #name: #ty }
+                let serde_attrs = if let Some(ref renamed) = info.serialized_name {
+                    quote! { #[serde(rename = #renamed)] }
+                } else {
+                    quote! {}
+                };
+                quote! {
+                    #serde_attrs
+                    pub #name: #ty
+                }
             })
             .collect();
 

--- a/zlink-macros/tests/proxy/rename.rs
+++ b/zlink-macros/tests/proxy/rename.rs
@@ -59,3 +59,70 @@ async fn rename_test() {
         serde_json::from_slice(&bytes_written[..bytes_written.len() - 1]).unwrap();
     assert_eq!(written["method"], "org.example.Rename.SnakeCaseMethod");
 }
+
+#[tokio::test]
+async fn param_rename_chain_test() {
+    use futures_util::{pin_mut, stream::StreamExt};
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Error;
+
+    #[proxy("org.example.ParamRename")]
+    trait ParamRenameProxy {
+        #[allow(unused)]
+        async fn set_config(
+            &mut self,
+            #[zlink(rename = "dryRun")] dry_run: bool,
+            #[zlink(rename = "configValue")] config_value: String,
+        ) -> zlink::Result<Result<(), Error>>;
+    }
+
+    // Test chain_* method with renamed parameters
+    let reply1 = json!({}).to_string();
+    let reply2 = json!({}).to_string();
+    let socket = MockSocket::new(&[&reply1, &reply2], vec![vec![]]);
+    let mut conn = Connection::new(socket);
+
+    {
+        let replies = conn
+            .chain_set_config::<(), Error>(true, "test_value".to_string())
+            .unwrap()
+            .set_config(false, "another_value".to_string())
+            .unwrap()
+            .send()
+            .await
+            .unwrap();
+
+        pin_mut!(replies);
+
+        let (reply1, _fds) = replies.next().await.unwrap().unwrap();
+        reply1.unwrap();
+        let (reply2, _fds) = replies.next().await.unwrap().unwrap();
+        reply2.unwrap();
+    }
+
+    // Verify both chain_* and chain extension methods use renamed parameters
+    let bytes_written = conn.write().write_half().written_data();
+
+    // Parse the two JSON messages (separated by null bytes)
+    let messages: Vec<&[u8]> = bytes_written
+        .split(|&b| b == 0)
+        .filter(|s| !s.is_empty())
+        .collect();
+    assert_eq!(messages.len(), 2);
+
+    // Check first message (from chain_set_config)
+    let written1: serde_json::Value = serde_json::from_slice(messages[0]).unwrap();
+    assert_eq!(written1["method"], "org.example.ParamRename.SetConfig");
+    assert_eq!(written1["parameters"]["dryRun"], true);
+    assert_eq!(written1["parameters"]["configValue"], "test_value");
+
+    // Check second message (from chain extension .set_config)
+    let written2: serde_json::Value = serde_json::from_slice(messages[1]).unwrap();
+    assert_eq!(written2["method"], "org.example.ParamRename.SetConfig");
+    assert_eq!(written2["parameters"]["dryRun"], false);
+    assert_eq!(written2["parameters"]["configValue"], "another_value");
+}


### PR DESCRIPTION
Fixes #169.
