### PR TITLE
🔥 macros: `proxy` only generate chain methods for owned types ret

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ The generated code includes type definitions and proxy traits ready to use in yo
 zlink supports method call pipelining for improved throughput and reduced latency. The `proxy` macro
 adds variants for each method named `chain_<method_name>` and a trait named `<TraitName>Chain` that
 allow you to batch multiple requests and send them out at once without waiting for individual
-responses:
+responses.
 
 > **Note**: Chain methods require owned types (`DeserializeOwned`) for **reply** parameters and
 > errors because the internal buffer may be reused between stream iterations. Input arguments can

--- a/README.md
+++ b/README.md
@@ -305,10 +305,10 @@ adds variants for each method named `chain_<method_name>` and a trait named `<Tr
 allow you to batch multiple requests and send them out at once without waiting for individual
 responses.
 
-> **Note**: Chain methods require owned types (`DeserializeOwned`) for **reply** parameters and
-> errors because the internal buffer may be reused between stream iterations. Input arguments can
-> still use borrowed types. This limitation may be lifted in the future when Rust supports lending
-> streams.
+> **Note**: Chain methods are only generated for proxy methods that use owned types
+> (`DeserializeOwned`) in their return type. Methods with borrowed types (non-static lifetimes)
+> don't get chain variants since the internal buffer may be reused between stream iterations. Input
+> arguments can still use borrowed types.
 
 ```rust,no_run
 use futures_util::{StreamExt, pin_mut};
@@ -321,6 +321,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = unix::connect("/tmp/batch_processor.varlink").await?;
 
     // Send multiple pipelined requests without waiting for responses.
+    // Note: chain methods are only generated for proxy methods with owned return types.
     let replies = conn
         .chain_process(1, "first")?
         .process(2, "second")?
@@ -329,7 +330,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             ProcessRequest { id: 4, data: "batch1" },
             ProcessRequest { id: 5, data: "batch2" },
         ])?
-        .send::<OwnedProcessReply, OwnedProcessError>()
+        .send::<ProcessReply, ProcessError>()
         .await?;
 
     // Collect all responses
