### PR TITLE
⚡️ core: Allow service to return borrowed data from call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "zlink"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "colored 3.0.0",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-core"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-smol"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-tokio"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "futures-util",
  "serde",

--- a/README.md
+++ b/README.md
@@ -196,11 +196,11 @@ impl Service for Calculator {
     type ReplyStream = futures_util::stream::Empty<zlink::Reply<()>>;
     type ReplyError<'ser> = CalculatorError<'ser>;
 
-    async fn handle<'ser, 'de: 'ser, Sock: Socket>(
-        &'ser mut self,
-        call: Call<Self::MethodCall<'de>>,
+    async fn handle<'c, Sock: Socket>(
+        &'c mut self,
+        call: &'c Call<Self::MethodCall<'_>>,
         conn: &mut Connection<Sock>,
-    ) -> MethodReply<Self::ReplyParams<'ser>, Self::ReplyStream, Self::ReplyError<'ser>> {
+    ) -> MethodReply<Self::ReplyParams<'c>, Self::ReplyStream, Self::ReplyError<'c>> {
         match call.method() {
             CalculatorMethod::Add { a, b } => {
                 self.operations.push(format!("add({}, {})", a, b));

--- a/zlink-codegen/Cargo.toml
+++ b/zlink-codegen/Cargo.toml
@@ -15,7 +15,7 @@ name = "zlink-codegen"
 path = "src/main.rs"
 
 [dependencies]
-zlink = { path = "../zlink", version = "0.2.0", features = [
+zlink = { path = "../zlink", version = "0.3.0", features = [
     "idl",
     "idl-parse",
 ] }

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-core"
-version = "0.2.0"
+version = "0.3.0"
 description = "The core crate of the zlink project"
 edition.workspace = true
 rust-version.workspace = true

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -167,7 +167,7 @@ where
         conn: &mut Connection<Listener::Socket>,
     ) -> crate::Result<Option<Service::ReplyStream>> {
         let mut stream = None;
-        match self.service.handle(call, conn).await {
+        match self.service.handle(&call, conn).await {
             MethodReply::Single(params) => {
                 let reply = Reply::new(params).set_continues(Some(false));
                 conn.send_reply(&reply, vec![]).await?

--- a/zlink-core/src/server/service.rs
+++ b/zlink-core/src/server/service.rs
@@ -41,13 +41,11 @@ pub trait Service {
         Self: 'ser;
 
     /// Handle a method call.
-    fn handle<'ser, 'de: 'ser, Sock: Socket>(
-        &'ser mut self,
-        method: Call<Self::MethodCall<'de>>,
+    fn handle<'c, Sock: Socket>(
+        &'c mut self,
+        method: &'c Call<Self::MethodCall<'_>>,
         conn: &mut Connection<Sock>,
-    ) -> impl Future<
-        Output = MethodReply<Self::ReplyParams<'ser>, Self::ReplyStream, Self::ReplyError<'ser>>,
-    >;
+    ) -> impl Future<Output = MethodReply<Self::ReplyParams<'c>, Self::ReplyStream, Self::ReplyError<'c>>>;
 }
 
 /// A service method call reply.

--- a/zlink-smol/Cargo.toml
+++ b/zlink-smol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-smol"
-version = "0.2.0"
+version = "0.3.0"
 description = "zlink library for the smol runtime"
 edition.workspace = true
 rust-version.workspace = true
@@ -18,7 +18,7 @@ tracing = ["zlink-core/tracing"]
 defmt = ["zlink-core/defmt"]
 
 [dependencies]
-zlink-core = { path = "../zlink-core", version = "=0.2.0", default-features = false, features = ["std"] }
+zlink-core = { path = "../zlink-core", version = "=0.3.0", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
     "async-await",
     "alloc",

--- a/zlink-tokio/Cargo.toml
+++ b/zlink-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-tokio"
-version = "0.2.0"
+version = "0.3.0"
 description = "zlink library for the Tokio runtime"
 edition.workspace = true
 rust-version.workspace = true
@@ -18,7 +18,7 @@ tracing = ["zlink-core/tracing", "tokio/tracing"]
 defmt = ["zlink-core/defmt"]
 
 [dependencies]
-zlink-core = { path = "../zlink-core", version = "=0.2.0", default-features = false, features = ["std"] }
+zlink-core = { path = "../zlink-core", version = "=0.3.0", default-features = false, features = ["std"] }
 tokio = { version = "1.44.0", features = ["net", "io-util"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
     "async-await",

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink"
-version = "0.2.0"
+version = "0.3.0"
 description = "Async Varlink API"
 edition.workspace = true
 rust-version.workspace = true
@@ -21,8 +21,8 @@ tracing = ["zlink-tokio?/tracing", "zlink-smol?/tracing"]
 defmt = ["zlink-tokio?/defmt", "zlink-smol?/defmt"]
 
 [dependencies]
-zlink-tokio = { path = "../zlink-tokio", version = "=0.2.0", default-features = false, optional = true }
-zlink-smol = { path = "../zlink-smol", version = "=0.2.0", default-features = false, optional = true }
+zlink-tokio = { path = "../zlink-tokio", version = "=0.3.0", default-features = false, optional = true }
+zlink-smol = { path = "../zlink-smol", version = "=0.3.0", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.44.0", features = [

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -234,11 +234,11 @@ impl Service for Ftl {
     type ReplyStreamParams = FtlReply;
     type ReplyError<'ser> = ReplyError<'ser>;
 
-    async fn handle<'ser, 'de: 'ser, Sock: Socket>(
-        &'ser mut self,
-        call: Call<Self::MethodCall<'de>>,
+    async fn handle<'c, Sock: Socket>(
+        &'c mut self,
+        call: &'c Call<Self::MethodCall<'_>>,
         _conn: &mut Connection<Sock>,
-    ) -> MethodReply<Self::ReplyParams<'ser>, Self::ReplyStream, Self::ReplyError<'ser>> {
+    ) -> MethodReply<Self::ReplyParams<'c>, Self::ReplyStream, Self::ReplyError<'c>> {
         match call.method() {
             Method::Ftl(FtlMethod::GetDriveCondition) if call.more() => {
                 MethodReply::Multi(self.drive_condition.stream())

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -274,12 +274,11 @@ mod server {
         type ReplyStreamParams = ();
         type ReplyError<'ser> = MockError<'ser>;
 
-        async fn handle<'ser, 'de: 'ser, Sock: Socket>(
-            &'ser mut self,
-            call: Call<Self::MethodCall<'de>>,
+        async fn handle<'c, Sock: Socket>(
+            &'c mut self,
+            call: &'c Call<Self::MethodCall<'_>>,
             _conn: &mut Connection<Sock>,
-        ) -> MethodReply<Self::ReplyParams<'ser>, Self::ReplyStream, Self::ReplyError<'ser>>
-        {
+        ) -> MethodReply<Self::ReplyParams<'c>, Self::ReplyStream, Self::ReplyError<'c>> {
             match call.method() {
                 Method::VarlinkService(varlink_service::Method::GetInfo) => {
                     // Return hardcoded info that matches the systemd machine service


### PR DESCRIPTION
This PR changes the `Service::handle` signature to receive a reference to the call instead of the call itself.