### PR TITLE
💥 core,zlink: chain::ReplyStream's items now owned

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Connect to a batch processing service
     let mut conn = unix::connect("/tmp/batch_processor.varlink").await?;
 
-    // Send multiple pipelined requests without waiting for responses
+    // Send multiple pipelined requests without waiting for responses.
     let replies = conn
         .chain_process::<ProcessReply, ProcessError>(1, "first")?
         .process(2, "second")?

--- a/README.md
+++ b/README.md
@@ -305,6 +305,11 @@ adds variants for each method named `chain_<method_name>` and a trait named `<Tr
 allow you to batch multiple requests and send them out at once without waiting for individual
 responses:
 
+> **Note**: Chain methods require owned types (`DeserializeOwned`) for **reply** parameters and
+> errors because the internal buffer may be reused between stream iterations. Input arguments can
+> still use borrowed types. This limitation may be lifted in the future when Rust supports lending
+> streams.
+
 ```rust,no_run
 use futures_util::{StreamExt, pin_mut};
 use serde::{Deserialize, Serialize};
@@ -316,8 +321,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = unix::connect("/tmp/batch_processor.varlink").await?;
 
     // Send multiple pipelined requests without waiting for responses.
+    // Chain API requires owned types for replies (OwnedProcessReply, OwnedProcessError).
+    // Input arguments can still be borrowed (&str, ProcessRequest<'_>).
     let replies = conn
