### PR TITLE
✨ macros: Allow borrowing deserializer lifetime in ReplyError

### DIFF
--- a/zlink-core/src/error.rs
+++ b/zlink-core/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     /// Missing required parameters.
     MissingParameters,
     /// A general service error.
-    VarlinkService(crate::varlink_service::Error),
+    VarlinkService(crate::varlink_service::Error<'static>),
 }
 
 /// The Result type for the zlink crate.

--- a/zlink-macros/src/utils.rs
+++ b/zlink-macros/src/utils.rs
@@ -271,6 +271,31 @@ pub(crate) fn convert_type_lifetimes(ty: &Type, target_lifetime: &str) -> Type {
     }
 }
 
+/// Check if a boolean zlink attribute with a specific key is present.
+///
+/// For example, check for `#[zlink(borrow)]` by calling with key "borrow".
+/// Returns true if the attribute is found.
+pub(crate) fn has_zlink_bool_attr(attrs: &[Attribute], key: &str) -> bool {
+    for attr in attrs {
+        if !attr.path().is_ident("zlink") {
+            continue;
+        }
+
+        let mut found = false;
+        let _ = attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident(key) {
+                found = true;
+            }
+            Ok(())
+        });
+
+        if found {
+            return true;
+        }
+    }
+    false
+}
+
 /// Parse a string value from a zlink attribute with a specific key.
 ///
 /// For example, parse `#[zlink(rename = "new_name")]` by calling with key "rename".

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "introspection", feature = "idl-parse"))]
 
-use std::{pin::pin, time::Duration};
+use std::{borrow::Cow, pin::pin, time::Duration};
 
 use futures_util::{pin_mut, stream::StreamExt, TryStreamExt};
 use serde::{Deserialize, Serialize};
@@ -232,7 +232,7 @@ impl Service for Ftl {
     type ReplyParams<'ser> = Reply<'ser>;
     type ReplyStream = notified::Stream<Self::ReplyStreamParams>;
     type ReplyStreamParams = FtlReply;
-    type ReplyError<'ser> = ReplyError;
+    type ReplyError<'ser> = ReplyError<'ser>;
 
     async fn handle<'ser, 'de: 'ser, Sock: Socket>(
         &'ser mut self,
@@ -297,7 +297,7 @@ impl Service for Ftl {
                     _ => {
                         return MethodReply::Error(ReplyError::VarlinkSrv(
                             varlink_service::Error::InterfaceNotFound {
-                                interface: "unknown.interface".try_into().unwrap(),
+                                interface: Cow::Borrowed(interface),
                             },
                         ))
                     }
@@ -375,9 +375,9 @@ enum Reply<'a> {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
 #[allow(unused)]
-enum ReplyError {
+enum ReplyError<'a> {
     Ftl(FtlError),
-    VarlinkSrv(varlink_service::Error),
+    VarlinkSrv(varlink_service::Error<'a>),
 }
 
 //

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -291,16 +291,15 @@ impl Service for MockMachinedService {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
-#[allow(unused)]
 pub enum MockError {
     VarlinkService(Error),
+    #[allow(unused)]
     Machined(MachinedError),
 }
 
 /// Errors that can be returned by the `io.systemd.Machine` interface.
 #[derive(Debug, Clone, PartialEq, ReplyError, introspect::ReplyError)]
 #[zlink(interface = "io.systemd.Machine")]
-#[allow(unused)]
 pub enum MachinedError {
     /// No matching machine currently running.
     NoSuchMachine,

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -202,7 +202,7 @@ impl Service for MockMachinedService {
     type ReplyParams<'ser> = Reply<'ser>;
     type ReplyStream = futures_util::stream::Empty<zlink::Reply<()>>;
     type ReplyStreamParams = ();
-    type ReplyError<'ser> = MockError;
+    type ReplyError<'ser> = MockError<'ser>;
 
     async fn handle<'ser, 'de: 'ser, Sock: Socket>(
         &'ser mut self,
@@ -246,7 +246,7 @@ impl Service for MockMachinedService {
                     _ => {
                         return MethodReply::Error(MockError::VarlinkService(
                             Error::InterfaceNotFound {
-                                interface: "unknown.interface".try_into().unwrap(),
+                                interface: Cow::Borrowed(interface),
                             },
                         ))
                     }
@@ -291,8 +291,8 @@ impl Service for MockMachinedService {
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(untagged)]
-pub enum MockError {
-    VarlinkService(Error),
+pub enum MockError<'a> {
+    VarlinkService(Error<'a>),
     #[allow(unused)]
     Machined(MachinedError),
 }


### PR DESCRIPTION
`ReplyError` now provides a `borrow` attribute that does exactly the same as the attribute of the same name in `serde` derives.

This PR also modifies `varlink_service::Error` to be able to borrow strings using this new attribute and `Cow`. While we still have to allocate & clone the strings on the client-side, we can now at least borrow strings from the input buffer on the service side. This PR also updates the test services to demonstrate that.

Fixes #173.
