### PR TITLE
⚡️ macros: `proxy` generates chain methods for oneway methods

### DIFF
--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -168,6 +168,8 @@ where
     ) -> crate::Result<Option<Service::ReplyStream>> {
         let mut stream = None;
         match self.service.handle(&call, conn).await {
+            // Don't send replies or errors for oneway calls.
+            MethodReply::Single(_) | MethodReply::Error(_) if call.oneway() => (),
             MethodReply::Single(params) => {
                 let reply = Reply::new(params).set_continues(Some(false));
                 conn.send_reply(&reply, vec![]).await?

--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -24,16 +24,19 @@ pub(super) fn generate_chain_extension_method(
     // Check for explicit lifetimes early
     let has_explicit_lifetimes = method.sig.generics.lifetimes().next().is_some();
 
-    // Skip chain extension methods for oneway, streaming, and return_fds methods.
-    if method_attrs.is_oneway || method_attrs.is_streaming || method_attrs.return_fds {
+    // Skip chain extension methods for streaming and return_fds methods.
+    if method_attrs.is_streaming || method_attrs.return_fds {
         return Ok((quote! {}, quote! {}));
     }
 
-    // Skip chain extension methods for methods with borrowed return types (non-static lifetimes).
+    // For non-oneway methods, skip if return types have borrowed types.
     // Chain API requires DeserializeOwned for reply and error types.
-    let (reply_type, error_type) = parse_return_type(&method.sig.output, false, false)?;
-    if type_contains_lifetime(&reply_type) || type_contains_lifetime(&error_type) {
-        return Ok((quote! {}, quote! {}));
+    // Oneway methods don't have return types so this check doesn't apply to them.
+    if !method_attrs.is_oneway {
+        let (reply_type, error_type) = parse_return_type(&method.sig.output, false, false)?;
+        if type_contains_lifetime(&reply_type) || type_contains_lifetime(&error_type) {
+            return Ok((quote! {}, quote! {}));
+        }
     }
 
     let converted_name = snake_case_to_pascal_case(&method_name_str);
@@ -112,6 +115,7 @@ pub(super) fn generate_chain_extension_method(
         generate_no_params_method(
             &method_ident,
             &method_path,
+            method_attrs.is_oneway,
             #[cfg(feature = "std")]
             fds_init,
             crate_path,
@@ -129,6 +133,7 @@ pub(super) fn generate_chain_extension_method(
             &method_where_clause,
             has_any_lifetime,
             has_explicit_lifetimes,
+            method_attrs.is_oneway,
             #[cfg(feature = "std")]
             fds_init,
             crate_path,
@@ -222,6 +227,7 @@ fn build_combined_where_clause(method_where_clause: &Option<syn::WhereClause>) -
 fn generate_no_params_method(
     method_name: &syn::Ident,
     method_path: &str,
+    is_oneway: bool,
     #[cfg(feature = "std")] fds_init: TokenStream,
     crate_path: &TokenStream,
 ) -> Result<(TokenStream, TokenStream), Error> {
@@ -239,21 +245,31 @@ fn generate_no_params_method(
     #[cfg(not(feature = "std"))]
     let append_args = quote! { &call };
 
+    let oneway = if is_oneway {
+        quote! { .set_oneway(true) }
+    } else {
+        quote! {}
+    };
+
+    let call_creation = quote! {
+        let call = #crate_path::Call::new({
+            #[derive(::serde::Serialize, ::core::fmt::Debug)]
+            #[serde(tag = "method")]
+            enum MethodWrapper {
+                #[serde(rename = #method_path)]
+                Method,
+            }
+            MethodWrapper::Method
+        }) #oneway;
+    };
+
     let impl_method = quote! {
         fn #method_name(
             self,
         ) -> #crate_path::Result<
             #crate_path::connection::chain::Chain<'c, S>
         > {
-            let call = #crate_path::Call::new({
-                #[derive(::serde::Serialize, ::core::fmt::Debug)]
-                #[serde(tag = "method")]
-                enum MethodWrapper {
-                    #[serde(rename = #method_path)]
-                    Method,
-                }
-                MethodWrapper::Method
-            });
+            #call_creation
             self.append(#append_args)
         }
     };
@@ -274,6 +290,7 @@ fn generate_with_params_method(
     method_where_clause: &Option<syn::WhereClause>,
     has_any_lifetime: bool,
     has_explicit_lifetimes: bool,
+    is_oneway: bool,
     #[cfg(feature = "std")] fds_init: TokenStream,
     crate_path: &TokenStream,
 ) -> Result<(TokenStream, TokenStream), Error> {
@@ -319,6 +336,36 @@ fn generate_with_params_method(
     #[cfg(not(feature = "std"))]
     let append_args = quote! { &call };
 
+    let method_call_expr = quote! {
+        {
+            #[derive(::serde::Serialize, ::core::fmt::Debug)]
+            struct #params_struct_name #generics
+            #struct_where
+            {
+                #(#regular_param_fields,)*
+            }
+
+            #[derive(::serde::Serialize, ::core::fmt::Debug)]
+            #[serde(tag = "method", content = "parameters")]
+            enum #wrapper_enum_name #struct_generics_without_bounds
+            #struct_where
+            {
+                #[serde(rename = #method_path)]
+                Method(#params_struct_name #struct_generics_without_bounds),
+            }
+
+            #wrapper_enum_name::Method(#params_struct_name {
+                #(#arg_names,)*
+            })
+        }
+    };
+
+    let call_creation = if is_oneway {
+        quote! { let call = #crate_path::Call::new(#method_call_expr).set_oneway(true); }
+    } else {
+        quote! { let call = #crate_path::Call::new(#method_call_expr); }
+    };
+
     let impl_method = quote! {
         fn #method_name #generics(
             self,
@@ -328,27 +375,7 @@ fn generate_with_params_method(
         >
         #combined_where_clause
         {
-            let call = #crate_path::Call::new({
-                #[derive(::serde::Serialize, ::core::fmt::Debug)]
-                struct #params_struct_name #generics
-                #struct_where
-                {
-                    #(#regular_param_fields,)*
-                }
-
-                #[derive(::serde::Serialize, ::core::fmt::Debug)]
-                #[serde(tag = "method", content = "parameters")]
-                enum #wrapper_enum_name #struct_generics_without_bounds
-                #struct_where
-                {
-                    #[serde(rename = #method_path)]
-                    Method(#params_struct_name #struct_generics_without_bounds),
-                }
-
-                #wrapper_enum_name::Method(#params_struct_name {
-                    #(#arg_names,)*
-                })
-            });
+            #call_creation
             self.append(#append_args)
         }
     };

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -30,18 +30,20 @@ pub(super) fn generate_chain_method(
     // Check for explicit lifetimes early
     let has_explicit_lifetimes = method.sig.generics.lifetimes().next().is_some();
 
-    // Skip chain methods for oneway methods since they don't get replies
-    // Also skip for methods that return FDs since chains don't support returning FDs
-    if method_attrs.is_oneway || method_attrs.return_fds {
+    // Skip chain methods for methods that return FDs since chains don't support returning FDs.
+    if method_attrs.return_fds {
         return Ok((quote! {}, quote! {}));
     }
 
-    // Skip chain methods for methods with borrowed return types (non-static lifetimes).
+    // For non-oneway methods, skip if return types have borrowed types.
     // Chain API requires DeserializeOwned for reply and error types.
-    let (reply_type, error_type) =
-        parse_return_type(&method.sig.output, method_attrs.is_streaming, false)?;
-    if type_contains_lifetime(&reply_type) || type_contains_lifetime(&error_type) {
-        return Ok((quote! {}, quote! {}));
+    // Oneway methods don't have return types so this check doesn't apply to them.
+    if !method_attrs.is_oneway {
+        let (reply_type, error_type) =
+            parse_return_type(&method.sig.output, method_attrs.is_streaming, false)?;
+        if type_contains_lifetime(&reply_type) || type_contains_lifetime(&error_type) {
+            return Ok((quote! {}, quote! {}));
+        }
     }
 
     // Generate chain method name
@@ -115,6 +117,7 @@ pub(super) fn generate_chain_method(
         &method_where_clause,
         has_any_lifetime,
         has_explicit_lifetimes,
+        method_attrs.is_oneway,
         crate_path,
     );
     #[cfg(feature = "std")]
@@ -211,6 +214,7 @@ fn generate_method_call_creation(
     method_where_clause: &Option<syn::WhereClause>,
     has_any_lifetime: bool,
     has_explicit_lifetimes: bool,
+    is_oneway: bool,
     crate_path: &TokenStream,
 ) -> MethodCallResult {
     // Separate FD parameters from regular parameters
@@ -299,7 +303,17 @@ fn generate_method_call_creation(
             let method_call = #wrapper_enum_name::Method(#params_struct_name {
                 #(#regular_arg_names,)*
             });
-            let call = #crate_path::Call::new(method_call);
+        };
+
+        let call_creation = if is_oneway {
+            quote! { let call = #crate_path::Call::new(method_call).set_oneway(true); }
+        } else {
+            quote! { let call = #crate_path::Call::new(method_call); }
+        };
+
+        let method_call_creation = quote! {
+            #method_call_creation
+            #call_creation
         };
 
         #[cfg(feature = "std")]
@@ -325,7 +339,17 @@ fn generate_method_call_creation(
             }
 
             let method_call = #wrapper_enum_name::Method;
-            let call = #crate_path::Call::new(method_call);
+        };
+
+        let call_creation = if is_oneway {
+            quote! { let call = #crate_path::Call::new(method_call).set_oneway(true); }
+        } else {
+            quote! { let call = #crate_path::Call::new(method_call); }
+        };
+
+        let method_call_creation = quote! {
+            #method_call_creation
+            #call_creation
         };
 
         #[cfg(feature = "std")]

--- a/zlink-macros/src/proxy/method_impl.rs
+++ b/zlink-macros/src/proxy/method_impl.rs
@@ -89,6 +89,18 @@ pub(super) fn generate_method_impl(
         )?
     };
 
+    // Streaming methods require owned return types (DeserializeOwned) because the internal buffer
+    // may be reused between stream iterations.
+    if method_attrs.is_streaming
+        && (type_contains_lifetime(&reply_type) || type_contains_lifetime(&error_type))
+    {
+        return Err(Error::new_spanned(
+            &method.sig.output,
+            "streaming methods (`more`) require owned return types (no non-static lifetimes) \
+             because the internal buffer may be reused between stream iterations",
+        ));
+    }
+
     // Generate the method parameters as an Option
     #[cfg(feature = "std")]
     let (params_struct_def, params_init, fds_init) = generate_method_params(

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -192,7 +192,7 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
 
     // `drive_monitor_conn` should have received the drive condition changes.
     let drive_cond = drive_monitor_stream.try_next().await?.unwrap()?;
-    let FtlReply::DriveCondition(condition) = drive_cond else {
+    let OwnedFtlReply::DriveCondition(condition) = drive_cond else {
         panic!("Expected DriveCondition reply");
     };
     assert_eq!(condition, conditions[1]);
@@ -217,13 +217,15 @@ enum OwnedFtlReply {
 
 #[zlink::proxy("org.example.ftl")]
 trait FtlProxy {
+    // Streaming methods require owned return types (DeserializeOwned).
     #[zlink(more, rename = "GetDriveCondition")]
     async fn get_drive_condition_more(
         &mut self,
     ) -> zlink::Result<
-        impl futures_util::Stream<Item = zlink::Result<Result<FtlReply<'_>, FtlError>>>,
+        impl futures_util::Stream<Item = zlink::Result<Result<OwnedFtlReply, FtlError>>>,
     >;
 
+    // Regular methods can use borrowed types.
     async fn locate(&mut self, target: &str) -> zlink::Result<Result<FtlReply<'_>, FtlError>>;
 
     // Owned return type variants for chain API (chain methods are generated).

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -103,10 +103,7 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
 
         // Locate a target.
         let target = "Alpha Centauri";
-        let reply = conn.locate(target).await.unwrap()?;
-        let FtlReply::Location(location) = reply else {
-            panic!("Unexpected reply");
-        };
+        let location = conn.locate(target).await.unwrap()?;
         assert_eq!(location.name, target);
 
         // Ask for the drive condition, then set them and then ask again.
@@ -226,7 +223,7 @@ trait FtlProxy {
     >;
 
     // Regular methods can use borrowed types.
-    async fn locate(&mut self, target: &str) -> zlink::Result<Result<FtlReply<'_>, FtlError>>;
+    async fn locate(&mut self, target: &str) -> zlink::Result<Result<Location<'_>, FtlError>>;
 
     // Owned return type variants for chain API (chain methods are generated).
     async fn get_drive_condition(&mut self) -> zlink::Result<Result<OwnedFtlReply, FtlError>>;

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -151,40 +151,95 @@ async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::er
             assert!(replies.next().await.is_none());
         }
 
-        let duration = 10;
-        let impossible_speed = conditions[1].tylium_level / duration + 1;
-        // Use owned variants for chain methods.
-        let replies = conn
-            .chain_jump(DriveConfiguration {
-                speed: impossible_speed,
-                trajectory: 1,
-                duration,
-            })?
-            // Now let's try to jump with a valid speed.
-            .jump(DriveConfiguration {
-                speed: impossible_speed - 1,
-                trajectory: 1,
-                duration,
-            })?
-            .send::<OwnedFtlReply, FtlError>()
-            .await?;
-        pin_mut!(replies);
-        let (result, _fds) = replies.try_next().await?.unwrap();
-        let e = result.unwrap_err();
-        // The first call should fail because we didn't have enough energy.
-        assert_eq!(e, FtlError::NotEnoughEnergy);
+        {
+            let duration = 10;
+            let impossible_speed = conditions[1].tylium_level / duration + 1;
+            // Use owned variants for chain methods.
+            let replies = conn
+                .chain_jump(DriveConfiguration {
+                    speed: impossible_speed,
+                    trajectory: 1,
+                    duration,
+                })?
+                // Now let's try to jump with a valid speed.
+                .jump(DriveConfiguration {
+                    speed: impossible_speed - 1,
+                    trajectory: 1,
+                    duration,
+                })?
+                .send::<OwnedFtlReply, FtlError>()
+                .await?;
+            pin_mut!(replies);
+            let (result, _fds) = replies.try_next().await?.unwrap();
+            let e = result.unwrap_err();
+            // The first call should fail because we didn't have enough energy.
+            assert_eq!(e, FtlError::NotEnoughEnergy);
 
-        // The second call should succeed.
-        let (reply, _fds) = replies.try_next().await?.unwrap();
-        let reply = reply?;
-        assert_eq!(
-            reply.parameters(),
-            Some(&OwnedFtlReply::Coordinates(Coordinate {
-                longitude: 1.0,
-                latitude: 0.0,
-                distance: 10,
-            }))
-        );
+            // The second call should succeed.
+            let (reply, _fds) = replies.try_next().await?.unwrap();
+            let reply = reply?;
+            assert_eq!(
+                reply.parameters(),
+                Some(&OwnedFtlReply::Coordinates(Coordinate {
+                    longitude: 1.0,
+                    latitude: 0.0,
+                    distance: 10,
+                }))
+            );
+        }
+
+        // Test oneway chain methods with a sandwich pattern to verify interleaving works.
+        // After the jump test above, coordinates should be (1.0, 0.0, 10).
+        // Pattern: get_coordinates -> reset_coordinates -> reset_coordinates -> get_coordinates
+        // This tests:
+        // 1. chain_get_coordinates() starts a chain with a regular call
+        // 2. reset_coordinates() chain extension is generated for oneway methods
+        // 3. Two consecutive oneway calls work correctly
+        // 4. Oneway calls are actually handled (coordinates change from non-zero to zero)
+        // 5. Only 2 replies are received (one per regular call, none for oneway)
+        {
+            let replies = conn
+                .chain_get_coordinates()?
+                .reset_coordinates()?
+                .reset_coordinates()?
+                .get_coordinates()?
+                .send::<OwnedFtlReply, FtlError>()
+                .await?;
+            pin_mut!(replies);
+
+            // First reply: coordinates before reset (non-zero from jump).
+            let (reply, _fds) = replies.next().await.unwrap()?;
+            let reply = reply.unwrap();
+            let Some(OwnedFtlReply::Coordinates(coords)) = reply.into_parameters() else {
+                panic!("Expected Coordinates reply");
+            };
+            assert_eq!(
+                coords,
+                Coordinate {
+                    longitude: 1.0,
+                    latitude: 0.0,
+                    distance: 10,
+                }
+            );
+
+            // Second reply: coordinates after reset (should be zero).
+            let (reply, _fds) = replies.next().await.unwrap()?;
+            let reply = reply.unwrap();
+            let Some(OwnedFtlReply::Coordinates(coords)) = reply.into_parameters() else {
+                panic!("Expected Coordinates reply");
+            };
+            assert_eq!(
+                coords,
+                Coordinate {
+                    longitude: 0.0,
+                    latitude: 0.0,
+                    distance: 0,
+                }
+            );
+
+            // No more replies - oneway calls don't generate replies.
+            assert!(replies.next().await.is_none());
+        }
     }
 
     // `drive_monitor_conn` should have received the drive condition changes.
@@ -237,6 +292,12 @@ trait FtlProxy {
         &mut self,
         config: DriveConfiguration,
     ) -> zlink::Result<Result<OwnedFtlReply, FtlError>>;
+
+    async fn get_coordinates(&mut self) -> zlink::Result<Result<OwnedFtlReply, FtlError>>;
+
+    // Oneway method - no reply expected. Chain methods are generated for these.
+    #[zlink(oneway)]
+    async fn reset_coordinates(&mut self) -> zlink::Result<()>;
 }
 
 // The FTL service.
@@ -330,6 +391,15 @@ impl Service for Ftl {
                     coordinates,
                 };
                 MethodReply::Single(Some(Reply::Ftl(FtlReply::Location(location))))
+            }
+            Method::Ftl(FtlMethod::ResetCoordinates) => {
+                // Oneway method - reset coordinates and don't send a reply.
+                self.coordinates = Coordinate {
+                    longitude: 0.0,
+                    latitude: 0.0,
+                    distance: 0,
+                };
+                MethodReply::Single(None)
             }
             Method::VarlinkSrv(VarlinkSrvMethod::GetInfo) => {
                 let interfaces = Vec::from_iter(INTERFACES.iter().cloned());
@@ -454,6 +524,7 @@ enum FtlMethod<'a> {
     GetCoordinates,
     Jump { config: DriveConfiguration },
     Locate { target: Cow<'a, str> },
+    ResetCoordinates,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
- **macros: `proxy` to require owned return types from streaming methods**
- **✅ zlink: Return more specific type**
- **⚡️ macros: `proxy` generates chain methods for oneway methods**
- **🐛 core: Don't send reply for `oneway` methods**
- **✅ zlink: Test oneway chained methods generated by `proxy` macro**

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