-        .chain_process::<ProcessReply, ProcessError>(1, "first")?
+        .chain_process::<OwnedProcessReply, OwnedProcessError>(1, "first")?
         .process(2, "second")?
         .process(3, "third")?
         .batch_process(vec![
@@ -334,10 +341,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (reply, _fds) = reply?;
         if let Ok(response) = reply {
             match response.into_parameters() {
-                Some(ProcessReply::Result(result)) => {
+                Some(OwnedProcessReply::Result(result)) => {
                     results.push(result);
                 }
-                Some(ProcessReply::BatchResult(batch)) => {
+                Some(OwnedProcessReply::BatchResult(batch)) => {
                     results.extend(batch.results);
                 }
                 None => {}
@@ -355,18 +362,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 #[proxy("org.example.BatchProcessor")]
 trait BatchProcessorProxy {
+    // Non-chain methods can use borrowed types for replies.
     async fn process(
         &mut self,
         id: u32,
         data: &str,
-    ) -> zlink::Result<Result<ProcessReply<'_>, ProcessError>>;
+    ) -> zlink::Result<Result<ProcessReply<'_>, ProcessError<'_>>>;
 
     async fn batch_process(
         &mut self,
         requests: Vec<ProcessRequest<'_>>,
-    ) -> zlink::Result<Result<ProcessReply<'_>, ProcessError>>;
+    ) -> zlink::Result<Result<ProcessReply<'_>, ProcessError<'_>>>;
 }
 
+// Input types can use borrowed data (they implement Serialize).
 #[derive(Debug, Serialize)]
 struct ProcessRequest<'a> {
     id: u32,
@@ -374,6 +383,7 @@ struct ProcessRequest<'a> {
     data: &'a str,
 }
 
+// Borrowed reply types for non-chain (single call) methods.
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
 enum ProcessReply<'a> {
@@ -398,8 +408,33 @@ struct BatchResult<'a> {
 
 #[derive(Debug, ReplyError)]
 #[zlink(interface = "org.example.BatchProcessor")]
-enum ProcessError {
-    InvalidRequest,
+enum ProcessError<'a> {
+    InvalidRequest { message: &'a str },
+}
+
+// Owned reply types for chain API (which requires DeserializeOwned).
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum OwnedProcessReply {
+    Result(OwnedProcessResult),
+    BatchResult(OwnedBatchResult),
+}
+
+#[derive(Debug, Deserialize)]
+struct OwnedProcessResult {
+    id: u32,
+    processed: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct OwnedBatchResult {
+    results: Vec<OwnedProcessResult>,
+}
+
+#[derive(Debug, ReplyError)]
+#[zlink(interface = "org.example.BatchProcessor")]
+enum OwnedProcessError {
+    InvalidRequest { message: String },
 }
 ```
 

--- a/zlink-core/src/connection/chain/mod.rs
+++ b/zlink-core/src/connection/chain/mod.rs
@@ -7,7 +7,7 @@ pub use reply_stream::ReplyStream;
 use crate::{connection::Socket, Call, Connection, Result};
 use core::fmt::Debug;
 use futures_util::stream::Stream;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 
 /// A chain of method calls that will be sent together.
 ///
@@ -31,8 +31,8 @@ pub struct Chain<'c, S: Socket, ReplyParams, ReplyError> {
 impl<'c, S, ReplyParams, ReplyError> Chain<'c, S, ReplyParams, ReplyError>
 where
     S: Socket,
-    ReplyParams: Deserialize<'c> + Debug,
-    ReplyError: Deserialize<'c> + Debug,
+    ReplyParams: DeserializeOwned + Debug,
+    ReplyError: DeserializeOwned + Debug,
 {
     /// Create a new chain with the first call.
     pub(super) fn new<Method>(

--- a/zlink-core/src/connection/chain/reply_stream.rs
+++ b/zlink-core/src/connection/chain/reply_stream.rs
@@ -6,7 +6,7 @@ use core::{
 };
 use futures_util::stream::Stream;
 use pin_project_lite::pin_project;
-use serde::Deserialize;
+use serde::de::DeserializeOwned;
 
 use crate::{
     connection::{socket::ReadHalf, ReadConnection},
@@ -29,6 +29,13 @@ pub(crate) type ChainResult<Params, ReplyError> = reply::Result<Params, ReplyErr
 
 pin_project! {
     /// A stream of replies from a chain of method calls.
+    ///
+    /// # Owned Data Requirement
+    ///
+    /// Stream items must use owned types (`DeserializeOwned`) rather than borrowed types. This is
+    /// because the internal buffer may be reused between stream iterations, which would invalidate
+    /// borrowed references. This limitation may be lifted in the future when Rust supports lending
+    /// streams.
     #[derive(Debug)]
     pub struct ReplyStream<'c, Read: ReadHalf, F, Fut, Params, ReplyError> {
         #[pin]
@@ -47,8 +54,8 @@ where
     Read: ReadHalf,
     F: FnMut(&'c mut ReadConnection<Read>) -> Fut,
     Fut: Future<Output = Result<ChainResult<Params, ReplyError>>>,
-    Params: Deserialize<'c> + Debug,
-    ReplyError: Deserialize<'c> + Debug,
+    Params: DeserializeOwned + Debug,
+    ReplyError: DeserializeOwned + Debug,
 {
     /// Create a new reply stream.
     ///
@@ -73,8 +80,8 @@ where
     Read: ReadHalf,
     F: FnMut(&'c mut ReadConnection<Read>) -> Fut,
     Fut: Future<Output = Result<ChainResult<Params, ReplyError>>>,
-    Params: Deserialize<'c> + Debug,
-    ReplyError: Deserialize<'c> + Debug,
+    Params: DeserializeOwned + Debug,
+    ReplyError: DeserializeOwned + Debug,
 {
     type Item = Result<ChainResult<Params, ReplyError>>;
 

--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -25,7 +25,7 @@ use core::{fmt::Debug, sync::atomic::AtomicUsize};
 use socket::FetchPeerCredentials;
 pub use write_connection::WriteConnection;
 
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 pub use socket::Socket;
 
 // Type alias for receive methods - std returns FDs, no_std doesn't
@@ -409,8 +409,8 @@ where
     ) -> Result<Chain<'c, S, ReplyParams, ReplyError>>
     where
         Method: Serialize + Debug,
-        ReplyParams: Deserialize<'c> + Debug,
-        ReplyError: Deserialize<'c> + Debug,
+        ReplyParams: DeserializeOwned + Debug,
+        ReplyError: DeserializeOwned + Debug,
     {
         Chain::new(
             self,

--- a/zlink-core/src/test_utils/mock_socket.rs
+++ b/zlink-core/src/test_utils/mock_socket.rs
@@ -7,8 +7,6 @@
 #[cfg(feature = "std")]
 use crate::connection;
 use crate::connection::socket::{ReadHalf, Socket, WriteHalf};
-#[cfg(feature = "std")]
-use alloc::vec;
 use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use core::cell::RefCell;
@@ -18,46 +16,46 @@ use rustix::fd::{BorrowedFd, OwnedFd};
 /// Mock socket implementation for testing.
 ///
 /// This socket pre-loads response data and allows tests to verify what was written.
-/// Responses should be provided as individual strings, and the mock will automatically
-/// add null byte separators between them.
+/// Each message is stored separately and returned one at a time per read() call,
+/// simulating non-pipelined socket behavior where each write is read separately.
 ///
 /// In std mode, also supports file descriptor passing for testing FD-based IPC.
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct MockSocket {
-    read_data: Vec<u8>,
-    read_pos: usize,
+    /// Each message stored separately with null terminator.
+    messages: Vec<Vec<u8>>,
     #[cfg(feature = "std")]
     fds: Vec<Vec<OwnedFd>>,
-    #[cfg(feature = "std")]
-    fd_index: usize,
 }
 
 impl MockSocket {
     /// Create a new mock socket with pre-configured responses.
     ///
-    /// Each response string will be automatically null-terminated.
-    /// An additional null byte is added at the end to mark the end of all messages.
+    /// Each response string will be null-terminated. Messages are stored separately and
+    /// returned one at a time, with a trailing null added after the last message.
     ///
-    /// In std mode, the `fds` parameter specifies which FDs to return for each read operation.
-    /// Use an empty vec for reads that should not return FDs.
+    /// In std mode, the `fds` parameter specifies which FDs to return with each message.
+    /// The i-th FD vec is returned with the i-th message.
     pub fn new(responses: &[&str], #[cfg(feature = "std")] fds: Vec<Vec<OwnedFd>>) -> Self {
-        let mut data = Vec::new();
+        let mut messages: Vec<Vec<u8>> = responses
+            .iter()
+            .map(|r| {
+                let mut msg = r.as_bytes().to_vec();
+                msg.push(b'\0');
+                msg
+            })
+            .collect();
 
-        for response in responses {
-            data.extend_from_slice(response.as_bytes());
-            data.push(b'\0');
+        // Add trailing null after last message for double-null end detection.
+        if let Some(last) = messages.last_mut() {
+            last.push(b'\0');
         }
-        // Add an extra null byte to mark end of all messages.
-        data.push(b'\0');
 
         Self {
-            read_data: data,
-            read_pos: 0,
+            messages,
             #[cfg(feature = "std")]
             fds,
-            #[cfg(feature = "std")]
-            fd_index: 0,
         }
     }
 
@@ -69,7 +67,7 @@ impl MockSocket {
         Self::new(
             responses,
             #[cfg(feature = "std")]
-            vec![],
+            Vec::new(),
         )
     }
 }
@@ -81,12 +79,11 @@ impl Socket for MockSocket {
     fn split(self) -> (Self::ReadHalf, Self::WriteHalf) {
         (
             MockReadHalf {
-                data: self.read_data,
-                pos: self.read_pos,
+                messages: self.messages,
+                msg_index: 0,
+                pos_in_msg: 0,
                 #[cfg(feature = "std")]
                 fds: self.fds,
-                #[cfg(feature = "std")]
-                fd_index: self.fd_index,
             },
             MockWriteHalf {
                 written: Vec::new(),
@@ -101,24 +98,23 @@ impl Socket for MockSocket {
 #[derive(Debug)]
 #[doc(hidden)]
 pub struct MockReadHalf {
-    data: Vec<u8>,
-    pos: usize,
+    messages: Vec<Vec<u8>>,
+    msg_index: usize,
+    pos_in_msg: usize,
     #[cfg(feature = "std")]
     fds: Vec<Vec<OwnedFd>>,
-    #[cfg(feature = "std")]
-    fd_index: usize,
 }
 
 impl MockReadHalf {
-    /// Get the remaining unread data in the buffer.
-    pub fn remaining_data(&self) -> &[u8] {
-        &self.data[self.pos..]
+    /// Get the number of messages remaining.
+    pub fn messages_remaining(&self) -> usize {
+        self.messages.len().saturating_sub(self.msg_index)
     }
 
     /// Get the number of FD sets that have been consumed (std only).
     #[cfg(feature = "std")]
     pub fn fds_consumed(&self) -> usize {
-        self.fd_index
+        self.msg_index
     }
 }
 
@@ -128,21 +124,29 @@ impl ReadHalf for MockReadHalf {
         &mut self,
         buf: &mut [u8],
     ) -> crate::Result<(usize, alloc::vec::Vec<std::os::fd::OwnedFd>)> {
-        let remaining = self.data.len().saturating_sub(self.pos);
-        if remaining == 0 {
-            return Ok((0, vec![]));
+        // No more messages - EOF.
+        if self.msg_index >= self.messages.len() {
+            return Ok((0, Vec::new()));
         }
 
+        let msg = &self.messages[self.msg_index];
+        let remaining = msg.len() - self.pos_in_msg;
         let to_read = remaining.min(buf.len());
-        buf[..to_read].copy_from_slice(&self.data[self.pos..self.pos + to_read]);
-        self.pos += to_read;
+        buf[..to_read].copy_from_slice(&msg[self.pos_in_msg..self.pos_in_msg + to_read]);
+        self.pos_in_msg += to_read;
 
-        let fds = if self.fd_index < self.fds.len() {
-            let fds = core::mem::take(&mut self.fds[self.fd_index]);
-            self.fd_index += 1;
+        // Return FDs only when message is fully read.
+        let fds = if self.pos_in_msg >= msg.len() {
+            let fds = if self.msg_index < self.fds.len() {
+                core::mem::take(&mut self.fds[self.msg_index])
+            } else {
+                Vec::new()
+            };
+            self.msg_index += 1;
+            self.pos_in_msg = 0;
             fds
         } else {
-            vec![]
+            Vec::new()
         };
 
         Ok((to_read, fds))
@@ -150,14 +154,23 @@ impl ReadHalf for MockReadHalf {
 
     #[cfg(not(feature = "std"))]
     async fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
-        let remaining = self.data.len().saturating_sub(self.pos);
-        if remaining == 0 {
+        // No more messages - EOF.
+        if self.msg_index >= self.messages.len() {
             return Ok(0);
         }
 
+        let msg = &self.messages[self.msg_index];
+        let remaining = msg.len() - self.pos_in_msg;
         let to_read = remaining.min(buf.len());
-        buf[..to_read].copy_from_slice(&self.data[self.pos..self.pos + to_read]);
-        self.pos += to_read;
+        buf[..to_read].copy_from_slice(&msg[self.pos_in_msg..self.pos_in_msg + to_read]);
+        self.pos_in_msg += to_read;
+
+        // Move to next message when current is fully read.
+        if self.pos_in_msg >= msg.len() {
+            self.msg_index += 1;
+            self.pos_in_msg = 0;
+        }
+
         Ok(to_read)
     }
 }

--- a/zlink-core/src/varlink_service/api.rs
+++ b/zlink-core/src/varlink_service/api.rs
@@ -1,4 +1,4 @@
-use alloc::borrow::Cow;
+use alloc::{borrow::Cow, string::String};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "introspection")]
@@ -6,9 +6,9 @@ use crate::introspect;
 
 use crate::ReplyError;
 
-use super::Info;
 #[cfg(feature = "idl")]
 use super::InterfaceDescription;
+use super::{Info, OwnedInfo};
 
 /// `org.varlink.service` interface methods.
 #[derive(Debug, Serialize, Deserialize)]
@@ -39,6 +39,40 @@ pub enum Reply<'a> {
     /// Note: InterfaceDescription only supports 'static lifetime for deserialization.
     #[cfg(feature = "idl")]
     InterfaceDescription(InterfaceDescription<'static>),
+}
+
+/// Owned version of [`Reply`] for use with the chain API.
+///
+/// This type uses owned types ([`OwnedInfo`]) instead of borrowed types, allowing it to be
+/// deserialized as owned data. This is required for the chain API because the internal buffer
+/// may be reused between stream iterations.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum OwnedReply {
+    /// Reply for `GetInfo` method.
+    Info(OwnedInfo),
+    /// Reply for `GetInterfaceDescription` method.
+    #[cfg(feature = "idl")]
+    InterfaceDescription(InterfaceDescription<'static>),
+}
+
+#[cfg(feature = "idl")]
+impl<'a> From<Reply<'a>> for OwnedReply {
+    fn from(reply: Reply<'a>) -> Self {
+        match reply {
+            Reply::Info(info) => OwnedReply::Info(info.into()),
+            Reply::InterfaceDescription(desc) => OwnedReply::InterfaceDescription(desc),
+        }
+    }
+}
+
+#[cfg(not(feature = "idl"))]
+impl<'a> From<Reply<'a>> for OwnedReply {
+    fn from(reply: Reply<'a>) -> Self {
+        match reply {
+            Reply::Info(info) => OwnedReply::Info(info.into()),
+        }
+    }
 }
 
 /// Errors that can be returned by the `org.varlink.service` interface.
@@ -128,6 +162,92 @@ impl core::fmt::Display for Error<'_> {
             Error::MethodNotImplemented { method } => {
                 write!(f, "Method not implemented: {method}")
             }
+        }
+    }
+}
+
+/// Owned version of [`Error`] for use with the chain API.
+///
+/// This type uses `String` instead of `Cow<'_, str>` for all fields, allowing it to be deserialized
+/// as owned data. This is required for the chain API because the internal buffer may be reused
+/// between stream iterations.
+#[derive(Debug, Clone, PartialEq, crate::ReplyError)]
+#[zlink(interface = "org.varlink.service")]
+pub enum OwnedError {
+    /// The requested interface was not found.
+    InterfaceNotFound {
+        /// The interface that was not found.
+        interface: String,
+    },
+    /// The requested method was not found.
+    MethodNotFound {
+        /// The method that was not found.
+        method: String,
+    },
+    /// The interface defines the requested method, but the service does not implement it.
+    MethodNotImplemented {
+        /// The method that is not implemented.
+        method: String,
+    },
+    /// One of the passed parameters is invalid.
+    InvalidParameter {
+        /// The parameter that is invalid.
+        parameter: String,
+    },
+    /// Client is denied access.
+    PermissionDenied,
+    /// Method is expected to be called with 'more' set to true, but wasn't.
+    ExpectedMore,
+}
+
+impl core::error::Error for OwnedError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        None
+    }
+}
+
+impl core::fmt::Display for OwnedError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            OwnedError::InterfaceNotFound { interface } => {
+                write!(f, "Interface not found: {interface}")
+            }
+            OwnedError::MethodNotFound { method } => {
+                write!(f, "Method not found: {method}")
+            }
+            OwnedError::InvalidParameter { parameter } => {
+                write!(f, "Invalid parameter: {parameter}")
+            }
+            OwnedError::PermissionDenied => {
+                write!(f, "Permission denied")
+            }
+            OwnedError::ExpectedMore => {
+                write!(f, "Expected more")
+            }
+            OwnedError::MethodNotImplemented { method } => {
+                write!(f, "Method not implemented: {method}")
+            }
+        }
+    }
+}
+
+impl<'a> From<Error<'a>> for OwnedError {
+    fn from(err: Error<'a>) -> Self {
+        match err {
+            Error::InterfaceNotFound { interface } => OwnedError::InterfaceNotFound {
+                interface: interface.into_owned(),
+            },
+            Error::MethodNotFound { method } => OwnedError::MethodNotFound {
+                method: method.into_owned(),
+            },
+            Error::MethodNotImplemented { method } => OwnedError::MethodNotImplemented {
+                method: method.into_owned(),
+            },
+            Error::InvalidParameter { parameter } => OwnedError::InvalidParameter {
+                parameter: parameter.into_owned(),
+            },
+            Error::PermissionDenied => OwnedError::PermissionDenied,
+            Error::ExpectedMore => OwnedError::ExpectedMore,
         }
     }
 }

