### PR TITLE
core: fix docstring typos

### DIFF
--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -39,7 +39,7 @@ type RecvResult<T> = T;
 /// The low-level API to send and receive messages.
 ///
 /// Each connection gets a unique identifier when created that can be queried using
-/// [`Connection::id`]. This ID is shared betwen the read and write halves of the connection. It
+/// [`Connection::id`]. This ID is shared between the read and write halves of the connection. It
 /// can be used to associate the read and write halves of the same connection.
 ///
 /// # Cancel safety

--- a/zlink-core/src/connection/socket.rs
+++ b/zlink-core/src/connection/socket.rs
@@ -47,9 +47,9 @@ pub trait ReadHalf: core::fmt::Debug {
     ///
     /// * The future returned by this method must be cancel safe.
     /// * While there is no explicit `Unpin` bound on the future returned by this method, it is
-    ///   expected that it provides the same guarentees as `Unpin` would require. The reason `Unpin`
-    ///   is not explicitly requied is that it would force boxing (and therefore allocation) on the
-    ///   implemention that use `async fn`, which is undesirable for embedded use cases. See [this
+    ///   expected that it provides the same guarantees as `Unpin` would require. The reason `Unpin`
+    ///   is not explicitly required is that it would force boxing (and therefore allocation) on the
+    ///   implementation that use `async fn`, which is undesirable for embedded use cases. See [this
     ///   issue](https://github.com/rust-lang/rust/issues/82187) for details.
     fn read(&mut self, buf: &mut [u8]) -> impl Future<Output = crate::Result<ReadResult>>;
 }

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -23,7 +23,7 @@ where
     Listener: listener::Listener,
     Service: service::Service,
 {
-    /// Create a new server that serves `service` to incomming connections from `listener`.
+    /// Create a new server that serves `service` to incoming connections from `listener`.
     pub fn new(listener: Listener, service: Service) -> Self {
         Self {
             listener: Some(listener),
@@ -43,7 +43,8 @@ where
     /// Fortunately, there are easy workarounds for this. You can either:
     ///
     /// * Use a thread-local runtime (for example [`tokio::runtime::LocalRuntime`] or
-    ///   [`tokio::task::LocalSet`]) to run the server in a local task, perhaps in a seprate thread.
+    ///   [`tokio::task::LocalSet`]) to run the server in a local task, perhaps in a separate
+    ///   thread.
     /// * Use some common API to run multiple futures at once, such as [`futures::select!`] or
     ///   [`tokio::select!`].
     ///

--- a/zlink-core/src/server/service.rs
+++ b/zlink-core/src/server/service.rs
@@ -1,4 +1,4 @@
-//! Serice-related API.
+//! Service-related API.
 
 use core::{fmt::Debug, future::Future};
 


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->

This PR fixes a few typos in docstrings spread around `core`
