### PR TITLE
💥 core: Move `Sock` from `handle` to the trait in Service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "zlink"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "colored 3.0.0",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-codegen"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-macros"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "futures-util",
  "proc-macro2",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-smol"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-tokio"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "futures-util",
  "serde",

--- a/README.md
+++ b/README.md
@@ -187,14 +187,21 @@ impl Calculator {
 }
 
 // Implement the Service trait
-impl Service for Calculator {
+impl<Sock> Service<Sock> for Calculator
+where
+    Sock: Socket,
+{
     type MethodCall<'de> = CalculatorMethod;
-    type ReplyParams<'ser> = CalculatorReply<'ser>;
+    type ReplyParams<'ser> = CalculatorReply<'ser>
+    where
+        Self: 'ser;
     type ReplyStreamParams = ();
     type ReplyStream = futures_util::stream::Empty<zlink::Reply<()>>;
-    type ReplyError<'ser> = CalculatorError<'ser>;
+    type ReplyError<'ser> = CalculatorError<'ser>
+    where
+        Self: 'ser;
 
-    async fn handle<'service, Sock: Socket>(
+    async fn handle<'service>(
         &'service mut self,
         call: &'service Call<Self::MethodCall<'_>>,
         conn: &mut Connection<Sock>,

--- a/zlink-codegen/Cargo.toml
+++ b/zlink-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-codegen"
-version = "0.3.0"
+version = "0.4.0"
 description = "Utility to generate zlink code from varlink IDL files"
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ name = "zlink-codegen"
 path = "src/main.rs"
 
 [dependencies]
-zlink = { path = "../zlink", version = "0.3.0", features = [
+zlink = { path = "../zlink", version = "0.4.0", features = [
     "idl",
     "idl-parse",
 ] }

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-core"
-version = "0.3.0"
+version = "0.4.0"
 description = "The core crate of the zlink project"
 edition.workspace = true
 rust-version.workspace = true
@@ -20,7 +20,7 @@ introspection = ["std", "idl", "zlink-macros/introspection"]
 
 [dependencies]
 serde = { version = "1.0.218", default-features = false, features = ["derive", "alloc"] }
-zlink-macros = { path = "../zlink-macros", version = "=0.3.0" }
+zlink-macros = { path = "../zlink-macros", version = "=0.4.0" }
 serde_json = { version = "1.0.139", default-features = false, features = ["alloc"] }
 itoa = { version = "1.0", default-features = false }
 ryu = { version = "1.0", default-features = false }

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -21,7 +21,7 @@ pub struct Server<Listener, Service> {
 impl<Listener, Service> Server<Listener, Service>
 where
     Listener: listener::Listener,
-    Service: service::Service,
+    Service: service::Service<Listener::Socket>,
 {
     /// Create a new server that serves `service` to incoming connections from `listener`.
     pub fn new(listener: Listener, service: Service) -> Self {

--- a/zlink-core/src/server/service.rs
+++ b/zlink-core/src/server/service.rs
@@ -8,7 +8,10 @@ use serde::{Deserialize, Serialize};
 use crate::{connection::Socket, Call, Connection, Reply};
 
 /// Service trait for handling method calls.
-pub trait Service {
+pub trait Service<Sock>
+where
+    Sock: Socket,
+{
     /// The type of method call that this service handles.
     ///
     /// This should be a type that can deserialize itself from a complete method call message: i-e
@@ -41,7 +44,7 @@ pub trait Service {
         Self: 'ser;
 
     /// Handle a method call.
-    fn handle<'ser, Sock: Socket>(
+    fn handle<'ser>(
         &'ser mut self,
         method: &'ser Call<Self::MethodCall<'_>>,
         conn: &mut Connection<Sock>,

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-macros"
-version = "0.3.0"
+version = "0.4.0"
 description = "Macros providing the high-level zlink API"
 edition.workspace = true
 rust-version.workspace = true

--- a/zlink-smol/Cargo.toml
+++ b/zlink-smol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-smol"
-version = "0.3.0"
+version = "0.4.0"
 description = "zlink library for the smol runtime"
 edition.workspace = true
 rust-version.workspace = true
@@ -19,7 +19,7 @@ tracing = ["zlink-core/tracing"]
 defmt = ["zlink-core/defmt"]
 
 [dependencies]
-zlink-core = { path = "../zlink-core", version = "=0.3.0", default-features = false, features = ["std"] }
+zlink-core = { path = "../zlink-core", version = "=0.4.0", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
     "async-await",
     "alloc",

--- a/zlink-tokio/Cargo.toml
+++ b/zlink-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-tokio"
-version = "0.3.0"
+version = "0.4.0"
 description = "zlink library for the Tokio runtime"
 edition.workspace = true
 rust-version.workspace = true
@@ -19,7 +19,7 @@ tracing = ["zlink-core/tracing", "tokio/tracing"]
 defmt = ["zlink-core/defmt"]
 
 [dependencies]
-zlink-core = { path = "../zlink-core", version = "=0.3.0", default-features = false, features = ["std"] }
+zlink-core = { path = "../zlink-core", version = "=0.4.0", default-features = false, features = ["std"] }
 tokio = { version = "1.44.0", features = ["net", "io-util"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
     "async-await",

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink"
-version = "0.3.0"
+version = "0.4.0"
 description = "Async Varlink API"
 edition.workspace = true
 rust-version.workspace = true
@@ -21,8 +21,8 @@ tracing = ["zlink-tokio?/tracing", "zlink-smol?/tracing"]
 defmt = ["zlink-tokio?/defmt", "zlink-smol?/defmt"]
 
 [dependencies]
-zlink-tokio = { path = "../zlink-tokio", version = "=0.3.0", default-features = false, optional = true }
-zlink-smol = { path = "../zlink-smol", version = "=0.3.0", default-features = false, optional = true }
+zlink-tokio = { path = "../zlink-tokio", version = "=0.4.0", default-features = false, optional = true }
+zlink-smol = { path = "../zlink-smol", version = "=0.4.0", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.44.0", features = [

--- a/zlink/tests/creds-utils.rs
+++ b/zlink/tests/creds-utils.rs
@@ -1,0 +1,82 @@
+//! Shared utilities for peer credentials verification in tests.
+
+#![cfg(feature = "server")]
+
+use rustix::process::Pid;
+use zlink::connection::Credentials;
+
+/// Verify that the given credentials match the current process.
+///
+/// Returns `Ok(())` if all checks pass, or `Err(message)` describing the failure.
+pub fn verify_credentials(creds: &Credentials) -> Result<(), &'static str> {
+    verify_uid(creds)?;
+    verify_pid(creds)?;
+    #[cfg(target_os = "linux")]
+    verify_pidfd(creds)?;
+    Ok(())
+}
+
+/// Verify UID matches current process.
+pub fn verify_uid(creds: &Credentials) -> Result<(), &'static str> {
+    let expected_uid = rustix::process::getuid();
+    if creds.unix_user_id() != expected_uid {
+        return Err("UID does not match current process");
+    }
+    Ok(())
+}
+
+/// Verify PID matches current process.
+///
+/// On FreeBSD < 13 and DragonFly BSD, PID may be 0.
+pub fn verify_pid(creds: &Credentials) -> Result<(), &'static str> {
+    let expected_pid = rustix::process::getpid();
+    let pid_ok = is_pid_valid(creds.process_id(), expected_pid);
+    if !pid_ok {
+        return Err("PID does not match current process");
+    }
+    Ok(())
+}
+
+/// Check if the credential PID matches expected, accounting for platform quirks.
+fn is_pid_valid(actual: Pid, expected: Pid) -> bool {
+    #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
+    {
+        // FreeBSD 13+ has PID support, older versions return 0.
+        // DragonFly BSD currently returns 0 (PID support TBD).
+        actual == expected || actual == Pid::from_raw(0).unwrap()
+    }
+    #[cfg(not(any(target_os = "freebsd", target_os = "dragonfly")))]
+    {
+        actual == expected
+    }
+}
+
+/// Verify pidfd refers to the current process (Linux only).
+#[cfg(target_os = "linux")]
+pub fn verify_pidfd(creds: &Credentials) -> Result<(), &'static str> {
+    use std::os::fd::{AsFd, AsRawFd};
+
+    let fd_num = creds.process_fd().as_fd().as_raw_fd();
+    if fd_num < 0 {
+        return Err("Process FD is invalid");
+    }
+
+    // Read /proc/self/fdinfo to verify pidfd refers to correct process.
+    let fdinfo_path = format!("/proc/self/fdinfo/{}", fd_num);
+    let fdinfo =
+        std::fs::read_to_string(&fdinfo_path).map_err(|_| "Failed to read fdinfo for pidfd")?;
+
+    let expected_pid = rustix::process::getpid();
+    let pid_matches = fdinfo
+        .lines()
+        .find(|line| line.starts_with("Pid:"))
+        .and_then(|line| line.strip_prefix("Pid:"))
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .and_then(Pid::from_raw)
+        .is_some_and(|pid| pid == expected_pid);
+
+    if !pid_matches {
+        return Err("pidfd does not refer to the current process");
+    }
+    Ok(())
+}

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -322,14 +322,20 @@ impl Ftl {
     }
 }
 
-impl Service for Ftl {
+impl<Sock: Socket> Service<Sock> for Ftl {
     type MethodCall<'de> = Method<'de>;
-    type ReplyParams<'ser> = Reply<'ser>;
+    type ReplyParams<'ser>
+        = Reply<'ser>
+    where
+        Self: 'ser;
     type ReplyStream = notified::Stream<Self::ReplyStreamParams>;
     type ReplyStreamParams = FtlReply<'static>;
-    type ReplyError<'ser> = ReplyError<'ser>;
+    type ReplyError<'ser>
+        = ReplyError<'ser>
+    where
+        Self: 'ser;
 
-    async fn handle<'service, Sock: Socket>(
+    async fn handle<'service>(
         &'service mut self,
         call: &'service Call<Self::MethodCall<'_>>,
         _conn: &mut Connection<Sock>,

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -302,14 +302,23 @@ mod server {
         Machined(MachinedError),
     }
 
-    impl Service for MockMachinedService {
+    impl<Sock> Service<Sock> for MockMachinedService
+    where
+        Sock: Socket,
+    {
         type MethodCall<'de> = Method<'de>;
-        type ReplyParams<'ser> = Reply<'ser>;
+        type ReplyParams<'ser>
+            = Reply<'ser>
+        where
+            Self: 'ser;
         type ReplyStream = futures_util::stream::Empty<zlink::Reply<()>>;
         type ReplyStreamParams = ();
-        type ReplyError<'ser> = MockError<'ser>;
+        type ReplyError<'ser>
+            = MockError<'ser>
+        where
+            Self: 'ser;
 
-        async fn handle<'service, Sock: Socket>(
+        async fn handle<'service>(
             &'service mut self,
             call: &'service Call<Self::MethodCall<'_>>,
             _conn: &mut Connection<Sock>,

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -137,6 +137,8 @@ pub enum MachinedError {
     NotSupported,
     /// There is no IPC service (such as system bus or varlink) in the container.
     NoIPC,
+    /// Failed to fetch peer credentials.
+    FetchPeerCredentialsFailed,
 }
 
 impl core::fmt::Display for MachinedError {
@@ -157,6 +159,9 @@ impl core::fmt::Display for MachinedError {
             MachinedError::NotAvailable => write!(f, "Requested information is not available"),
             MachinedError::NotSupported => write!(f, "Requested operation is not supported"),
             MachinedError::NoIPC => write!(f, "There is no IPC service in the container"),
+            MachinedError::FetchPeerCredentialsFailed => {
+                write!(f, "Failed to fetch peer credentials")
+            }
         }
     }
 }
@@ -168,11 +173,15 @@ impl core::error::Error for MachinedError {}
 // ============================================================================
 
 #[cfg(feature = "server")]
+#[path = "creds-utils.rs"]
+mod creds_utils;
+
+#[cfg(feature = "server")]
 mod server {
     use super::*;
     use serde_prefix_all::prefix_all;
     use zlink::{
-        connection::Socket,
+        connection::{socket::FetchPeerCredentials, Socket},
         idl::{self, Comment, Interface, Parameter},
         service::MethodReply,
         varlink_service::{self, Error, Info, InterfaceDescription},
@@ -305,6 +314,7 @@ mod server {
     impl<Sock> Service<Sock> for MockMachinedService
     where
         Sock: Socket,
+        Sock::ReadHalf: FetchPeerCredentials,
     {
         type MethodCall<'de> = Method<'de>;
         type ReplyParams<'ser>
@@ -321,9 +331,21 @@ mod server {
         async fn handle<'service>(
             &'service mut self,
             call: &'service Call<Self::MethodCall<'_>>,
-            _conn: &mut Connection<Sock>,
+            conn: &mut Connection<Sock>,
         ) -> MethodReply<Self::ReplyParams<'service>, Self::ReplyStream, Self::ReplyError<'service>>
         {
+            let Ok(creds) = conn.peer_credentials().await else {
+                return MethodReply::Error(MockError::Machined(
+                    MachinedError::FetchPeerCredentialsFailed,
+                ));
+            };
+            // Verify credentials match current process.
+            if creds_utils::verify_credentials(&creds).is_err() {
+                return MethodReply::Error(MockError::Machined(
+                    MachinedError::FetchPeerCredentialsFailed,
+                ));
+            }
+
             match call.method() {
                 Method::VarlinkService(varlink_service::Method::GetInfo) => {
                     // Return hardcoded info that matches the systemd machine service

--- a/zlink/tests/peer_credentials.rs
+++ b/zlink/tests/peer_credentials.rs
@@ -2,16 +2,15 @@
 
 #![cfg(feature = "server")]
 
-use std::os::fd::{AsFd, AsRawFd};
+#[path = "creds-utils.rs"]
+mod creds_utils;
+
+use std::os::fd::AsRawFd;
 use tempfile::TempDir;
 use zlink::Listener;
 
 #[tokio::test]
 async fn peer_credentials_unix_socket() {
-    // Get the expected credentials of the current process.
-    let expected_uid = rustix::process::getuid();
-    let expected_pid = rustix::process::getpid();
-
     // Create a temporary directory for the socket.
     let temp_dir = TempDir::new().unwrap();
     let socket_path = temp_dir.path().join("test_creds.sock");
@@ -32,71 +31,8 @@ async fn peer_credentials_unix_socket() {
     // Get peer credentials.
     let creds = connection.peer_credentials().await.unwrap();
 
-    // Verify we got the correct credentials.
-    assert_eq!(
-        creds.unix_user_id(),
-        expected_uid,
-        "UID should match current process"
-    );
-
-    // On most platforms, we can get the actual PID.
-    // Exception: FreeBSD < 13 and DragonFly BSD (where it's 0).
-    #[cfg(any(
-        target_os = "linux",
-        target_os = "android",
-        target_os = "macos",
-        target_os = "ios",
-        target_os = "openbsd",
-        target_os = "netbsd"
-    ))]
-    assert_eq!(
-        creds.process_id(),
-        expected_pid,
-        "PID should match current process"
-    );
-
-    #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
-    {
-        // FreeBSD 13+ has PID support, older versions return 0.
-        // DragonFly BSD currently returns 0 (PID support TBD).
-        let pid = creds.process_id();
-        assert!(
-            pid == expected_pid || pid == rustix::process::Pid::from_raw(0).unwrap(),
-            "PID should be either the actual PID or 0 on older FreeBSD/DragonFly"
-        );
-    }
-
-    // On Linux, we expect a valid process FD (pidfd) on recent kernels.
-    #[cfg(target_os = "linux")]
-    {
-        let pidfd = creds.process_fd();
-
-        // Verify the pidfd is valid by checking if we can use it.
-        let fd_num = pidfd.as_fd().as_raw_fd();
-        assert!(fd_num >= 0, "Process FD should be valid");
-
-        // Verify the pidfd refers to the correct process by reading /proc/self/fdinfo.
-        let fdinfo_path = format!("/proc/self/fdinfo/{}", fd_num);
-        let fdinfo = std::fs::read_to_string(&fdinfo_path).unwrap();
-        // The fdinfo should contain "Pid:" followed by our PID.
-
-        use rustix::process::Pid;
-        let pid_line = fdinfo
-            .lines()
-            .find(|line| line.starts_with("Pid:"))
-            .expect("fdinfo should contain Pid field");
-        let pid = pid_line
-            .strip_prefix("Pid:")
-            .unwrap()
-            .trim()
-            .parse::<i32>()
-            .expect("Pid field should be a valid number");
-        let pid = Pid::from_raw(pid).unwrap();
-        assert_eq!(
-            pid, expected_pid,
-            "pidfd should refer to the correct process"
-        );
-    }
+    // Verify all credentials match current process using shared utilities.
+    creds_utils::verify_credentials(&creds).expect("Credentials should match current process");
 
     // Save values for comparison.
     let uid1 = creds.unix_user_id();


### PR DESCRIPTION
Otherwise, users can't add their own constraints on their service implementations or implement the service for concrete socket types. The former means that the peer credentials API is unavailable in the `handle` method, which is the primary use-case.

Fixes #207.