--- a/zlink-core/src/varlink_service/info.rs
+++ b/zlink-core/src/varlink_service/info.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "introspection")]
 use crate::introspect::Type;
-use alloc::vec::Vec;
+use alloc::{string::String, vec::Vec};
 use serde::{Deserialize, Serialize};
 
 /// Information about a Varlink service implementation.
@@ -37,6 +37,66 @@ impl<'a> Info<'a> {
             version,
             url,
             interfaces,
+        }
+    }
+}
+
+/// Owned version of [`Info`] for use with the chain API.
+///
+/// This type uses `String` instead of `&str` for all fields, allowing it to be deserialized
+/// as owned data. This is required for the chain API because the internal buffer may be reused
+/// between stream iterations.
+///
+/// # Example
+///
+/// ```no_run
+/// use zlink_core::varlink_service::OwnedInfo;
+///
+/// // OwnedInfo can be deserialized from JSON without borrowing.
+/// let json = r#"{"vendor":"Test","product":"Product","version":"1.0","url":"https://example.com","interfaces":["org.varlink.service"]}"#;
+/// let info: OwnedInfo = serde_json::from_str(json).unwrap();
+/// ```
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OwnedInfo {
+    /// The vendor of the service.
+    pub vendor: String,
+    /// The product name of the service.
+    pub product: String,
+    /// The version of the service.
+    pub version: String,
+    /// The URL associated with the service.
+    pub url: String,
+    /// List of interfaces provided by the service.
+    pub interfaces: Vec<String>,
+}
+
+impl OwnedInfo {
+    /// Create a new `OwnedInfo` instance.
+    pub fn new(
+        vendor: String,
+        product: String,
+        version: String,
+        url: String,
+        interfaces: Vec<String>,
+    ) -> Self {
+        Self {
+            vendor,
+            product,
+            version,
+            url,
+            interfaces,
+        }
+    }
+}
+
+impl<'a> From<Info<'a>> for OwnedInfo {
+    fn from(info: Info<'a>) -> Self {
+        Self {
+            vendor: info.vendor.into(),
+            product: info.product.into(),
+            version: info.version.into(),
+            url: info.url.into(),
+            interfaces: info.interfaces.into_iter().map(Into::into).collect(),
         }
     }
 }

