### PR TITLE
🤖 release-plz: Custom regex for minor version bump

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -12,6 +12,13 @@ git_tag_enable = true
 publish = true
 semver_check = true
 
+# Bump minor version for non-bugfix commits (gimoji).
+# Bugfixes (🐛🚑️🩹🥅) and docs (📝💡) remain as patches.
+# Emojis extracted from gimoji database with correct variation selectors.
+custom_minor_increment_regex = """\
+^(🎨|⚡️|🔥|✨|💄|🎉|✅|🔒️|💚|⬇️|⬆️|📌|👷|♻️|➕|➖|🔧|👽️|🚚|💥|♿️|💬|🔊|🔇|🚸|🏗️|🗑️|🧪)\
+"""
+
 # PR configuration.
 pr_name = "🔖 Releases"
 


### PR DESCRIPTION
Now that the latest `release-plz` allows specifying a regex to determine
if minor version should be bumped, let's make use of it.
