### PR TITLE
Allow converting tokio unix listener into unix::Listener

### DIFF
--- a/zlink-tokio/src/unix/listener.rs
+++ b/zlink-tokio/src/unix/listener.rs
@@ -30,6 +30,12 @@ impl crate::Listener for Listener {
     }
 }
 
+impl From<tokio::net::UnixListener> for Listener {
+    fn from(listener: tokio::net::UnixListener) -> Self {
+        Listener { listener }
+    }
+}
+
 impl TryFrom<OwnedFd> for Listener {
     type Error = crate::Error;
 


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->

This PR includes a small `From` impl that makes my life a bit easier. Instead of rebinding to the socket by using its file descriptor, it just wraps an existing socket.