@@ -339,10 +340,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let (reply, _fds) = reply?;
         if let Ok(response) = reply {
             match response.into_parameters() {
-                Some(OwnedProcessReply::Result(result)) => {
+                Some(ProcessReply::Result(result)) => {
                     results.push(result);
                 }
-                Some(OwnedProcessReply::BatchResult(batch)) => {
+                Some(ProcessReply::BatchResult(batch)) => {
                     results.extend(batch.results);
                 }
                 None => {}
@@ -358,80 +359,50 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+// Proxy trait with owned return types - chain methods are generated.
 #[proxy("org.example.BatchProcessor")]
 trait BatchProcessorProxy {
-    // Non-chain methods can use borrowed types for replies.
     async fn process(
         &mut self,
         id: u32,
         data: &str,
-    ) -> zlink::Result<Result<ProcessReply<'_>, ProcessError<'_>>>;
+    ) -> zlink::Result<Result<ProcessReply, ProcessError>>;
 
     async fn batch_process(
         &mut self,
         requests: Vec<ProcessRequest<'_>>,
-    ) -> zlink::Result<Result<ProcessReply<'_>, ProcessError<'_>>>;
+    ) -> zlink::Result<Result<ProcessReply, ProcessError>>;
 }
 
-// Input types can use borrowed data (they implement Serialize).
+// Input types can use borrowed data (they implement Serialize, not DeserializeOwned).
 #[derive(Debug, Serialize)]
 struct ProcessRequest<'a> {
     id: u32,
-    #[serde(borrow)]
     data: &'a str,
 }
 
-// Borrowed reply types for non-chain (single call) methods.
+// Owned reply types - required for chain API (DeserializeOwned).
 #[derive(Debug, Deserialize)]
 #[serde(untagged)]
-enum ProcessReply<'a> {
-    #[serde(borrow)]
-    Result(ProcessResult<'a>),
-    #[serde(borrow)]
-    BatchResult(BatchResult<'a>),
+enum ProcessReply {
+    Result(ProcessResult),
+    BatchResult(BatchResult),
 }
 
 #[derive(Debug, Deserialize)]
-struct ProcessResult<'a> {
-    id: u32,
-    #[serde(borrow)]
-    processed: &'a str,
-}
-
-#[derive(Debug, Deserialize)]
-struct BatchResult<'a> {
-    #[serde(borrow)]
-    results: Vec<ProcessResult<'a>>,
-}
-
-#[derive(Debug, ReplyError)]
-#[zlink(interface = "org.example.BatchProcessor")]
-enum ProcessError<'a> {
-    InvalidRequest { message: &'a str },
-}
-
-// Owned reply types for chain API (which requires DeserializeOwned).
-#[derive(Debug, Deserialize)]
-#[serde(untagged)]
-enum OwnedProcessReply {
-    Result(OwnedProcessResult),
-    BatchResult(OwnedBatchResult),
-}
-
-#[derive(Debug, Deserialize)]
-struct OwnedProcessResult {
+struct ProcessResult {
     id: u32,
     processed: String,
 }
 
 #[derive(Debug, Deserialize)]
-struct OwnedBatchResult {
-    results: Vec<OwnedProcessResult>,
+struct BatchResult {
+    results: Vec<ProcessResult>,
 }
 
 #[derive(Debug, ReplyError)]
 #[zlink(interface = "org.example.BatchProcessor")]
-enum OwnedProcessError {
+enum ProcessError {
     InvalidRequest { message: String },
 }
 ```

--- a/zlink-core/src/varlink_service/proxy.rs
+++ b/zlink-core/src/varlink_service/proxy.rs
@@ -5,43 +5,64 @@
 
 use crate::proxy;
 
-use super::{Error, Info, InterfaceDescription};
+use super::{Error, Info, InterfaceDescription, OwnedError, OwnedInfo};
 
 /// Client-side proxy for the `org.varlink.service` interface.
 ///
-/// This trait provides methods to call the standard Varlink service interface
-/// methods on a connection.
+/// This trait provides methods to call the standard Varlink service interface methods on a
+/// connection.
 ///
-/// # Chaining Calls
+/// # Borrowed vs Owned Methods
 ///
-/// The trait is implemented for both [`crate::Connection`] and [`Chain`], allowing you to
-/// chain calls together for efficient batching. Use [`crate::Connection::chain_get_info`] or
-/// [`crate::Connection::chain_get_interface_description`] to start a chain.
+/// The trait provides both borrowed and owned variants of each method:
 ///
-/// ## Owned Data Requirement for Chains
+/// - **Borrowed methods** (`get_info`, `get_interface_description`): Return borrowed types for
+///   efficient zero-copy deserialization. These are preferred for single calls.
 ///
-/// Chain methods require owned types (`DeserializeOwned`) for reply parameters and errors
-/// because the internal buffer may be reused between stream iterations. This limitation may be
-/// lifted in the future when Rust supports lending streams.
+/// - **Owned methods** (`owned_get_info`, `owned_get_interface_description`): Return owned types
+///   ([`OwnedInfo`], [`OwnedError`]) required for the chain API. Chain methods (`chain_*`) are
+///   generated only for these variants since `DeserializeOwned` is required for pipelining.
 ///
-/// [`super::OwnedReply`], [`super::OwnedInfo`], and [`super::OwnedError`] are provided for use
-/// with the chain API.
+/// # Example: Basic Usage
 ///
-/// ## Example
+/// ```no_run
+/// use zlink_core::{Connection, varlink_service::Proxy};
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// # let mut conn: Connection<zlink_core::connection::socket::impl_for_doc::Socket> = todo!();
+/// // Get service information (borrowed - zero-copy).
+/// let info = conn.get_info().await?.map_err(|e| e.to_string())?;
+/// println!("Service: {} v{} by {}", info.product, info.version, info.vendor);
+/// println!("URL: {}", info.url);
+/// println!("Interfaces: {:?}", info.interfaces);
+///
+/// // Get interface description.
+/// let desc = conn
+///     .get_interface_description("org.varlink.service")
+///     .await?
+///     .map_err(|e| e.to_string())?;
+/// println!("Interface description: {}", desc.as_raw().unwrap());
+///
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Example: Chaining (Pipelining)
 ///
 /// ```no_run
 /// use zlink_core::{
 ///     Connection,
-///     varlink_service::{Chain, OwnedError, OwnedInfo, OwnedReply, Proxy},
+///     varlink_service::{Chain, OwnedError, OwnedReply, Proxy},
 /// };
 /// use futures_util::{pin_mut, stream::StreamExt};
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// # let mut conn: Connection<zlink_core::connection::socket::impl_for_doc::Socket> = todo!();
+/// // Chain multiple calls using owned methods (required for pipelining).
 /// let chain = conn
-///     .chain_get_info()?
-///     .get_interface_description("org.example.interface")?
-///     .get_info()?;
+///     .chain_owned_get_info()?
+///     .owned_get_interface_description("org.example.interface")?
+///     .owned_get_info()?;
 ///
 /// // Send the chain and process replies.
 /// let replies = chain.send::<OwnedReply, OwnedError>().await?;
@@ -50,68 +71,12 @@ use super::{Error, Info, InterfaceDescription};
 /// // Process each reply in the order they were chained.
 /// while let Some(result) = replies.next().await {
 ///     let (reply, _fds) = result?;
-///     match reply.unwrap().parameters().unwrap() {
+///     match reply.unwrap().into_parameters().unwrap() {
 ///         OwnedReply::Info(info) => {
 ///             println!("Service: {} v{} by {}", info.product, info.version, info.vendor);
-///             println!("URL: {}", info.url);
-///             println!("Interfaces: {:?}", info.interfaces);
 ///         }
 ///         OwnedReply::InterfaceDescription(desc) => {
-///             // Use as_raw() to get the raw description string.
 ///             println!("Interface description: {}", desc.as_raw().unwrap());
-///         }
-///     }
-/// }
-///
-/// // For combining multiple interfaces, create a combined reply enum:
-/// use serde::Deserialize;
-///
-/// #[derive(Debug, Deserialize)]
-/// #[serde(untagged)]
-/// enum CombinedReply {
-///     VarlinkService(OwnedReply),
-///     // Add other interface reply types here
-///     // OtherInterface(other_interface::OwnedReply),
-/// }
-///
-/// #[derive(Debug, zlink_core::ReplyError)]
-/// #[zlink(interface = "org.varlink.service")]
-/// enum CombinedError {
-///     // Varlink service errors
-///     InterfaceNotFound { interface: String },
-///     // Add other interface error types here
-/// }
-///
-/// // Then use the combined types for cross-interface chaining.
-/// let combined_chain = conn
-///     .chain_get_info()?;
-///     // .other_interface_method()?;  // Chain calls from other interfaces
-///
-/// // Specify combined types when sending.
-/// let combined_replies = combined_chain.send::<CombinedReply, CombinedError>().await?;
-/// pin_mut!(combined_replies);
-///
-/// while let Some(result) = combined_replies.next().await {
-///     let (reply, _fds) = result?;
-///     match reply {
-///         Ok(reply) => {
-///             match reply.parameters().unwrap() {
-///                 CombinedReply::VarlinkService(varlink_reply) => match varlink_reply {
-///                     OwnedReply::Info(info) => println!("Varlink service info: {:?}", info),
-///                     OwnedReply::InterfaceDescription(desc) => {
-///                         println!("Varlink interface: {:?}", desc)
-///                     }
-///                 }
-///                 // Handle other interface replies here
-///             }
-///         }
-///         Err(error) => {
-///             match error {
-///                 CombinedError::InterfaceNotFound { interface } => {
-///                     println!("Interface not found: {}", interface);
-///                 }
-///                 // Handle other interface errors here
-///             }
 ///         }
 ///     }
 /// }
@@ -128,13 +93,33 @@ use super::{Error, Info, InterfaceDescription};
 pub trait Proxy {
     /// Get information about a Varlink service.
     ///
+    /// This method uses borrowed types for zero-copy deserialization. For chaining (pipelining),
+    /// use [`owned_get_info`](Self::owned_get_info) instead.
+    ///
     /// # Returns
     ///
     /// Two-layer result: outer for connection errors, inner for method errors. On success, contains
     /// service information as [`Info`].
     async fn get_info(&mut self) -> crate::Result<core::result::Result<Info<'_>, Error<'_>>>;
 
+    /// Get information about a Varlink service (owned variant for chain API).
+    ///
+    /// This method returns owned types, which is required for the chain API (pipelining).
+    /// For single calls, prefer [`get_info`](Self::get_info) for zero-copy deserialization.
+    ///
+    /// # Returns
+    ///
+    /// Two-layer result: outer for connection errors, inner for method errors. On success, contains
+    /// service information as [`OwnedInfo`].
+    #[zlink(rename = "GetInfo")]
+    async fn owned_get_info(
+        &mut self,
+    ) -> crate::Result<core::result::Result<OwnedInfo, OwnedError>>;
+
     /// Get the IDL description of an interface.
+    ///
+    /// This method uses borrowed types for zero-copy deserialization. For chaining (pipelining),
+    /// use [`owned_get_interface_description`](Self::owned_get_interface_description) instead.
     ///
     /// # Arguments
     ///
@@ -149,21 +134,38 @@ pub trait Proxy {
         &mut self,
         interface: &str,
     ) -> crate::Result<core::result::Result<InterfaceDescription<'static>, Error<'_>>>;
+
+    /// Get the IDL description of an interface (owned variant for chain API).
+    ///
+    /// This method returns owned types, which is required for the chain API (pipelining).
+    /// For single calls, prefer [`get_interface_description`](Self::get_interface_description)
+    /// for zero-copy deserialization.
+    ///
+    /// # Arguments
+    ///
+    /// * `interface` - The name of the interface to get the description for.
+    ///
+    /// # Returns
+    ///
+    /// Two-layer result: outer for connection errors, inner for method errors. On success, contains
+    /// the unparsed interface definition as a [`InterfaceDescription`]. Use
+    /// [`InterfaceDescription::parse`] to parse it.
+    #[zlink(rename = "GetInterfaceDescription")]
+    async fn owned_get_interface_description(
+        &mut self,
+        interface: &str,
+    ) -> crate::Result<core::result::Result<InterfaceDescription<'static>, OwnedError>>;
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    // Use consolidated mock socket from test_utils.
-    use crate::{
-        test_utils::mock_socket::MockSocket,
-        varlink_service::{OwnedError, OwnedReply},
-        Connection,
-    };
+    use super::{super::OwnedReply, *};
+    use crate::{test_utils::mock_socket::MockSocket, Connection};
+    use futures_util::{pin_mut, stream::StreamExt};
 
     #[tokio::test]
     async fn chain_api_creation() -> crate::Result<()> {
-        // Test that we can create chains with the new API.
+        // Test that we can create chains with the owned API.
         let responses = [
             r#"{"parameters":{"vendor":"Test","product":"TestProduct","version":"1.0","url":"https://test.com","interfaces":["org.varlink.service"]}}"#,
             r#"{"parameters":{"description":"interface org.varlink.service {}"}}"#,
@@ -172,8 +174,8 @@ mod tests {
         let mut conn = Connection::new(socket);
 
         // Test that we can create the chain APIs.
-        let _chain1 = conn.chain_get_info()?;
-        let _chain2 = conn.chain_get_interface_description("org.varlink.service")?;
+        let _chain1 = conn.chain_owned_get_info()?;
+        let _chain2 = conn.chain_owned_get_interface_description("org.varlink.service")?;
 
         Ok(())
     }
@@ -191,18 +193,17 @@ mod tests {
 
         // Test that we can chain calls using extension methods and actually read replies.
         let chained = conn
-            .chain_get_info()?
-            .get_interface_description("org.varlink.service")?
-            .get_info()?;
+            .chain_owned_get_info()?
+            .owned_get_interface_description("org.varlink.service")?
+            .owned_get_info()?;
 
         let replies = chained.send::<OwnedReply, OwnedError>().await?;
-        use futures_util::{pin_mut, stream::StreamExt};
         pin_mut!(replies);
 
         // Read first reply (GetInfo).
         let (first_reply, _fds) = replies.next().await.unwrap()?;
         let first_reply = first_reply.unwrap();
-        match first_reply.parameters().unwrap() {
+        match first_reply.into_parameters().unwrap() {
             OwnedReply::Info(info) => {
                 assert_eq!(info.vendor, "Test");
                 assert_eq!(info.product, "TestProduct");
@@ -216,7 +217,7 @@ mod tests {
         // Read second reply (GetInterfaceDescription).
         let (second_reply, _fds) = replies.next().await.unwrap()?;
         let second_reply = second_reply.unwrap();
-        match second_reply.parameters().unwrap() {
+        match second_reply.into_parameters().unwrap() {
             OwnedReply::InterfaceDescription(desc) => {
                 assert_eq!(desc.as_raw().unwrap(), "interface org.varlink.service {}");
             }
@@ -226,7 +227,7 @@ mod tests {
         // Read third reply (GetInfo again).
         let (third_reply, _fds) = replies.next().await.unwrap()?;
         let third_reply = third_reply.unwrap();
-        match third_reply.parameters().unwrap() {
+        match third_reply.into_parameters().unwrap() {
             OwnedReply::Info(info) => {
                 assert_eq!(info.vendor, "Test");
             }

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -444,12 +444,12 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// together. This is useful for reducing round trips and efficiently calling methods across
 /// multiple interfaces. Each method gets a `chain_` prefixed variant that starts a chain.
 ///
-/// ## Example: Chaining Method Calls
+/// **Important**: Chain methods are only generated for proxy methods that use owned types
+/// (`DeserializeOwned`) in their return type. Methods with borrowed types (non-static lifetimes)
+/// don't get chain variants since the internal buffer may be reused between stream iterations.
+/// Input arguments can still use borrowed types.
 ///
-/// Note: Chain methods require owned types (`DeserializeOwned`) for **reply** parameters and errors
-/// because the internal buffer may be reused between stream iterations. Input arguments can still
-/// use borrowed types. This limitation may be lifted in the future when Rust supports lending
-/// streams.
+/// ## Example: Chaining Method Calls
 ///
 /// ```rust
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
@@ -457,32 +457,17 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// # use serde::{Deserialize, Serialize};
 /// # use futures_util::{pin_mut, TryStreamExt};
 /// #
-/// // Borrowed reply types for single-call methods.
-/// # #[derive(Debug, Serialize, Deserialize)]
-/// # struct User<'a> { id: u64, name: &'a str }
-/// # #[derive(Debug, Serialize, Deserialize)]
-/// # struct Post<'a> { id: u64, user_id: u64, content: &'a str }
-/// # #[derive(Debug, Serialize, Deserialize)]
-/// # #[serde(untagged)]
-/// # enum BlogReply<'a> {
-/// #     #[serde(borrow)]
-/// #     User(User<'a>),
-/// #     #[serde(borrow)]
-/// #     Post(Post<'a>),
-/// #     #[serde(borrow)]
-/// #     Posts(Vec<Post<'a>>)
-/// # }
 /// // Owned reply types for chain API.
 /// # #[derive(Debug, Serialize, Deserialize)]
-/// # struct OwnedUser { id: u64, name: String }
+/// # struct User { id: u64, name: String }
 /// # #[derive(Debug, Serialize, Deserialize)]
-/// # struct OwnedPost { id: u64, user_id: u64, content: String }
+/// # struct Post { id: u64, user_id: u64, content: String }
 /// # #[derive(Debug, Serialize, Deserialize)]
 /// # #[serde(untagged)]
-/// # enum OwnedBlogReply {
-/// #     User(OwnedUser),
-/// #     Post(OwnedPost),
-/// #     Posts(Vec<OwnedPost>)
+/// # enum BlogReply {
+/// #     User(User),
+/// #     Post(Post),
+/// #     Posts(Vec<Post>)
 /// # }
 /// # #[derive(Debug, Serialize, Deserialize)]
 /// # #[serde(tag = "error")]
@@ -497,22 +482,21 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// # }
 /// # impl std::error::Error for BlogError {}
 /// #
-/// // Define proxies for two different services.
-/// // Single-call methods use borrowed reply types.
+/// // Define proxies with owned return types - chain methods are generated.
 /// #[proxy("org.example.blog.Users")]
 /// trait UsersProxy {
 ///     async fn get_user(&mut self, id: u64)
-///         -> zlink::Result<Result<BlogReply<'_>, BlogError>>;
+///         -> zlink::Result<Result<BlogReply, BlogError>>;
 ///     async fn create_user(&mut self, name: &str)
-///         -> zlink::Result<Result<BlogReply<'_>, BlogError>>;
+///         -> zlink::Result<Result<BlogReply, BlogError>>;
 /// }
 ///
 /// #[proxy("org.example.blog.Posts")]
 /// trait PostsProxy {
 ///     async fn get_posts_by_user(&mut self, user_id: u64)
-///         -> zlink::Result<Result<BlogReply<'_>, BlogError>>;
+///         -> zlink::Result<Result<BlogReply, BlogError>>;
 ///     async fn create_post(&mut self, user_id: u64, content: &str)
-///         -> zlink::Result<Result<BlogReply<'_>, BlogError>>;
+///         -> zlink::Result<Result<BlogReply, BlogError>>;
 /// }
 ///
 /// # use zlink::test_utils::mock_socket::MockSocket;
@@ -531,7 +515,7 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///     .get_user(1)?;
 ///
 /// // Send all calls in a single batch.
-/// let replies = chain.send::<OwnedBlogReply, BlogError>().await?;
+/// let replies = chain.send::<BlogReply, BlogError>().await?;
 /// pin_mut!(replies);
 ///
 /// // Process replies in order.
@@ -540,9 +524,9 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///     reply_count += 1;
 ///     if let Ok(response) = reply {
 ///         match response.parameters() {
-///             Some(OwnedBlogReply::User(user)) => assert_eq!(user.name, "Alice"),
-///             Some(OwnedBlogReply::Post(post)) => assert_eq!(post.content, "My first post!"),
-///             Some(OwnedBlogReply::Posts(posts)) => assert_eq!(posts.len(), 1),
+///             Some(BlogReply::User(user)) => assert_eq!(user.name, "Alice"),
+///             Some(BlogReply::Post(post)) => assert_eq!(post.content, "My first post!"),
+///             Some(BlogReply::Posts(posts)) => assert_eq!(posts.len(), 1),
 ///             None => {} // set_value returns empty response
 ///         }
 ///     }
@@ -552,86 +536,82 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// # }).unwrap();
 /// ```
 ///
-/// ## Combining with Standard Varlink Service
+/// ## Combining Multiple Services
 ///
-/// When the `idl-parse` feature is enabled, you can also chain calls between your custom
-/// interfaces and the standard Varlink service interface for introspection. Remember that
-/// chain methods require owned types (`DeserializeOwned`) for **replies**.
+/// You can chain calls across multiple custom services. Define a combined reply type that can
+/// deserialize responses from all interfaces:
 ///
 /// ```rust
-/// # #[cfg(feature = "idl-parse")] {
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
-/// # use zlink::{proxy, varlink_service, ReplyError};
+/// # use zlink::proxy;
 /// # use serde::{Deserialize, Serialize};
+/// # use futures_util::{pin_mut, TryStreamExt};
 /// #
 /// # #[derive(Debug, Serialize, Deserialize)]
 /// # struct Status { active: bool, message: String }
 /// # #[derive(Debug, Serialize, Deserialize)]
+/// # struct HealthInfo { healthy: bool, uptime: u64 }
+/// # #[derive(Debug, Serialize, Deserialize)]
 /// # #[serde(tag = "error")]
-/// # enum MyError { NotFound, InvalidRequest }
+/// # enum ServiceError { NotFound, InvalidRequest }
+/// # impl std::fmt::Display for ServiceError {
+/// #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+/// #         match self {
+/// #             Self::NotFound => write!(f, "Not found"),
+/// #             Self::InvalidRequest => write!(f, "Invalid input")
+/// #         }
+/// #     }
+/// # }
+/// # impl std::error::Error for ServiceError {}
 /// #
-/// #[proxy("com.example.MyService")]
-/// trait MyServiceProxy {
-///     async fn get_status(&mut self) -> zlink::Result<Result<Status, MyError>>;
+/// // Multiple proxies with owned return types.
+/// #[proxy("com.example.StatusService")]
+/// trait StatusProxy {
+///     async fn get_status(&mut self) -> zlink::Result<Result<Status, ServiceError>>;
 /// }
 ///
-/// // Owned reply types for cross-interface chaining (required by chain API).
-/// #[derive(Debug, Deserialize)]
-/// struct OwnedInfo {
-///     vendor: String,
-///     product: String,
-///     version: String,
-///     url: String,
-///     interfaces: Vec<String>,
+/// #[proxy("com.example.HealthService")]
+/// trait HealthProxy {
+///     async fn get_health(&mut self) -> zlink::Result<Result<HealthInfo, ServiceError>>;
 /// }
 ///
-/// #[derive(Debug, Deserialize)]
-/// struct OwnedInterfaceDescription {
-///     description: String,
-/// }
-///
+/// // Combined reply type for cross-interface chaining.
 /// #[derive(Debug, Deserialize)]
 /// #[serde(untagged)]
-/// enum OwnedCombinedReply {
-///     Info(OwnedInfo),
-///     InterfaceDescription(OwnedInterfaceDescription),
-///     MyService(Status),
+/// enum CombinedReply {
+///     Status(Status),
+///     Health(HealthInfo),
 /// }
 ///
-/// // For deserialization, we can use #[serde(untagged)] to combine error types.
-/// #[derive(Debug, Deserialize)]
-/// #[serde(untagged)]
-/// enum OwnedCombinedError {
-///     InterfaceNotFound { interface: String },
-///     MyService(MyError),
-/// }
-///
-/// // Example usage:
 /// # use zlink::test_utils::mock_socket::MockSocket;
 /// # let responses = vec![
-/// #     concat!(
-/// #         r#"{"parameters":{"vendor":"Test","product":"Example","version":"1.0","#,
-/// #         r#""url":"https://example.com","interfaces":["com.example.MyService","#,
-/// #         r#""org.varlink.service"]}}"#
-/// #     ),
 /// #     r#"{"parameters":{"active":true,"message":"Running"}}"#,
-/// #     r#"{"parameters":{"description":"interface com.example.MyService\n..."}}"#,
+/// #     r#"{"parameters":{"healthy":true,"uptime":12345}}"#,
 /// # ];
 /// # let socket = MockSocket::with_responses(&responses);
 /// # let mut conn = zlink::Connection::new(socket);
-/// use varlink_service::Proxy;
-/// use zlink::varlink_service::Chain;
-///
-/// // Get service info and custom status in one batch.
+/// // Chain calls across both services.
 /// let chain = conn
-///     .chain_get_info()?                                           // Varlink service interface
-///     .get_status()?                                               // MyService interface
-///     .get_interface_description("com.example.MyService")?;        // Back to Varlink service
+///     .chain_get_status()?
+///     .get_health()?;
 ///
-/// let replies = chain.send::<OwnedCombinedReply, OwnedCombinedError>().await?;
+/// let replies = chain.send::<CombinedReply, ServiceError>().await?;
+/// pin_mut!(replies);
+///
+/// let mut count = 0;
+/// while let Some((reply, _fds)) = replies.try_next().await? {
+///     count += 1;
+///     if let Ok(response) = reply {
+///         match response.parameters() {
+///             Some(CombinedReply::Status(s)) => println!("Status: {}", s.message),
+///             Some(CombinedReply::Health(h)) => println!("Uptime: {}", h.uptime),
+///             None => {}
+///         }
+///     }
+/// }
+/// assert_eq!(count, 2);
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 /// # }).unwrap();
-/// # }
 /// ```
 ///
 /// ## Chain Extension Traits

--- a/zlink-macros/src/proxy.rs
+++ b/zlink-macros/src/proxy.rs
@@ -264,7 +264,9 @@ fn build_chain_extension_trait(
     crate_path: &TokenStream,
     custom_chain_name: Option<syn::Ident>,
 ) -> TokenStream {
-    if chain_extension_methods.is_empty() {
+    // Skip generating chain trait if there are no methods and no custom name.
+    // When a custom name is specified, always generate the trait for API consistency.
+    if chain_extension_methods.is_empty() && custom_chain_name.is_none() {
         return quote! {};
     }
 

--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -5,7 +5,8 @@ use syn::{Error, FnArg, Pat};
 use super::{
     types::{ArgInfo, MethodAttrs},
     utils::{
-        convert_to_single_lifetime, snake_case_to_pascal_case, type_contains_lifetime, ParamAttrs,
+        convert_to_single_lifetime, parse_return_type, snake_case_to_pascal_case,
+        type_contains_lifetime, ParamAttrs,
     },
 };
 
@@ -23,8 +24,15 @@ pub(super) fn generate_chain_extension_method(
     // Check for explicit lifetimes early
     let has_explicit_lifetimes = method.sig.generics.lifetimes().next().is_some();
 
-    // Skip chain extension methods for oneway and streaming methods
-    if method_attrs.is_oneway || method_attrs.is_streaming {
+    // Skip chain extension methods for oneway, streaming, and return_fds methods.
+    if method_attrs.is_oneway || method_attrs.is_streaming || method_attrs.return_fds {
+        return Ok((quote! {}, quote! {}));
+    }
+
+    // Skip chain extension methods for methods with borrowed return types (non-static lifetimes).
+    // Chain API requires DeserializeOwned for reply and error types.
+    let (reply_type, error_type) = parse_return_type(&method.sig.output, false, false)?;
+    if type_contains_lifetime(&reply_type) || type_contains_lifetime(&error_type) {
         return Ok((quote! {}, quote! {}));
     }
 

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -5,7 +5,8 @@ use syn::{Error, FnArg, Pat};
 use super::{
     types::{ArgInfo, MethodAttrs},
     utils::{
-        convert_to_single_lifetime, snake_case_to_pascal_case, type_contains_lifetime, ParamAttrs,
+        convert_to_single_lifetime, parse_return_type, snake_case_to_pascal_case,
+        type_contains_lifetime, ParamAttrs,
     },
 };
 
@@ -32,6 +33,14 @@ pub(super) fn generate_chain_method(
     // Skip chain methods for oneway methods since they don't get replies
     // Also skip for methods that return FDs since chains don't support returning FDs
     if method_attrs.is_oneway || method_attrs.return_fds {
+        return Ok((quote! {}, quote! {}));
+    }
+
+    // Skip chain methods for methods with borrowed return types (non-static lifetimes).
+    // Chain API requires DeserializeOwned for reply and error types.
+    let (reply_type, error_type) =
+        parse_return_type(&method.sig.output, method_attrs.is_streaming, false)?;
+    if type_contains_lifetime(&reply_type) || type_contains_lifetime(&error_type) {
         return Ok((quote! {}, quote! {}));
     }
 

--- a/zlink-macros/src/proxy/utils.rs
+++ b/zlink-macros/src/proxy/utils.rs
@@ -24,17 +24,28 @@ pub(super) fn convert_to_single_lifetime(ty: &Type) -> Type {
     convert_type_lifetimes(ty, "'__proxy_params")
 }
 
-/// Check if a type contains any lifetime references.
+/// Check if a type contains any non-static lifetime references.
 /// This recursively checks all nested types.
+/// Note: `'static` lifetimes are not considered problematic for chain methods.
 pub(super) fn type_contains_lifetime(ty: &Type) -> bool {
     match ty {
-        Type::Reference(_) => true,
+        Type::Reference(type_ref) => {
+            // Check if it's a 'static reference
+            match &type_ref.lifetime {
+                Some(lt) if lt.ident == "static" => {
+                    // 'static is fine, but check the inner type
+                    type_contains_lifetime(&type_ref.elem)
+                }
+                Some(_) => true, // Non-static lifetime
+                None => true,    // Elided lifetime (treated as non-static)
+            }
+        }
         Type::Path(type_path) => type_path.path.segments.iter().any(|segment| {
             let PathArguments::AngleBracketed(args) = &segment.arguments else {
                 return false;
             };
             args.args.iter().any(|arg| match arg {
-                GenericArgument::Lifetime(_) => true,
+                GenericArgument::Lifetime(lt) => lt.ident != "static",
                 GenericArgument::Type(ty) => type_contains_lifetime(ty),
                 _ => false,
             })

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -110,11 +110,12 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
         assert_eq!(location.name, target);
 
         // Ask for the drive condition, then set them and then ask again.
+        // Use owned variants for chain methods (chain requires owned types).
         let replies = conn
             .chain_get_drive_condition()?
             .set_drive_condition(conditions[1])?
             .get_drive_condition()?
-            .send::<FtlReply, FtlError>()
+            .send::<OwnedFtlReply, FtlError>()
             .await?;
 
         // Now we should be able to get all the replies.
@@ -124,7 +125,8 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
             // First reply: initial drive condition
             let (reply, _fds) = replies.next().await.unwrap()?;
             let reply = reply.unwrap();
-            let Some(FtlReply::DriveCondition(drive_condition)) = reply.into_parameters() else {
+            let Some(OwnedFtlReply::DriveCondition(drive_condition)) = reply.into_parameters()
+            else {
                 panic!("Unexpected reply");
             };
             assert_eq!(drive_condition, conditions[0]);
@@ -132,7 +134,8 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
             // Second reply: confirmation of set_drive_condition
             let (reply, _fds) = replies.next().await.unwrap()?;
             let reply = reply.unwrap();
-            let Some(FtlReply::DriveCondition(drive_condition)) = reply.into_parameters() else {
+            let Some(OwnedFtlReply::DriveCondition(drive_condition)) = reply.into_parameters()
+            else {
                 panic!("Unexpected reply");
             };
             assert_eq!(drive_condition, conditions[1]);
@@ -140,7 +143,8 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
             // Third reply: get_drive_condition after the set
             let (reply, _fds) = replies.next().await.unwrap()?;
             let reply = reply.unwrap();
-            let Some(FtlReply::DriveCondition(drive_condition)) = reply.into_parameters() else {
+            let Some(OwnedFtlReply::DriveCondition(drive_condition)) = reply.into_parameters()
+            else {
                 panic!("Unexpected reply");
             };
             // Should match the current server state (after the set_drive_condition call)
@@ -152,9 +156,8 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
 
         let duration = 10;
         let impossible_speed = conditions[1].tylium_level / duration + 1;
+        // Use owned variants for chain methods.
         let replies = conn
-            // Let's try to jump to a new coordinate but first requiring more tylium
-            // than we have.
             .chain_jump(DriveConfiguration {
                 speed: impossible_speed,
                 trajectory: 1,
@@ -166,7 +169,7 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
                 trajectory: 1,
                 duration,
             })?
-            .send::<FtlReply, FtlError>()
+            .send::<OwnedFtlReply, FtlError>()
             .await?;
         pin_mut!(replies);
         let (result, _fds) = replies.try_next().await?.unwrap();
@@ -179,7 +182,7 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
         let reply = reply?;
         assert_eq!(
             reply.parameters(),
-            Some(&FtlReply::Coordinates(Coordinate {
+            Some(&OwnedFtlReply::Coordinates(Coordinate {
                 longitude: 1.0,
                 latitude: 0.0,
                 distance: 10,
@@ -197,10 +200,23 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
     Ok(())
 }
 
+// Owned versions for chain API (requires DeserializeOwned).
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+struct OwnedLocation {
+    name: String,
+    coordinates: Coordinate,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(untagged)]
+enum OwnedFtlReply {
+    DriveCondition(DriveCondition),
+    Coordinates(Coordinate),
+    Location(OwnedLocation),
+}
+
 #[zlink::proxy("org.example.ftl")]
 trait FtlProxy {
-    async fn get_drive_condition(&mut self) -> zlink::Result<Result<FtlReply<'_>, FtlError>>;
-
     #[zlink(more, rename = "GetDriveCondition")]
     async fn get_drive_condition_more(
         &mut self,
@@ -208,17 +224,20 @@ trait FtlProxy {
         impl futures_util::Stream<Item = zlink::Result<Result<FtlReply<'_>, FtlError>>>,
     >;
 
+    async fn locate(&mut self, target: &str) -> zlink::Result<Result<FtlReply<'_>, FtlError>>;
+
+    // Owned return type variants for chain API (chain methods are generated).
+    async fn get_drive_condition(&mut self) -> zlink::Result<Result<OwnedFtlReply, FtlError>>;
+
     async fn set_drive_condition(
         &mut self,
         condition: DriveCondition,
-    ) -> zlink::Result<Result<FtlReply<'_>, FtlError>>;
+    ) -> zlink::Result<Result<OwnedFtlReply, FtlError>>;
 
     async fn jump(
         &mut self,
         config: DriveConfiguration,
-    ) -> zlink::Result<Result<FtlReply<'_>, FtlError>>;
-
-    async fn locate(&mut self, target: &str) -> zlink::Result<Result<FtlReply<'_>, FtlError>>;
+    ) -> zlink::Result<Result<OwnedFtlReply, FtlError>>;
 }
 
 // The FTL service.


### PR DESCRIPTION
Since `ReplyStream` requires owned types, there is no point in generating chain variants of the methods when they return borrowed types (types with non-static lifetimes).