--- a/zlink-core/src/varlink_service/mod.rs
+++ b/zlink-core/src/varlink_service/mod.rs
@@ -42,7 +42,7 @@ pub const DESCRIPTION: &crate::idl::Interface<'static> = &{
         &Method::new(
             "GetInterfaceDescription",
             &[INTERFACE_PARAM],
-            &InterfaceDescription::TYPE
+            InterfaceDescription::TYPE
                 .as_object()
                 .unwrap()
                 .as_borrowed()

--- a/zlink-core/src/varlink_service/mod.rs
+++ b/zlink-core/src/varlink_service/mod.rs
@@ -4,9 +4,9 @@
 //! implementations of the standard Varlink service interface.
 
 mod info;
-pub use info::Info;
+pub use info::{Info, OwnedInfo};
 mod api;
-pub use api::{Error, Method, Reply, Result};
+pub use api::{Error, Method, OwnedError, OwnedReply, Reply, Result};
 
 #[cfg(all(feature = "idl-parse", feature = "std"))]
 mod proxy;

--- a/zlink-core/src/varlink_service/proxy.rs
+++ b/zlink-core/src/varlink_service/proxy.rs
@@ -148,7 +148,7 @@ mod tests {
     use crate::{test_utils::mock_socket::MockSocket, Connection};
 
     #[tokio::test]
-    async fn test_chain_api_creation() -> crate::Result<()> {
+    async fn chain_api_creation() -> crate::Result<()> {
         // Test that we can create chains with the new API.
         let responses = [
             r#"{"parameters":{"vendor":"Test","product":"TestProduct","version":"1.0","url":"https://test.com","interfaces":["org.varlink.service"]}}"#,
@@ -169,7 +169,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_chain_extension_methods() -> crate::Result<()> {
+    async fn chain_extension_methods() -> crate::Result<()> {
         // Test that we can use chain extension methods.
         let responses = [
             r#"{"parameters":{"vendor":"Test","product":"TestProduct","version":"1.0","url":"https://test.com","interfaces":["org.varlink.service"]}}"#,

--- a/zlink-core/src/varlink_service/proxy.rs
+++ b/zlink-core/src/varlink_service/proxy.rs
@@ -33,11 +33,11 @@ use super::{Error, Info, InterfaceDescription};
 ///     .get_interface_description("org.example.interface")?
 ///     .get_info()?;
 ///
-/// // Send the chain and process replies
+/// // Send the chain and process replies.
 /// let replies = chain.send().await?;
 /// pin_mut!(replies);
 ///
-/// // Process each reply in the order they were chained
+/// // Process each reply in the order they were chained.
 /// while let Some(result) = replies.next().await {
 ///     let (reply, _fds) = result?;
 ///     match reply?.parameters().unwrap() {
@@ -75,7 +75,7 @@ use super::{Error, Info, InterfaceDescription};
 ///     // OtherInterface(other_interface::Error<'a>),
 /// }
 ///
-/// // Then use the combined types for cross-interface chaining
+/// // Then use the combined types for cross-interface chaining.
 /// let combined_chain = conn
 ///     .chain_get_info::<CombinedReply<'_>, CombinedError<'_>>()?;
 ///     // .other_interface_method()?;  // Chain calls from other interfaces
@@ -149,7 +149,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_chain_api_creation() -> crate::Result<()> {
-        // Test that we can create chains with the new API
+        // Test that we can create chains with the new API.
         let responses = [
             r#"{"parameters":{"vendor":"Test","product":"TestProduct","version":"1.0","url":"https://test.com","interfaces":["org.varlink.service"]}}"#,
             r#"{"parameters":{"description":"interface org.varlink.service {}"}}"#,
@@ -170,7 +170,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_chain_extension_methods() -> crate::Result<()> {
-        // Test that we can use chain extension methods
+        // Test that we can use chain extension methods.
         let responses = [
             r#"{"parameters":{"vendor":"Test","product":"TestProduct","version":"1.0","url":"https://test.com","interfaces":["org.varlink.service"]}}"#,
             r#"{"parameters":{"description":"interface org.varlink.service {}"}}"#,
@@ -191,7 +191,7 @@ mod tests {
         use futures_util::{pin_mut, stream::StreamExt};
         pin_mut!(replies);
 
-        // Read first reply (GetInfo)
+        // Read first reply (GetInfo).
         let (first_reply, _fds) = replies.next().await.unwrap()?;
         let first_reply = first_reply.unwrap();
         match first_reply.parameters().unwrap() {
@@ -205,7 +205,7 @@ mod tests {
             _ => panic!("Expected Info reply"),
         }
 
-        // Read second reply (GetInterfaceDescription)
+        // Read second reply (GetInterfaceDescription).
         let (second_reply, _fds) = replies.next().await.unwrap()?;
         let second_reply = second_reply.unwrap();
         match second_reply.parameters().unwrap() {
@@ -215,7 +215,7 @@ mod tests {
             _ => panic!("Expected InterfaceDescription reply"),
         }
 
-        // Read third reply (GetInfo again)
+        // Read third reply (GetInfo again).
         let (third_reply, _fds) = replies.next().await.unwrap()?;
         let third_reply = third_reply.unwrap();
         match third_reply.parameters().unwrap() {
@@ -225,7 +225,7 @@ mod tests {
             _ => panic!("Expected Info reply"),
         }
 
-        // No more replies
+        // No more replies.
         assert!(replies.next().await.is_none());
 
         Ok(())

--- a/zlink-core/src/varlink_service/proxy.rs
+++ b/zlink-core/src/varlink_service/proxy.rs
@@ -18,18 +18,29 @@ use super::{Error, Info, InterfaceDescription};
 /// chain calls together for efficient batching. Use [`crate::Connection::chain_get_info`] or
 /// [`crate::Connection::chain_get_interface_description`] to start a chain.
 ///
+/// ## Owned Data Requirement for Chains
+///
+/// Chain methods require owned types (`DeserializeOwned`) for reply parameters and errors
+/// because the internal buffer may be reused between stream iterations. This limitation may be
+/// lifted in the future when Rust supports lending streams.
+///
+/// [`super::OwnedReply`], [`super::OwnedInfo`], and [`super::OwnedError`] are provided for use
+/// with the chain API.
+///
 /// ## Example
 ///
 /// ```no_run
-/// use zlink_core::{Connection, varlink_service::{Proxy, Chain, Reply, Error}};
-/// use serde::Deserialize;
+/// use zlink_core::{
+///     Connection,
+///     varlink_service::{Chain, OwnedError, OwnedInfo, OwnedReply, Proxy},
+/// };
 /// use futures_util::{pin_mut, stream::StreamExt};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let mut conn: Connection<zlink_core::connection::socket::impl_for_doc::Socket> = todo!();
-/// // For a single interface, use the provided Reply enum directly
+/// // Chain API uses owned types (DeserializeOwned) provided by varlink_service module.
 /// let chain = conn
-///     .chain_get_info::<Reply<'_>, Error<'_>>()?
+///     .chain_get_info::<OwnedReply, OwnedError>()?
 ///     .get_interface_description("org.example.interface")?
 ///     .get_info()?;
 ///
@@ -40,44 +51,41 @@ use super::{Error, Info, InterfaceDescription};
 /// // Process each reply in the order they were chained.
 /// while let Some(result) = replies.next().await {
 ///     let (reply, _fds) = result?;
-///     match reply?.parameters().unwrap() {
-///         Reply::Info(info) => {
+///     match reply.unwrap().parameters().unwrap() {
+///         OwnedReply::Info(info) => {
 ///             println!("Service: {} v{} by {}", info.product, info.version, info.vendor);
 ///             println!("URL: {}", info.url);
 ///             println!("Interfaces: {:?}", info.interfaces);
 ///         }
-///         Reply::InterfaceDescription(desc) => {
-///             println!("Interface description: {}", desc.as_raw().unwrap_or("<parsed>"));
-///             // Parse the interface if needed
-///             if let Ok(interface) = desc.parse() {
-///                 println!("Interface name: {}", interface.name());
-///             }
+///         OwnedReply::InterfaceDescription(desc) => {
+///             // Use as_raw() to get the raw description string.
+///             println!("Interface description: {}", desc.as_raw().unwrap());
 ///         }
 ///     }
 /// }
 ///
 /// // For combining multiple interfaces, create a combined reply enum:
-/// #[derive(Debug, Deserialize)]
-/// #[serde(untagged)]
-/// enum CombinedReply<'a> {
-///     #[serde(borrow)]
-///     VarlinkService(Reply<'a>),
-///     // Add other interface reply types here
-///     // OtherInterface(other_interface::Reply<'a>),
-/// }
+/// use serde::Deserialize;
 ///
 /// #[derive(Debug, Deserialize)]
 /// #[serde(untagged)]
-/// enum CombinedError<'a> {
-///     #[serde(borrow)]
-///     VarlinkService(Error<'a>),
+/// enum CombinedReply {
+///     VarlinkService(OwnedReply),
+///     // Add other interface reply types here
+///     // OtherInterface(other_interface::OwnedReply),
+/// }
+///
+/// #[derive(Debug, zlink_core::ReplyError)]
+/// #[zlink(interface = "org.varlink.service")]
+/// enum CombinedError {
+///     // Varlink service errors
+///     InterfaceNotFound { interface: String },
 ///     // Add other interface error types here
-///     // OtherInterface(other_interface::Error<'a>),
 /// }
 ///
 /// // Then use the combined types for cross-interface chaining.
 /// let combined_chain = conn
-///     .chain_get_info::<CombinedReply<'_>, CombinedError<'_>>()?;
+///     .chain_get_info::<CombinedReply, CombinedError>()?;
 ///     // .other_interface_method()?;  // Chain calls from other interfaces
 ///
 /// let combined_replies = combined_chain.send().await?;
@@ -89,16 +97,18 @@ use super::{Error, Info, InterfaceDescription};
 ///         Ok(reply) => {
 ///             match reply.parameters().unwrap() {
 ///                 CombinedReply::VarlinkService(varlink_reply) => match varlink_reply {
-///                     Reply::Info(info) => println!("Varlink service info: {:?}", info),
-///                     Reply::InterfaceDescription(desc) => println!("Varlink interface: {:?}", desc),
+///                     OwnedReply::Info(info) => println!("Varlink service info: {:?}", info),
+///                     OwnedReply::InterfaceDescription(desc) => {
+///                         println!("Varlink interface: {:?}", desc)
+///                     }
 ///                 }
 ///                 // Handle other interface replies here
 ///             }
 ///         }
 ///         Err(error) => {
 ///             match error {
-///                 CombinedError::VarlinkService(varlink_error) => {
-///                     println!("Varlink service error: {:?}", varlink_error);
+///                 CombinedError::InterfaceNotFound { interface } => {
+///                     println!("Interface not found: {}", interface);
 ///                 }
 ///                 // Handle other interface errors here
 ///             }
@@ -145,11 +155,16 @@ pub trait Proxy {
 mod tests {
     use super::*;
     // Use consolidated mock socket from test_utils.
-    use crate::{test_utils::mock_socket::MockSocket, Connection};
+    use crate::{
+        test_utils::mock_socket::MockSocket,
+        varlink_service::{OwnedError, OwnedReply},
+        Connection,
+    };
 
     #[tokio::test]
     async fn chain_api_creation() -> crate::Result<()> {
         // Test that we can create chains with the new API.
+        // Note: Chains require DeserializeOwned types, so we use owned types here.
         let responses = [
             r#"{"parameters":{"vendor":"Test","product":"TestProduct","version":"1.0","url":"https://test.com","interfaces":["org.varlink.service"]}}"#,
             r#"{"parameters":{"description":"interface org.varlink.service {}"}}"#,
@@ -157,13 +172,10 @@ mod tests {
         let socket = MockSocket::with_responses(&responses);
         let mut conn = Connection::new(socket);
 
-        // Use the provided Reply enum from the varlink service module
-        use super::{super::Reply, Error};
-
-        // Test that we can create the chain APIs.
-        let _chain1 = conn.chain_get_info::<Reply<'_>, Error<'_>>()?;
+        // Test that we can create the chain APIs with owned types.
+        let _chain1 = conn.chain_get_info::<OwnedReply, OwnedError>()?;
         let _chain2 =
-            conn.chain_get_interface_description::<Reply<'_>, Error<'_>>("org.varlink.service")?;
+            conn.chain_get_interface_description::<OwnedReply, OwnedError>("org.varlink.service")?;
 
         Ok(())
     }
@@ -171,6 +183,7 @@ mod tests {
     #[tokio::test]
     async fn chain_extension_methods() -> crate::Result<()> {
         // Test that we can use chain extension methods.
+        // Note: Chains require DeserializeOwned types, so we use owned types here.
         let responses = [
             r#"{"parameters":{"vendor":"Test","product":"TestProduct","version":"1.0","url":"https://test.com","interfaces":["org.varlink.service"]}}"#,
             r#"{"parameters":{"description":"interface org.varlink.service {}"}}"#,
@@ -179,11 +192,9 @@ mod tests {
         let socket = MockSocket::with_responses(&responses);
         let mut conn = Connection::new(socket);
 
-        use super::{super::Reply, Error};
-
         // Test that we can chain calls using extension methods and actually read replies.
         let chained = conn
-            .chain_get_info::<Reply<'_>, Error<'_>>()?
+            .chain_get_info::<OwnedReply, OwnedError>()?
             .get_interface_description("org.varlink.service")?
             .get_info()?;
 
@@ -195,7 +206,7 @@ mod tests {
         let (first_reply, _fds) = replies.next().await.unwrap()?;
         let first_reply = first_reply.unwrap();
         match first_reply.parameters().unwrap() {
-            Reply::Info(info) => {
+            OwnedReply::Info(info) => {
                 assert_eq!(info.vendor, "Test");
                 assert_eq!(info.product, "TestProduct");
                 assert_eq!(info.version, "1.0");
@@ -209,7 +220,7 @@ mod tests {
         let (second_reply, _fds) = replies.next().await.unwrap()?;
         let second_reply = second_reply.unwrap();
         match second_reply.parameters().unwrap() {
-            Reply::InterfaceDescription(desc) => {
+            OwnedReply::InterfaceDescription(desc) => {
                 assert_eq!(desc.as_raw().unwrap(), "interface org.varlink.service {}");
             }
             _ => panic!("Expected InterfaceDescription reply"),
@@ -219,7 +230,7 @@ mod tests {
         let (third_reply, _fds) = replies.next().await.unwrap()?;
         let third_reply = third_reply.unwrap();
         match third_reply.parameters().unwrap() {
-            Reply::Info(info) => {
+            OwnedReply::Info(info) => {
                 assert_eq!(info.vendor, "Test");
             }
             _ => panic!("Expected Info reply"),

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -461,7 +461,7 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// # }
 /// # impl std::error::Error for BlogError {}
 /// #
-/// // Define proxies for two different services
+/// // Define proxies for two different services.
 /// #[proxy("org.example.blog.Users")]
 /// trait UsersProxy {
 ///     async fn get_user(&mut self, id: u64) -> zlink::Result<Result<BlogReply<'_>, BlogError>>;
@@ -493,11 +493,11 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///     .get_posts_by_user(1)?                                   // Get all posts
 ///     .get_user(1)?;                                           // Get user details
 ///
-/// // Send all calls in a single batch
+/// // Send all calls in a single batch.
 /// let replies = chain.send().await?;
 /// pin_mut!(replies);
 ///
-/// // Process replies in order
+/// // Process replies in order.
 /// let mut reply_count = 0;
 /// while let Some((reply, _fds)) = replies.try_next().await? {
 ///     reply_count += 1;

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -366,27 +366,29 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///
 /// #[proxy("org.example.MyService")]
 /// trait MyServiceProxy {
+///     // Non-streaming methods can use borrowed types.
 ///     async fn get_status(&mut self) -> zlink::Result<Result<Status<'_>, MyError<'_>>>;
 ///     async fn set_value(
 ///         &mut self,
 ///         key: &str,
 ///         value: i32,
 ///     ) -> zlink::Result<Result<(), MyError<'_>>>;
-///     // This will call the `io.systemd.Machine.List` method when `list_machines()` is invoked.
 ///     #[zlink(rename = "ListMachines")]
 ///     async fn list_machines(&mut self) -> zlink::Result<Result<Vec<Machine<'_>>, MyError<'_>>>;
-///     // Streaming version of get_status - calls the same method but returns a stream
+///     // Streaming methods must use owned types (DeserializeOwned) because the internal buffer may
+///     // be reused between stream iterations.
 ///     #[zlink(rename = "GetStatus", more)]
 ///     async fn stream_status(
 ///         &mut self,
 ///     ) -> zlink::Result<
-///         impl Stream<Item = zlink::Result<Result<Status<'_>, MyError<'_>>>>,
+///         impl Stream<Item = zlink::Result<Result<OwnedStatus, OwnedMyError>>>,
 ///     >;
 /// }
 ///
 /// // The macro generates:
 /// // impl<S: Socket> MyServiceProxy for Connection<S> { ... }
 ///
+/// // Borrowed types for non-streaming methods.
 /// #[derive(Debug, Serialize, Deserialize)]
 /// struct Status<'m> {
 ///     active: bool,
@@ -404,6 +406,22 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///     InvalidRequest,
 ///     // Parameters must be named.
 ///     CodedError { code: u32, message: &'a str },
+/// }
+///
+/// // Owned types for streaming methods (required by the `more` attribute).
+/// #[derive(Debug, Serialize, Deserialize)]
+/// struct OwnedStatus {
+///     active: bool,
+///     message: String,
+/// }
+///
+/// #[prefix_all("org.example.MyService.")]
+/// #[derive(Debug, Serialize, Deserialize)]
+/// #[serde(tag = "error", content = "parameters")]
+/// enum OwnedMyError {
+///     NotFound,
+///     InvalidRequest,
+///     CodedError { code: u32, message: String },
 /// }
 ///
 /// // Example usage:
@@ -428,12 +446,18 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///
 /// ## Example: Chaining Method Calls
 ///
+/// Note: Chain methods require owned types (`DeserializeOwned`) for **reply** parameters and errors
+/// because the internal buffer may be reused between stream iterations. Input arguments can still
+/// use borrowed types. This limitation may be lifted in the future when Rust supports lending
+/// streams.
+///
 /// ```rust
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
 /// # use zlink::proxy;
 /// # use serde::{Deserialize, Serialize};
 /// # use futures_util::{pin_mut, TryStreamExt};
 /// #
+/// // Borrowed reply types for single-call methods.
 /// # #[derive(Debug, Serialize, Deserialize)]
 /// # struct User<'a> { id: u64, name: &'a str }
 /// # #[derive(Debug, Serialize, Deserialize)]
@@ -447,6 +471,18 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// #     Post(Post<'a>),
 /// #     #[serde(borrow)]
 /// #     Posts(Vec<Post<'a>>)
+/// # }
+/// // Owned reply types for chain API.
+/// # #[derive(Debug, Serialize, Deserialize)]
+/// # struct OwnedUser { id: u64, name: String }
+/// # #[derive(Debug, Serialize, Deserialize)]
+/// # struct OwnedPost { id: u64, user_id: u64, content: String }
+/// # #[derive(Debug, Serialize, Deserialize)]
+/// # #[serde(untagged)]
+/// # enum OwnedBlogReply {
+/// #     User(OwnedUser),
+/// #     Post(OwnedPost),
+/// #     Posts(Vec<OwnedPost>)
 /// # }
 /// # #[derive(Debug, Serialize, Deserialize)]
 /// # #[serde(tag = "error")]
@@ -462,9 +498,11 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// # impl std::error::Error for BlogError {}
 /// #
 /// // Define proxies for two different services.
+/// // Single-call methods use borrowed reply types.
 /// #[proxy("org.example.blog.Users")]
 /// trait UsersProxy {
-///     async fn get_user(&mut self, id: u64) -> zlink::Result<Result<BlogReply<'_>, BlogError>>;
+///     async fn get_user(&mut self, id: u64)
+///         -> zlink::Result<Result<BlogReply<'_>, BlogError>>;
 ///     async fn create_user(&mut self, name: &str)
 ///         -> zlink::Result<Result<BlogReply<'_>, BlogError>>;
 /// }
@@ -486,12 +524,13 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// # ];
 /// # let socket = MockSocket::with_responses(&responses);
 /// # let mut conn = zlink::Connection::new(socket);
-/// // Chain calls across both interfaces in a single batch
+/// // Chain calls use owned reply types (OwnedBlogReply, BlogError).
+/// // Input arguments can still be borrowed (&str).
 /// let chain = conn
-///     .chain_create_user::<BlogReply<'_>, BlogError>("Alice")? // Start with Users interface
-///     .create_post(1, "My first post!")?                       // Chain Posts interface
-///     .get_posts_by_user(1)?                                   // Get all posts
-///     .get_user(1)?;                                           // Get user details
+///     .chain_create_user::<OwnedBlogReply, BlogError>("Alice")?
+///     .create_post(1, "My first post!")?
+///     .get_posts_by_user(1)?
+///     .get_user(1)?;
 ///
 /// // Send all calls in a single batch.
 /// let replies = chain.send().await?;
@@ -503,9 +542,9 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///     reply_count += 1;
 ///     if let Ok(response) = reply {
 ///         match response.parameters() {
-///             Some(BlogReply::User(user)) => assert_eq!(user.name, "Alice"),
-///             Some(BlogReply::Post(post)) => assert_eq!(post.content, "My first post!"),
-///             Some(BlogReply::Posts(posts)) => assert_eq!(posts.len(), 1),
+///             Some(OwnedBlogReply::User(user)) => assert_eq!(user.name, "Alice"),
+///             Some(OwnedBlogReply::Post(post)) => assert_eq!(post.content, "My first post!"),
+///             Some(OwnedBlogReply::Posts(posts)) => assert_eq!(posts.len(), 1),
 ///             None => {} // set_value returns empty response
 ///         }
 ///     }
@@ -518,12 +557,13 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// ## Combining with Standard Varlink Service
 ///
 /// When the `idl-parse` feature is enabled, you can also chain calls between your custom
-/// interfaces and the standard Varlink service interface for introspection:
+/// interfaces and the standard Varlink service interface for introspection. Remember that
+/// chain methods require owned types (`DeserializeOwned`) for **replies**.
 ///
 /// ```rust
 /// # #[cfg(feature = "idl-parse")] {
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
-/// # use zlink::{proxy, varlink_service};
+/// # use zlink::{proxy, varlink_service, ReplyError};
 /// # use serde::{Deserialize, Serialize};
 /// #
 /// # #[derive(Debug, Serialize, Deserialize)]
@@ -537,20 +577,34 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///     async fn get_status(&mut self) -> zlink::Result<Result<Status, MyError>>;
 /// }
 ///
-/// // Combined types for cross-interface chaining
+/// // Owned reply types for cross-interface chaining (required by chain API).
 /// #[derive(Debug, Deserialize)]
-/// #[serde(untagged)]
-/// enum CombinedReply<'a> {
-///     #[serde(borrow)]
-///     VarlinkService(varlink_service::Reply<'a>),
-///     MyService(Status),
+/// struct OwnedInfo {
+///     vendor: String,
+///     product: String,
+///     version: String,
+///     url: String,
+///     interfaces: Vec<String>,
+/// }
+///
+/// #[derive(Debug, Deserialize)]
+/// struct OwnedInterfaceDescription {
+///     description: String,
 /// }
 ///
 /// #[derive(Debug, Deserialize)]
 /// #[serde(untagged)]
-/// enum CombinedError<'a> {
-///     #[serde(borrow)]
-///     VarlinkService(varlink_service::Error<'a>),
+/// enum OwnedCombinedReply {
+///     Info(OwnedInfo),
+///     InterfaceDescription(OwnedInterfaceDescription),
+///     MyService(Status),
+/// }
+///
+/// // For deserialization, we can use #[serde(untagged)] to combine error types.
+/// #[derive(Debug, Deserialize)]
+/// #[serde(untagged)]
+/// enum OwnedCombinedError {
+///     InterfaceNotFound { interface: String },
 ///     MyService(MyError),
 /// }
 ///
@@ -570,11 +624,11 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// use varlink_service::Proxy;
 /// use zlink::varlink_service::Chain;
 ///
-/// // Get service info and custom status in one batch
+/// // Get service info and custom status in one batch using owned reply types.
 /// let chain = conn
-///     .chain_get_info::<CombinedReply<'_>, CombinedError<'_>>()? // Varlink service interface
-///     .get_status()?                                         // MyService interface
-///     .get_interface_description("com.example.MyService")?;  // Back to Varlink service
+///     .chain_get_info::<OwnedCombinedReply, OwnedCombinedError>()? // Varlink service interface
+///     .get_status()?                                               // MyService interface
+///     .get_interface_description("com.example.MyService")?;        // Back to Varlink service
 ///
 /// let replies = chain.send().await?;
 /// # Ok::<(), Box<dyn std::error::Error>>(())

--- a/zlink-macros/src/proxy.rs
+++ b/zlink-macros/src/proxy.rs
@@ -278,8 +278,8 @@ fn build_chain_extension_trait(
         pub trait #chain_trait_name<'c, S, ReplyParams, ReplyError>
         where
             S: #crate_path::connection::socket::Socket,
-            ReplyParams: ::serde::Deserialize<'c> + ::core::fmt::Debug,
-            ReplyError: ::serde::Deserialize<'c> + ::core::fmt::Debug,
+            ReplyParams: ::serde::de::DeserializeOwned + ::core::fmt::Debug,
+            ReplyError: ::serde::de::DeserializeOwned + ::core::fmt::Debug,
         {
             #(#chain_extension_methods)*
         }
@@ -288,8 +288,8 @@ fn build_chain_extension_trait(
             for #crate_path::connection::chain::Chain<'c, S, ReplyParams, ReplyError>
         where
             S: #crate_path::connection::socket::Socket,
-            ReplyParams: ::serde::Deserialize<'c> + ::core::fmt::Debug,
-            ReplyError: ::serde::Deserialize<'c> + ::core::fmt::Debug,
+            ReplyParams: ::serde::de::DeserializeOwned + ::core::fmt::Debug,
+            ReplyError: ::serde::de::DeserializeOwned + ::core::fmt::Debug,
         {
             #(#chain_extension_impls)*
         }

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -187,7 +187,7 @@ fn parse_method_arguments<'a>(
 fn build_chain_where_clause(method_where_clause: &Option<syn::WhereClause>) -> syn::WhereClause {
     let mut chain_where_predicates = syn::punctuated::Punctuated::new();
 
-    // Add ReplyParams and ReplyError bounds
+    // Add ReplyParams and ReplyError bounds.
     chain_where_predicates
         .push(syn::parse_quote!(ReplyParams: ::serde::Deserialize<'c> + ::core::fmt::Debug));
     chain_where_predicates

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -188,10 +188,11 @@ fn build_chain_where_clause(method_where_clause: &Option<syn::WhereClause>) -> s
     let mut chain_where_predicates = syn::punctuated::Punctuated::new();
 
     // Add ReplyParams and ReplyError bounds.
+    // DeserializeOwned is required because stream items must be owned (cannot borrow from buffer).
     chain_where_predicates
-        .push(syn::parse_quote!(ReplyParams: ::serde::Deserialize<'c> + ::core::fmt::Debug));
+        .push(syn::parse_quote!(ReplyParams: ::serde::de::DeserializeOwned + ::core::fmt::Debug));
     chain_where_predicates
-        .push(syn::parse_quote!(ReplyError: ::serde::Deserialize<'c> + ::core::fmt::Debug));
+        .push(syn::parse_quote!(ReplyError: ::serde::de::DeserializeOwned + ::core::fmt::Debug));
 
     // Add method where clause predicates if present
     if let Some(method_where) = method_where_clause {

--- a/zlink-macros/tests/proxy/streaming.rs
+++ b/zlink-macros/tests/proxy/streaming.rs
@@ -7,6 +7,9 @@ async fn streaming_test() {
     use serde_json::json;
     use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
 
+    // Non-streaming methods can use borrowed types.
+    // Streaming methods must use owned types (DeserializeOwned) because the internal buffer may be
+    // reused between stream iterations, which would invalidate borrowed references.
     #[proxy("org.example.Stream")]
     trait StreamProxy {
         async fn get_single(&mut self) -> zlink::Result<Result<SingleReply<'_>, Error>>;
@@ -14,7 +17,7 @@ async fn streaming_test() {
         #[zlink(more)]
         async fn get_stream(
             &mut self,
-        ) -> zlink::Result<impl Stream<Item = zlink::Result<Result<StreamReply<'_>, Error>>>>;
+        ) -> zlink::Result<impl Stream<Item = zlink::Result<Result<StreamReply, Error>>>>;
 
         #[zlink(rename = "CustomStream", more)]
         async fn custom_stream(
@@ -32,16 +35,17 @@ async fn streaming_test() {
     #[derive(Debug, Serialize, Deserialize, PartialEq)]
     struct Error;
 
+    // Non-streaming reply can borrow from the connection buffer.
     #[derive(Debug, Serialize, Deserialize)]
     struct SingleReply<'a> {
         #[serde(borrow)]
         result: &'a str,
     }
 
+    // Streaming reply must be owned (no lifetime parameter).
     #[derive(Debug, Serialize, Deserialize)]
-    struct StreamReply<'a> {
-        #[serde(borrow)]
-        result: &'a str,
+    struct StreamReply {
+        result: String,
     }
 
     // Test get_single

--- a/zlink/examples/resolved.rs
+++ b/zlink/examples/resolved.rs
@@ -22,6 +22,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Build the chain of pipelined requests.
+    // Note: Chain API requires owned types (DeserializeOwned) because the internal buffer may be
+    // reused between stream iterations, which would invalidate borrowed references.
     let mut chain = connection.chain_resolve_hostname::<ReplyParams, ReplyError>(&args[0])?;
     for name in &args[1..] {
         chain = chain.resolve_hostname(name)?;
@@ -57,14 +59,15 @@ trait ResolvedProxy {
     async fn resolve_hostname(
         &mut self,
         name: &str,
-    ) -> zlink::Result<Result<ReplyParams<'_>, ReplyError<'_>>>;
+    ) -> zlink::Result<Result<ReplyParams, ReplyError>>;
 }
 
+// Owned types (required by chain API which needs DeserializeOwned).
 #[derive(Debug, serde::Deserialize)]
-struct ReplyParams<'r> {
+struct ReplyParams {
     addresses: Vec<ResolvedAddress>,
     #[serde(rename = "name")]
-    _name: &'r str,
+    _name: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
@@ -106,7 +109,7 @@ enum ProtocolFamily {
 
 #[derive(Debug, ReplyError)]
 #[zlink(interface = "io.systemd.Resolve")]
-enum ReplyError<'e> {
+enum ReplyError {
     NoNameServers,
     NoSuchResourceRecord,
     QueryTimedOut,
@@ -115,11 +118,11 @@ enum ReplyError<'e> {
     QueryAborted,
     DNSSECValidationFailed {
         #[zlink(rename = "result")]
-        _result: &'e str,
+        _result: String,
         #[zlink(rename = "extendedDNSErrorCode")]
         _extended_dns_error_code: Option<i32>,
         #[zlink(rename = "extendedDNSErrorMessage")]
-        _extended_dns_error_message: Option<&'e str>,
+        _extended_dns_error_message: Option<String>,
     },
     NoTrustAnchor,
     ResourceRecordTypeUnsupported,
@@ -132,7 +135,7 @@ enum ReplyError<'e> {
         #[zlink(rename = "extendedDNSErrorCode")]
         _extended_dns_error_code: Option<i32>,
         #[zlink(rename = "extendedDNSErrorMessage")]
-        _extended_dns_error_message: Option<&'e str>,
+        _extended_dns_error_message: Option<String>,
     },
     CNAMELoop,
     BadAddressSize,
@@ -141,10 +144,10 @@ enum ReplyError<'e> {
     ResourceRecordTypeObsolete,
 }
 
-impl Display for ReplyError<'_> {
+impl Display for ReplyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{self:?}")
     }
 }
 
-impl std::error::Error for ReplyError<'_> {}
+impl std::error::Error for ReplyError {}

--- a/zlink/tests/machined_proxy_e2e.rs
+++ b/zlink/tests/machined_proxy_e2e.rs
@@ -16,7 +16,7 @@ use zlink::{
     varlink_service::{self, Proxy},
 };
 
-use mock_machined_service::{AcquireMetadata, ListReply, MachinedError, ProcessId};
+use mock_machined_service::{AcquireMetadata, ListReply, MachinedError, OwnedListReply, ProcessId};
 
 #[tokio::test]
 async fn introspect_machined() {
@@ -162,6 +162,8 @@ trait MachineProxy {
         #[zlink(rename = "acquireMetadata")] acquire_metadata: Option<AcquireMetadata>,
     ) -> zlink::Result<Result<ListReply<'_>, MachinedError>>;
 
+    // Streaming methods require owned types (DeserializeOwned) because the internal buffer may be
+    // reused between stream iterations, which would invalidate borrowed references.
     #[zlink(more, rename = "List")]
     async fn list_more(
         &mut self,
@@ -170,7 +172,7 @@ trait MachineProxy {
         #[zlink(rename = "allowInteractiveAuthentication")]
         allow_interactive_authentication: Option<bool>,
         #[zlink(rename = "acquireMetadata")] acquire_metadata: Option<AcquireMetadata>,
-    ) -> zlink::Result<impl Stream<Item = zlink::Result<Result<ListReply<'_>, MachinedError>>>>;
+    ) -> zlink::Result<impl Stream<Item = zlink::Result<Result<OwnedListReply, MachinedError>>>>;
 }
 
 /// Run test with either real systemd service or mock service.

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -41,6 +41,31 @@ pub struct ListReply<'a> {
     pub uid_shift: Option<u64>,
 }
 
+// Owned version for streaming APIs (which require DeserializeOwned).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OwnedListReply {
+    pub name: String,
+    pub id: Option<String>,
+    pub service: Option<String>,
+    pub class: String,
+    pub leader: Option<OwnedProcessId>,
+    #[serde(rename = "rootDirectory")]
+    pub root_directory: Option<String>,
+    pub unit: Option<String>,
+    pub timestamp: Option<Timestamp>,
+    #[serde(rename = "vSockCid")]
+    pub v_sock_cid: Option<u64>,
+    #[serde(rename = "sshAddress")]
+    pub ssh_address: Option<String>,
+    #[serde(rename = "sshPrivateKeyPath")]
+    pub ssh_private_key_path: Option<String>,
+    pub addresses: Option<Vec<Address>>,
+    #[serde(rename = "OSRelease")]
+    pub os_release: Option<Vec<String>>,
+    #[serde(rename = "UIDShift")]
+    pub uid_shift: Option<u64>,
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, CustomType)]
 #[serde(rename_all = "lowercase")]
 pub enum AcquireMetadata {
@@ -67,6 +92,16 @@ pub struct ProcessId<'a> {
     // According to the IDL, this should be a number but we actually get a string.
     // See https://github.com/systemd/systemd/issues/38276
     pub boot_id: Option<&'a str>,
+}
+
+// Owned version for streaming APIs (which require DeserializeOwned).
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+pub struct OwnedProcessId {
+    pub pid: i64,
+    #[serde(rename = "pidfdId")]
+    pub pidfd_id: Option<u64>,
+    #[serde(rename = "bootId")]
+    pub boot_id: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, CustomType)]


### PR DESCRIPTION
This was a major fuckup from my side that I thought that the Stream impl of chain::ReplayStream can return borrowed items. This means that replies can be over-written while still borrowed by the user.

Unfortunately, the Stream API doesn't currently allow us to borrow from self, so we have no choice but to switch to require DeserializeOwned for the item type.

In the future, this may be solvable when Stream allows borrowing from self.

Fixes #185.

