### PR TITLE
✨ macros: Add `service` attribute macro

### DIFF
--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -13,6 +13,7 @@ default = ["std", "server", "proxy", "tracing"]
 std = ["dep:rustix", "dep:libc", "zlink-macros/std"]
 server = []
 proxy = ["zlink-macros/proxy"]
+service = ["server", "zlink-macros/service"]
 # IDL and introspection support
 idl = []
 idl-parse = ["idl", "dep:winnow", "zlink-macros/idl-parse"]

--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -47,6 +47,9 @@ pub mod varlink_service;
 #[cfg(feature = "proxy")]
 pub use zlink_macros::proxy;
 
+#[cfg(feature = "service")]
+pub use zlink_macros::service;
+
 pub use zlink_macros::ReplyError;
 
 #[cfg(feature = "std")]

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -29,7 +29,7 @@ syn = { version = "2.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-zlink = { path = "../zlink", default-features = false, features = ["tokio", "introspection"] }
+zlink = { path = "../zlink", default-features = false, features = ["tokio", "introspection", "tracing", "proxy"] }
 serde = "1.0"
 serde_json = "1.0"
 serde-json-core = { version = "0.6.0", default-features = false, features = [

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -15,6 +15,7 @@ proc-macro = true
 default = ["proxy"]
 std = []
 proxy = ["syn/full", "syn/clone-impls"]
+service = ["syn/full", "syn/clone-impls"]
 idl-parse = []
 introspection = []
 
@@ -29,7 +30,7 @@ syn = { version = "2.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-zlink = { path = "../zlink", default-features = false, features = ["tokio", "introspection", "tracing", "proxy"] }
+zlink = { path = "../zlink", default-features = false, features = ["tokio", "introspection", "tracing", "proxy", "service"] }
 serde = "1.0"
 serde_json = "1.0"
 serde-json-core = { version = "0.6.0", default-features = false, features = [

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -20,6 +20,9 @@ mod reply_error;
 #[cfg(feature = "proxy")]
 mod proxy;
 
+#[cfg(feature = "service")]
+mod service;
+
 /// Derives `Type` for structs and enums, generating appropriate `Type::Object` or `Type::Enum`
 /// representation.
 ///
@@ -983,4 +986,279 @@ pub fn proxy(
 #[proc_macro_derive(ReplyError, attributes(zlink))]
 pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     reply_error::derive_reply_error(input)
+}
+
+/// Transforms an impl block into a `Service` trait implementation.
+///
+/// **Requires the `service` feature to be enabled.**
+///
+/// This attribute macro takes a regular impl block and generates the necessary code to implement
+/// the `Service` trait, enabling the type to handle Varlink method calls.
+///
+/// # Supported Attributes
+///
+/// ## On the impl block:
+///
+/// * `crate = "path"` - Specifies the crate path to use for zlink types. Defaults to `::zlink`.
+///
+/// ## On methods:
+///
+/// * `#[zlink(interface = "...")]` - Set the interface name for this and subsequent methods.
+/// * `#[zlink(rename = "MethodName")]` - Custom Varlink method name.
+///
+/// ## On parameters:
+///
+/// * `#[zlink(rename = "paramName")]` - Custom serialized parameter name.
+/// * `#[zlink(connection)]` - Mark this parameter to receive a mutable reference to the connection.
+///   This is useful for accessing peer credentials or other connection-specific functionality.
+///   **Requires an explicit generic socket type parameter** (e.g., `impl<Sock> MyService`).
+///
+/// # Generated Code
+///
+/// The macro generates:
+/// 1. A `{TypeName}MethodCall` enum for deserializing incoming method calls.
+/// 2. A `{TypeName}ReplyParams` enum for serializing outgoing replies.
+/// 3. A `{TypeName}ReplyError` combo enum that wraps all error types used by methods. This enum
+///    uses `#[serde(untagged)]` for transparent serialization.
+/// 4. An `impl<Sock: Socket> Service<Sock> for YourType` with the `handle` method.
+///
+/// # Error Handling
+///
+/// Methods can return `Result<T, E>` with any error type `E` that implements `Serialize` and
+/// `Debug`. Different methods can use different error types - the macro automatically generates a
+/// combo enum (`{TypeName}ReplyError`) that wraps all unique error types, with `From` impls for
+/// each type.
+///
+/// When a method returns `Err(e)`, the macro generates code that wraps it in the appropriate
+/// combo enum variant and returns `MethodReply::Error(...)`.
+/// When a method returns `Ok(v)`, it returns `MethodReply::Single(Some(v))`.
+///
+/// Methods can also return plain values (not wrapped in Result) - these are always treated as
+/// successful responses.
+///
+/// # Custom Socket Bounds
+///
+/// By default, the generated `Service` impl uses a generic socket parameter with just the `Socket`
+/// bound. If you need additional bounds (e.g., for peer credential checking), you can provide your
+/// own generics on the impl block:
+///
+/// ```rust
+/// use zlink::{service, connection::socket::FetchPeerCredentials};
+/// use serde::Serialize;
+///
+/// struct MyService;
+///
+/// #[derive(Debug, Serialize)]
+/// struct MyError;
+///
+/// #[service]
+/// impl<Sock> MyService
+/// where
+///     Sock::ReadHalf: FetchPeerCredentials,
+/// {
+///     #[zlink(interface = "org.example.service")]
+///     async fn get_status(&self) -> Result<(), MyError> {
+///         Ok(())
+///     }
+/// }
+/// ```
+///
+/// The first type parameter is used as the socket type for the generated `Service` impl. The
+/// `Socket` bound is automatically added, so you only need to specify additional bounds.
+///
+/// # Connection Parameter
+///
+/// Methods can receive a mutable reference to the connection using `#[zlink(connection)]`:
+///
+/// ```rust
+/// use zlink::{service, Connection, connection::socket::FetchPeerCredentials};
+/// use serde::Serialize;
+///
+/// struct MyService;
+///
+/// #[derive(Debug, Serialize)]
+/// struct MyError;
+///
+/// #[service]
+/// impl<Sock> MyService
+/// where
+///     Sock::ReadHalf: FetchPeerCredentials,
+/// {
+///     #[zlink(interface = "org.example.service")]
+///     async fn check_credentials(
+///         &self,
+///         #[zlink(connection)] conn: &mut Connection<Sock>,
+///     ) -> Result<(), MyError> {
+///         let _creds = conn.peer_credentials().await;
+///         Ok(())
+///     }
+/// }
+/// ```
+///
+/// Methods with connection parameters are only callable through the `Service` trait (not directly
+/// on the type), since they require the socket type to be known.
+///
+/// # Example
+///
+/// ```rust
+/// use zlink::{
+///     service,
+///     unix::{bind, connect},
+///     Server,
+/// };
+/// use serde::{Deserialize, Serialize};
+///
+/// // Response type for balance operations.
+/// #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+/// struct Balance {
+///     amount: i64,
+/// }
+///
+/// // Error type - must derive zlink::ReplyError for proper serialization.
+/// #[derive(Debug, Clone, PartialEq, zlink::ReplyError)]
+/// #[zlink(interface = "org.example.bank")]
+/// enum BankError {
+///     InsufficientFunds { available: i64, requested: i64 },
+///     InvalidAmount { amount: i64 },
+///     AccountLocked,
+/// }
+///
+/// struct BankAccount {
+///     balance: i64,
+///     locked: bool,
+/// }
+///
+/// impl BankAccount {
+///     fn new(initial_balance: i64) -> Self {
+///         Self { balance: initial_balance, locked: false }
+///     }
+/// }
+///
+/// // Service implementation with error handling.
+/// #[service]
+/// impl BankAccount {
+///     // Method that returns a plain value (not Result) - always succeeds.
+///     #[zlink(interface = "org.example.bank")]
+///     async fn get_balance(&self) -> Balance {
+///         Balance { amount: self.balance }
+///     }
+///
+///     // Method that can fail - returns Result<Balance, BankError>.
+///     async fn deposit(&mut self, amount: i64) -> Result<Balance, BankError> {
+///         if self.locked {
+///             return Err(BankError::AccountLocked);
+///         }
+///         if amount <= 0 {
+///             return Err(BankError::InvalidAmount { amount });
+///         }
+///         self.balance += amount;
+///         Ok(Balance { amount: self.balance })
+///     }
+///
+///     async fn withdraw(&mut self, amount: i64) -> Result<Balance, BankError> {
+///         if self.locked {
+///             return Err(BankError::AccountLocked);
+///         }
+///         if amount <= 0 {
+///             return Err(BankError::InvalidAmount { amount });
+///         }
+///         if amount > self.balance {
+///             return Err(BankError::InsufficientFunds {
+///                 available: self.balance,
+///                 requested: amount,
+///             });
+///         }
+///         self.balance -= amount;
+///         Ok(Balance { amount: self.balance })
+///     }
+///
+///     // Method returning Result<(), E> - void success, can fail.
+///     async fn lock_account(&mut self) -> Result<(), BankError> {
+///         if self.locked {
+///             return Err(BankError::AccountLocked);
+///         }
+///         self.locked = true;
+///         Ok(())
+///     }
+/// }
+///
+/// // Client-side proxy definition.
+/// #[zlink::proxy("org.example.bank")]
+/// trait BankProxy {
+///     async fn get_balance(&mut self) -> zlink::Result<Result<Balance, BankError>>;
+///     async fn deposit(&mut self, amount: i64) -> zlink::Result<Result<Balance, BankError>>;
+///     async fn withdraw(&mut self, amount: i64) -> zlink::Result<Result<Balance, BankError>>;
+///     async fn lock_account(&mut self) -> zlink::Result<Result<(), BankError>>;
+/// }
+///
+/// # tokio::runtime::Runtime::new().unwrap().block_on(async {
+/// // Server setup.
+/// let socket_path = "/tmp/zlink-service-example.sock";
+/// let _ = std::fs::remove_file(socket_path);
+/// let listener = bind(socket_path)?;
+/// let service = BankAccount::new(1000);
+/// let server = Server::new(listener, service);
+///
+/// // Run server and client concurrently.
+/// tokio::select! {
+///     res = server.run() => res?,
+///     res = async {
+///         let mut conn = connect(socket_path).await?;
+///
+///         // Check initial balance.
+///         let balance = conn.get_balance().await?.unwrap();
+///         assert_eq!(balance.amount, 1000);
+///
+///         // Successful deposit.
+///         let balance = conn.deposit(500).await?.unwrap();
+///         assert_eq!(balance.amount, 1500);
+///
+///         // Successful withdrawal.
+///         let balance = conn.withdraw(200).await?.unwrap();
+///         assert_eq!(balance.amount, 1300);
+///
+///         // Error: withdraw more than available.
+///         let err = conn.withdraw(5000).await?.unwrap_err();
+///         assert_eq!(err, BankError::InsufficientFunds { available: 1300, requested: 5000 });
+///
+///         // Error: invalid amount.
+///         let err = conn.deposit(-100).await?.unwrap_err();
+///         assert_eq!(err, BankError::InvalidAmount { amount: -100 });
+///
+///         // Lock account and verify subsequent operations fail.
+///         conn.lock_account().await?.unwrap();
+///         let err = conn.withdraw(100).await?.unwrap_err();
+///         assert_eq!(err, BankError::AccountLocked);
+///
+///         Ok::<(), Box<dyn std::error::Error>>(())
+///     } => res?,
+/// }
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// # })?;
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+/// ```
+///
+/// # Method Name Conversion
+///
+/// By default, method names are converted from snake_case to PascalCase for the Varlink call.
+/// For example, `get_balance` becomes `GetBalance`. Use `#[zlink(rename = "...")]` to override
+/// this.
+///
+/// # Full Method Path
+///
+/// The full Varlink method path is constructed as `{interface}.{MethodName}`. For example,
+/// if the interface is `org.example.bank` and the method is `GetBalance`, the full path
+/// will be `org.example.bank.GetBalance`.
+///
+/// # Interface Propagation
+///
+/// Once an interface is set with `#[zlink(interface = "...")]`, it applies to that method and
+/// all subsequent methods until another interface attribute is encountered.
+#[cfg(feature = "service")]
+#[proc_macro_attribute]
+pub fn service(
+    attr: proc_macro::TokenStream,
+    input: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    service::service(attr.into(), input.into()).into()
 }

--- a/zlink-macros/src/service/attrs.rs
+++ b/zlink-macros/src/service/attrs.rs
@@ -1,0 +1,45 @@
+//! Service macro attribute parsing.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse::Parser, Error, ItemImpl};
+
+/// Attributes parsed from the `#[service(...)]` macro invocation.
+pub(super) struct ServiceAttrs {
+    /// The crate path to use (defaults to `::zlink`).
+    pub crate_path: TokenStream,
+}
+
+impl ServiceAttrs {
+    /// Parse attributes from the macro attribute token stream.
+    pub(super) fn parse(attr: &TokenStream, item_impl: &ItemImpl) -> Result<Self, Error> {
+        let mut crate_path = None;
+
+        if !attr.is_empty() {
+            let parser = syn::meta::parser(|meta| {
+                if meta.path.is_ident("crate") {
+                    let value: syn::LitStr = meta.value()?.parse()?;
+                    let path_str = value.value();
+                    crate_path = Some(syn::parse_str(&path_str)?);
+                } else {
+                    return Err(meta.error("unsupported service attribute"));
+                }
+                Ok(())
+            });
+
+            parser.parse2(attr.clone()).map_err(|e| {
+                Error::new_spanned(
+                    item_impl,
+                    format!(
+                        "failed to parse service attributes: {e}. Expected: \
+                         #[service] or #[service(crate = \"path\")]"
+                    ),
+                )
+            })?;
+        }
+
+        Ok(Self {
+            crate_path: crate_path.unwrap_or_else(|| quote! { ::zlink }),
+        })
+    }
+}

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -1,0 +1,568 @@
+//! Code generation for the service macro.
+
+use std::collections::HashMap;
+
+use proc_macro2::{Ident, TokenStream};
+use quote::{format_ident, quote};
+use syn::{Error, GenericParam, ItemImpl, Type};
+
+use super::{attrs::ServiceAttrs, method::MethodInfo};
+
+/// Extract a simple type name from a Type for generating auxiliary type names.
+fn extract_type_name(ty: &Type) -> Option<String> {
+    match ty {
+        Type::Path(type_path) => type_path
+            .path
+            .segments
+            .last()
+            .map(|seg| seg.ident.to_string()),
+        _ => None,
+    }
+}
+
+/// Generate the Service trait implementation.
+pub(super) fn generate_service_impl(
+    item_impl: &ItemImpl,
+    methods_info: &[MethodInfo],
+    service_attrs: &ServiceAttrs,
+) -> Result<TokenStream, Error> {
+    let crate_path = &service_attrs.crate_path;
+    let self_ty = &item_impl.self_ty;
+
+    // Extract the type name for generating auxiliary type names.
+    let type_name = extract_type_name(self_ty).unwrap_or_else(|| "Service".to_string());
+    let method_call_name = format_ident!("{}MethodCall", type_name);
+    let reply_params_name = format_ident!("{}ReplyParams", type_name);
+    let reply_error_name = format_ident!("{}ReplyError", type_name);
+
+    // Generate the MethodCall enum.
+    let method_call_enum = generate_method_call_enum(methods_info, &method_call_name)?;
+
+    // Generate the Reply enum for parameters.
+    let reply_params_enum =
+        generate_reply_params_enum(methods_info, &method_call_name, &reply_params_name)?;
+
+    // Generate the combo ReplyError enum.
+    let (reply_error_enum, error_type_map) =
+        generate_reply_error_enum(methods_info, &reply_error_name);
+
+    // Determine the error type to use in the Service impl.
+    let has_result_methods = methods_info.iter().any(|m| m.returns_result);
+    let error_type: syn::Type = if has_result_methods {
+        syn::parse_quote!(#reply_error_name)
+    } else {
+        syn::parse_quote!(())
+    };
+
+    // Generate the handle method body.
+    let handle_body = generate_handle_body(
+        methods_info,
+        crate_path,
+        &method_call_name,
+        &reply_params_name,
+        &reply_error_name,
+        &error_type_map,
+    )?;
+
+    // Extract socket type parameter: use user-provided first type param, or default to __ZlinkSock.
+    let (socket_ty, generics, user_where_clause) = item_impl
+        .generics
+        .params
+        .iter()
+        .find_map(|p| match p {
+            GenericParam::Type(ty) => Some((
+                ty.ident.clone(),
+                item_impl.generics.clone(),
+                item_impl.generics.where_clause.clone(),
+            )),
+            _ => None,
+        })
+        .unwrap_or_else(|| {
+            let default_ident: Ident = format_ident!("__ZlinkSock");
+            let mut generics = syn::Generics::default();
+            generics
+                .params
+                .push(GenericParam::Type(syn::TypeParam::from(
+                    default_ident.clone(),
+                )));
+            (default_ident, generics, None)
+        });
+
+    // Build the where clause: always add Socket bound, then user's additional predicates.
+    let user_predicates = user_where_clause.map(|w| w.predicates).unwrap_or_default();
+    let where_clause = quote! {
+        where
+            #socket_ty: #crate_path::connection::Socket,
+            #user_predicates
+    };
+
+    // Generate the impl block.
+    let service_impl = quote! {
+        impl #generics #crate_path::Service<#socket_ty> for #self_ty
+        #where_clause
+        {
+            type MethodCall<'de> = #method_call_name<'de>;
+            type ReplyParams<'ser> = #reply_params_name<'ser> where Self: 'ser;
+            type ReplyStream = ::futures_util::stream::Empty<#crate_path::Reply<()>>;
+            type ReplyStreamParams = ();
+            type ReplyError<'ser> = #error_type where Self: 'ser;
+
+            async fn handle<'__zlink_ser>(
+                &'__zlink_ser mut self,
+                __zlink_call: &'__zlink_ser #crate_path::Call<Self::MethodCall<'_>>,
+                __zlink_conn: &mut #crate_path::Connection<#socket_ty>,
+            ) -> #crate_path::service::MethodReply<
+                Self::ReplyParams<'__zlink_ser>,
+                Self::ReplyStream,
+                Self::ReplyError<'__zlink_ser>,
+            > {
+                #handle_body
+            }
+        }
+    };
+
+    Ok(quote! {
+        #method_call_enum
+
+        #reply_params_enum
+
+        #reply_error_enum
+
+        #service_impl
+    })
+}
+
+/// Generate the MethodCall enum for deserializing incoming calls.
+fn generate_method_call_enum(
+    methods_info: &[MethodInfo],
+    enum_name: &Ident,
+) -> Result<TokenStream, Error> {
+    let variants: Vec<TokenStream> = methods_info
+        .iter()
+        .filter_map(|method| {
+            let full_path = method.full_method_path()?;
+            let variant_name = format_ident!("{}", method.varlink_name);
+
+            // Only include serialized params (exclude connection params).
+            let serialized_params: Vec<_> = method.serialized_params().collect();
+
+            let fields = if serialized_params.is_empty() {
+                quote! {}
+            } else {
+                let field_defs: Vec<TokenStream> = serialized_params
+                    .iter()
+                    .map(|param| {
+                        let name = &param.name;
+                        let ty = &param.ty;
+
+                        let serde_attr = if let Some(ref renamed) = param.serialized_name {
+                            quote! { #[serde(rename = #renamed)] }
+                        } else {
+                            quote! {}
+                        };
+
+                        quote! {
+                            #serde_attr
+                            #name: #ty
+                        }
+                    })
+                    .collect();
+
+                quote! {
+                    { #(#field_defs),* }
+                }
+            };
+
+            Some(quote! {
+                #[serde(rename = #full_path)]
+                #variant_name #fields
+            })
+        })
+        .collect();
+
+    let unused_variant = format_ident!("__{}Unused", enum_name);
+
+    if variants.is_empty() {
+        return Ok(quote! {
+            #[derive(::core::fmt::Debug, ::serde::Deserialize)]
+            #[serde(tag = "method", content = "parameters")]
+            enum #enum_name<'__de> {
+                #[doc(hidden)]
+                #unused_variant(::core::marker::PhantomData<&'__de ()>),
+            }
+        });
+    }
+
+    let unknown_variant = format_ident!("__{}Unknown", enum_name);
+
+    // Note: #[serde(other)] must be on the last variant.
+    Ok(quote! {
+        #[derive(::core::fmt::Debug, ::serde::Deserialize)]
+        #[serde(tag = "method", content = "parameters")]
+        enum #enum_name<'__de> {
+            #[doc(hidden)]
+            #unused_variant(::core::marker::PhantomData<&'__de ()>),
+            #(#variants,)*
+            #[doc(hidden)]
+            #[serde(other)]
+            #unknown_variant,
+        }
+    })
+}
+
+/// Build a mapping from return type string representation to variant index.
+/// This ensures consistent variant naming between reply enum generation and handle body.
+fn build_return_type_variant_map(methods_info: &[MethodInfo]) -> HashMap<String, usize> {
+    let mut type_to_variant: HashMap<String, usize> = HashMap::new();
+    let mut variant_idx = 0;
+
+    for method in methods_info {
+        let Some(ref return_type) = method.return_type else {
+            continue;
+        };
+
+        // Use a simple string representation to check for duplicates.
+        let type_str = quote!(#return_type).to_string();
+        if let std::collections::hash_map::Entry::Vacant(e) = type_to_variant.entry(type_str) {
+            e.insert(variant_idx);
+            variant_idx += 1;
+        }
+    }
+
+    type_to_variant
+}
+
+/// Build a mapping from error type string representation to variant index.
+/// This ensures consistent variant naming for the combo error enum.
+fn build_error_type_variant_map(methods_info: &[MethodInfo]) -> HashMap<String, usize> {
+    let mut type_to_variant: HashMap<String, usize> = HashMap::new();
+    let mut variant_idx = 0;
+
+    for method in methods_info {
+        let Some(ref error_type) = method.error_type else {
+            continue;
+        };
+
+        // Use a simple string representation to check for duplicates.
+        let type_str = quote!(#error_type).to_string();
+        if let std::collections::hash_map::Entry::Vacant(e) = type_to_variant.entry(type_str) {
+            e.insert(variant_idx);
+            variant_idx += 1;
+        }
+    }
+
+    type_to_variant
+}
+
+/// Generate the combo ReplyError enum and From impls for each error type.
+/// Returns the enum definition, From impls, and the error type map.
+fn generate_reply_error_enum(
+    methods_info: &[MethodInfo],
+    enum_name: &Ident,
+) -> (TokenStream, HashMap<String, usize>) {
+    let error_type_map = build_error_type_variant_map(methods_info);
+
+    if error_type_map.is_empty() {
+        // No methods return Result, no enum needed.
+        return (quote! {}, error_type_map);
+    }
+
+    // Build variants in order of their indices.
+    let mut type_variant_pairs: Vec<_> = error_type_map.iter().collect();
+    type_variant_pairs.sort_by_key(|(_, idx)| *idx);
+
+    let mut variants: Vec<TokenStream> = Vec::new();
+    let mut from_impls: Vec<TokenStream> = Vec::new();
+
+    for (type_str, idx) in type_variant_pairs {
+        // Find the actual error type from methods.
+        for method in methods_info {
+            let Some(ref error_type) = method.error_type else {
+                continue;
+            };
+            if &quote!(#error_type).to_string() == type_str {
+                let variant_name = format_ident!("__{}Variant{}", enum_name, idx);
+                variants.push(quote! {
+                    #variant_name(#error_type)
+                });
+
+                from_impls.push(quote! {
+                    impl ::core::convert::From<#error_type> for #enum_name {
+                        fn from(e: #error_type) -> Self {
+                            #enum_name::#variant_name(e)
+                        }
+                    }
+                });
+                break;
+            }
+        }
+    }
+
+    let unused_variant = format_ident!("__{}Unused", enum_name);
+
+    let enum_def = quote! {
+        #[derive(::core::fmt::Debug, ::serde::Serialize)]
+        #[serde(untagged)]
+        enum #enum_name {
+            #(#variants,)*
+            #[doc(hidden)]
+            #unused_variant,
+        }
+
+        #(#from_impls)*
+    };
+
+    (enum_def, error_type_map)
+}
+
+/// Generate the ReplyParams enum for serializing outgoing replies.
+fn generate_reply_params_enum(
+    methods_info: &[MethodInfo],
+    method_call_name: &Ident,
+    enum_name: &Ident,
+) -> Result<TokenStream, Error> {
+    // Collect unique return types from methods.
+    let mut variants: Vec<TokenStream> = Vec::new();
+    let type_to_variant = build_return_type_variant_map(methods_info);
+
+    // Build variants in order of their indices.
+    let mut type_variant_pairs: Vec<_> = type_to_variant.iter().collect();
+    type_variant_pairs.sort_by_key(|(_, idx)| *idx);
+
+    for (type_str, idx) in type_variant_pairs {
+        // Find the actual return type from methods.
+        for method in methods_info {
+            let Some(ref return_type) = method.return_type else {
+                continue;
+            };
+            if &quote!(#return_type).to_string() == type_str {
+                let variant_name = format_ident!("__{}Variant{}", method_call_name, idx);
+                variants.push(quote! {
+                    #variant_name(#return_type)
+                });
+                break;
+            }
+        }
+    }
+
+    let unused_variant = format_ident!("__{}Unused", enum_name);
+
+    if variants.is_empty() {
+        return Ok(quote! {
+            #[derive(::core::fmt::Debug, ::serde::Serialize)]
+            #[serde(untagged)]
+            enum #enum_name<'__ser> {
+                #[doc(hidden)]
+                #unused_variant(::core::marker::PhantomData<&'__ser ()>),
+            }
+        });
+    }
+
+    Ok(quote! {
+        #[derive(::core::fmt::Debug, ::serde::Serialize)]
+        #[serde(untagged)]
+        enum #enum_name<'__ser> {
+            #(#variants,)*
+            #[doc(hidden)]
+            #unused_variant(::core::marker::PhantomData<&'__ser ()>),
+        }
+    })
+}
+
+/// Generate the handle method body with match arms.
+fn generate_handle_body(
+    methods_info: &[MethodInfo],
+    crate_path: &TokenStream,
+    method_call_name: &Ident,
+    reply_params_name: &Ident,
+    reply_error_name: &Ident,
+    error_type_map: &HashMap<String, usize>,
+) -> Result<TokenStream, Error> {
+    let mut match_arms: Vec<TokenStream> = Vec::new();
+    let type_to_variant = build_return_type_variant_map(methods_info);
+
+    for method in methods_info {
+        let Some(_full_path) = method.full_method_path() else {
+            continue;
+        };
+
+        let enum_variant_name = format_ident!("{}", method.varlink_name);
+        let method_name = &method.name;
+
+        // Only include serialized params in the pattern (exclude connection params).
+        let serialized_params: Vec<_> = method.serialized_params().collect();
+
+        // Build the pattern for the match arm.
+        let pattern = if serialized_params.is_empty() {
+            quote! { #method_call_name::#enum_variant_name }
+        } else {
+            let param_names: Vec<_> = serialized_params.iter().map(|p| &p.name).collect();
+            quote! { #method_call_name::#enum_variant_name { #(#param_names),* } }
+        };
+
+        // Build the method call expression.
+        // For methods with connection params, inline the body (the method isn't in the output
+        // impl). For other methods, call the method normally.
+        let method_call = if method.has_connection_param() {
+            // Inline the method body with variable bindings.
+            let body = &method.body;
+
+            // Set up bindings for connection params.
+            let conn_bindings: Vec<TokenStream> = method
+                .params
+                .iter()
+                .filter(|p| p.is_connection)
+                .map(|p| {
+                    let name = &p.name;
+                    quote! { let #name = __zlink_conn; }
+                })
+                .collect();
+
+            // Set up bindings for regular params (clone from pattern match).
+            let param_bindings: Vec<TokenStream> = method
+                .params
+                .iter()
+                .filter(|p| !p.is_connection)
+                .map(|p| {
+                    let name = &p.name;
+                    quote! { let #name = ::core::clone::Clone::clone(#name); }
+                })
+                .collect();
+
+            quote! {
+                {
+                    #(#conn_bindings)*
+                    #(#param_bindings)*
+                    async #body
+                }.await
+            }
+        } else {
+            // Build the method call arguments, cloning values from the pattern match.
+            let call_args: Vec<TokenStream> = method
+                .params
+                .iter()
+                .map(|p| {
+                    let name = &p.name;
+                    quote! { ::core::clone::Clone::clone(#name) }
+                })
+                .collect();
+
+            quote! { self.#method_name(#(#call_args),*).await }
+        };
+
+        // Build the return expression based on method type.
+        let return_expr = if method.returns_result {
+            // Method returns Result<T, E>. Get the error variant for this method's error type.
+            let error_variant = method.error_type.as_ref().map(|err_ty| {
+                let type_str = quote!(#err_ty).to_string();
+                let variant_idx = error_type_map.get(&type_str).copied().unwrap_or(0);
+                format_ident!("__{}Variant{}", reply_error_name, variant_idx)
+            });
+
+            if let Some(ref return_type) = method.return_type {
+                // Result<T, E> where T is not ().
+                let type_str = quote!(#return_type).to_string();
+                let variant_idx = type_to_variant.get(&type_str).copied().unwrap_or(0);
+                let reply_variant_name =
+                    format_ident!("__{}Variant{}", method_call_name, variant_idx);
+                let error_convert = if let Some(err_variant) = error_variant {
+                    quote! { #reply_error_name::#err_variant(__err) }
+                } else {
+                    quote! { ::core::convert::From::from(__err) }
+                };
+                quote! {
+                    match #method_call {
+                        ::core::result::Result::Ok(__ok) => {
+                            #crate_path::service::MethodReply::Single(Some(
+                                #reply_params_name::#reply_variant_name(__ok)
+                            ))
+                        }
+                        ::core::result::Result::Err(__err) => {
+                            #crate_path::service::MethodReply::Error(#error_convert)
+                        }
+                    }
+                }
+            } else {
+                // Result<(), E>.
+                let error_convert = if let Some(err_variant) = error_variant {
+                    quote! { #reply_error_name::#err_variant(__err) }
+                } else {
+                    quote! { ::core::convert::From::from(__err) }
+                };
+                quote! {
+                    match #method_call {
+                        ::core::result::Result::Ok(()) => {
+                            #crate_path::service::MethodReply::Single(None)
+                        }
+                        ::core::result::Result::Err(__err) => {
+                            #crate_path::service::MethodReply::Error(#error_convert)
+                        }
+                    }
+                }
+            }
+        } else if let Some(ref return_type) = method.return_type {
+            // Method returns T directly (not a Result).
+            let type_str = quote!(#return_type).to_string();
+            let variant_idx = type_to_variant.get(&type_str).copied().unwrap_or(0);
+            let reply_variant_name = format_ident!("__{}Variant{}", method_call_name, variant_idx);
+            quote! {
+                let __result = #method_call;
+                #crate_path::service::MethodReply::Single(Some(
+                    #reply_params_name::#reply_variant_name(__result)
+                ))
+            }
+        } else {
+            // Method has no return type.
+            quote! {
+                let _ = #method_call;
+                #crate_path::service::MethodReply::Single(None)
+            }
+        };
+
+        match_arms.push(quote! {
+            #pattern => {
+                #return_expr
+            }
+        });
+    }
+
+    let unused_variant = format_ident!("__{}Unused", method_call_name);
+    let unknown_variant = format_ident!("__{}Unknown", method_call_name);
+
+    // Add the unused variant arm first (to match enum order).
+    match_arms.insert(
+        0,
+        quote! {
+            #method_call_name::#unused_variant(_) => {
+                unreachable!("unused variant should never be matched")
+            }
+        },
+    );
+
+    // Add a catch-all arm for unknown methods (last to match enum order).
+    match_arms.push(quote! {
+        #method_call_name::#unknown_variant => {
+            // Unknown method - this should ideally return an error.
+            // For now, return None.
+            #crate_path::service::MethodReply::Single(None)
+        }
+    });
+
+    // Check if any method uses the connection parameter.
+    let uses_connection = methods_info.iter().any(|m| m.has_connection_param());
+
+    let conn_suppression = if uses_connection {
+        // Connection is used, no suppression needed.
+        quote! {}
+    } else {
+        // Suppress unused warning when no methods use the connection.
+        quote! { let _ = __zlink_conn; }
+    };
+
+    Ok(quote! {
+        #conn_suppression
+        match __zlink_call.method() {
+            #(#match_arms)*
+        }
+    })
+}

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -1,0 +1,301 @@
+//! Method information extraction for service macro.
+
+use proc_macro2::TokenStream;
+use syn::{
+    Attribute, Error, Expr, GenericArgument, Ident, ImplItemFn, Lit, Meta, PathArguments,
+    ReturnType, Type,
+};
+
+use super::types::ParamInfo;
+
+/// Information extracted from a service method.
+pub(super) struct MethodInfo {
+    /// The original method name (snake_case).
+    pub name: Ident,
+    /// The Varlink method name (PascalCase or renamed).
+    pub varlink_name: String,
+    /// The interface name for this method.
+    pub interface: Option<String>,
+    /// Parameters for this method (excluding self).
+    pub params: Vec<ParamInfo>,
+    /// The return type for serialization (the `T` in `Result<T, E>`, or the type itself).
+    pub return_type: Option<Type>,
+    /// Whether the method returns `Result<T, E>` (true) or just `T` (false).
+    pub returns_result: bool,
+    /// The error type if the method returns `Result<T, E>` (the `E`).
+    pub error_type: Option<Type>,
+    /// The method body tokens (for inlining methods with connection params).
+    pub body: TokenStream,
+}
+
+impl MethodInfo {
+    /// Extract method information from an impl method, updating current_interface if a new
+    /// interface attribute is found.
+    pub(super) fn extract(
+        method: &mut ImplItemFn,
+        current_interface: &mut Option<String>,
+    ) -> Result<Self, Error> {
+        let name = method.sig.ident.clone();
+
+        // Extract method attributes.
+        let method_attrs = MethodAttrs::extract(&mut method.attrs)?;
+
+        // Update current interface if this method specifies one.
+        if let Some(ref iface) = method_attrs.interface {
+            *current_interface = Some(iface.clone());
+        }
+
+        // Determine the Varlink method name.
+        let varlink_name = method_attrs
+            .rename
+            .unwrap_or_else(|| snake_case_to_pascal_case(&name.to_string()));
+
+        // Extract parameters (skip self).
+        let params = method
+            .sig
+            .inputs
+            .iter()
+            .skip(1)
+            .filter_map(|arg| {
+                let mut param_info = ParamInfo::from_fn_arg(arg)?;
+                // Try to extract zlink attributes from the parameter.
+                if let syn::FnArg::Typed(pat_type) = arg {
+                    let param_attrs = extract_param_attrs(&pat_type.attrs);
+                    param_info.serialized_name = param_attrs.rename;
+                    param_info.is_connection = param_attrs.is_connection;
+                }
+                Some(param_info)
+            })
+            .collect();
+
+        // Extract return type and check if it's a Result.
+        let (return_type, returns_result, error_type) = match &method.sig.output {
+            ReturnType::Default => (None, false, None),
+            ReturnType::Type(_, ty) => {
+                if let Some((inner_ty, err_ty)) = extract_result_types(ty) {
+                    (inner_ty, true, Some(err_ty))
+                } else {
+                    (Some((**ty).clone()), false, None)
+                }
+            }
+        };
+
+        // Capture the method body.
+        let block = &method.block;
+        let body = quote::quote! { #block };
+
+        Ok(Self {
+            name,
+            varlink_name,
+            interface: current_interface.clone(),
+            params,
+            return_type,
+            returns_result,
+            error_type,
+            body,
+        })
+    }
+
+    /// Get the full Varlink method path (interface.MethodName).
+    pub(super) fn full_method_path(&self) -> Option<String> {
+        self.interface
+            .as_ref()
+            .map(|iface| format!("{}.{}", iface, self.varlink_name))
+    }
+
+    /// Check if this method has a connection parameter.
+    pub(super) fn has_connection_param(&self) -> bool {
+        self.params.iter().any(|p| p.is_connection)
+    }
+
+    /// Get parameters that are not connection parameters (for serialization).
+    pub(super) fn serialized_params(&self) -> impl Iterator<Item = &ParamInfo> {
+        self.params.iter().filter(|p| !p.is_connection)
+    }
+}
+
+/// Attributes extracted from method-level `#[zlink(...)]`.
+#[derive(Default)]
+struct MethodAttrs {
+    /// The interface name for this method.
+    interface: Option<String>,
+    /// Custom method name.
+    rename: Option<String>,
+}
+
+impl MethodAttrs {
+    /// Extract method attributes from a method's attribute list, removing processed attributes.
+    fn extract(attrs: &mut Vec<Attribute>) -> Result<Self, Error> {
+        let mut result = Self::default();
+        let mut indices_to_remove = Vec::new();
+
+        for (i, attr) in attrs.iter().enumerate() {
+            if !attr.path().is_ident("zlink") {
+                continue;
+            }
+
+            indices_to_remove.push(i);
+
+            let Meta::List(list) = &attr.meta else {
+                continue;
+            };
+
+            if list.tokens.is_empty() {
+                continue;
+            }
+
+            let nested = list.parse_args_with(
+                syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
+            )?;
+
+            for meta in nested {
+                match &meta {
+                    Meta::NameValue(nv) if nv.path.is_ident("interface") => {
+                        let Expr::Lit(expr_lit) = &nv.value else {
+                            return Err(Error::new_spanned(
+                                &nv.value,
+                                "interface value must be a string literal",
+                            ));
+                        };
+                        let Lit::Str(lit_str) = &expr_lit.lit else {
+                            return Err(Error::new_spanned(
+                                &nv.value,
+                                "interface value must be a string literal",
+                            ));
+                        };
+                        result.interface = Some(lit_str.value());
+                    }
+                    Meta::NameValue(nv) if nv.path.is_ident("rename") => {
+                        let Expr::Lit(expr_lit) = &nv.value else {
+                            return Err(Error::new_spanned(
+                                &nv.value,
+                                "rename value must be a string literal",
+                            ));
+                        };
+                        let Lit::Str(lit_str) = &expr_lit.lit else {
+                            return Err(Error::new_spanned(
+                                &nv.value,
+                                "rename value must be a string literal",
+                            ));
+                        };
+                        result.rename = Some(lit_str.value());
+                    }
+                    _ => {
+                        return Err(Error::new_spanned(&meta, "unknown zlink attribute"));
+                    }
+                }
+            }
+        }
+
+        // Remove zlink attributes in reverse order to preserve indices.
+        for &index in indices_to_remove.iter().rev() {
+            attrs.remove(index);
+        }
+
+        Ok(result)
+    }
+}
+
+/// Attributes extracted from parameter-level `#[zlink(...)]`.
+#[derive(Default)]
+struct ParamAttrs {
+    /// Custom serialized name for the parameter.
+    rename: Option<String>,
+    /// Whether this parameter should receive the connection.
+    is_connection: bool,
+}
+
+/// Extract zlink attributes from parameter attributes.
+fn extract_param_attrs(attrs: &[Attribute]) -> ParamAttrs {
+    let mut result = ParamAttrs::default();
+
+    for attr in attrs {
+        if !attr.path().is_ident("zlink") {
+            continue;
+        }
+
+        let Meta::List(list) = &attr.meta else {
+            continue;
+        };
+
+        let Ok(nested) = list
+            .parse_args_with(syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated)
+        else {
+            continue;
+        };
+
+        for meta in nested {
+            match &meta {
+                Meta::NameValue(nv) if nv.path.is_ident("rename") => {
+                    if let Expr::Lit(expr_lit) = &nv.value {
+                        if let Lit::Str(lit_str) = &expr_lit.lit {
+                            result.rename = Some(lit_str.value());
+                        }
+                    }
+                }
+                Meta::Path(path) if path.is_ident("connection") => {
+                    result.is_connection = true;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    result
+}
+
+/// Convert snake_case to PascalCase.
+fn snake_case_to_pascal_case(input: &str) -> String {
+    input
+        .split('_')
+        .map(|word| {
+            let mut chars = word.chars();
+            let Some(first) = chars.next() else {
+                return String::new();
+            };
+            first.to_uppercase().collect::<String>() + &chars.as_str().to_lowercase()
+        })
+        .collect()
+}
+
+/// Extract `T` and `E` types from `Result<T, E>`. Returns `None` if the type is not a `Result`.
+/// Returns `Some((None, E))` if the Result's Ok type is `()`.
+fn extract_result_types(ty: &Type) -> Option<(Option<Type>, Type)> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+
+    let last_segment = type_path.path.segments.last()?;
+    if last_segment.ident != "Result" {
+        return None;
+    }
+
+    let PathArguments::AngleBracketed(args) = &last_segment.arguments else {
+        return None;
+    };
+
+    // Get the first generic argument (the Ok type).
+    let first_arg = args.args.first()?;
+    let GenericArgument::Type(ok_type) = first_arg else {
+        return None;
+    };
+
+    // Get the second generic argument (the Err type).
+    let second_arg = args.args.iter().nth(1)?;
+    let GenericArgument::Type(err_type) = second_arg else {
+        return None;
+    };
+
+    // Check if the Ok type is `()`.
+    let ok_type = if let Type::Tuple(tuple) = ok_type {
+        if tuple.elems.is_empty() {
+            None
+        } else {
+            Some(ok_type.clone())
+        }
+    } else {
+        Some(ok_type.clone())
+    };
+
+    Some((ok_type, err_type.clone()))
+}

--- a/zlink-macros/src/service/mod.rs
+++ b/zlink-macros/src/service/mod.rs
@@ -1,0 +1,147 @@
+//! Service macro implementation.
+//!
+//! This module provides the `#[service]` attribute macro that transforms an impl block into a
+//! Service trait implementation.
+
+mod attrs;
+mod codegen;
+mod method;
+mod types;
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse2, Error, ImplItem, ItemImpl};
+
+use attrs::ServiceAttrs;
+use method::MethodInfo;
+
+pub(crate) fn service(attr: TokenStream, input: TokenStream) -> TokenStream {
+    match service_impl(attr, input) {
+        Ok(tokens) => tokens,
+        Err(err) => err.to_compile_error(),
+    }
+}
+
+fn service_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Error> {
+    let mut item_impl = parse2::<ItemImpl>(input)?;
+
+    // Parse macro attributes.
+    let service_attrs = ServiceAttrs::parse(&attr, &item_impl)?;
+
+    // Validate impl block.
+    validate_impl(&item_impl)?;
+
+    // Process methods and collect method information.
+    let mut methods_info = Vec::new();
+    let mut current_interface: Option<String> = None;
+
+    for item in &mut item_impl.items {
+        let ImplItem::Fn(method) = item else {
+            continue;
+        };
+
+        let method_info = MethodInfo::extract(method, &mut current_interface)?;
+        methods_info.push(method_info);
+    }
+
+    // Validate that we have at least one method with an interface.
+    if methods_info.is_empty() {
+        return Err(Error::new_spanned(
+            &item_impl,
+            "service impl block must have at least one method",
+        ));
+    }
+
+    if methods_info.iter().all(|m| m.interface.is_none()) {
+        return Err(Error::new_spanned(
+            &item_impl,
+            "at least one method must have an interface specified via #[zlink(interface = \"...\")]",
+        ));
+    }
+
+    // Validate that connection parameters are only used with explicit generic socket type.
+    let has_explicit_generics = item_impl
+        .generics
+        .params
+        .iter()
+        .any(|p| matches!(p, syn::GenericParam::Type(_)));
+
+    if !has_explicit_generics && methods_info.iter().any(|m| m.has_connection_param()) {
+        return Err(Error::new_spanned(
+            &item_impl,
+            "#[zlink(connection)] parameter requires an explicit generic socket type parameter. \
+             Use `impl<Sock> YourType` to specify a socket type.",
+        ));
+    }
+
+    // Generate the Service trait implementation (uses generics from item_impl if present).
+    let service_impl = codegen::generate_service_impl(&item_impl, &methods_info, &service_attrs)?;
+
+    // Prepare the output impl block.
+    let mut output_impl = item_impl;
+
+    // Remove methods that have connection parameters from the output impl.
+    // These methods are only callable via the Service trait (they need the socket type parameter),
+    // and including them would result in unconstrained type parameter errors.
+    let methods_with_conn: std::collections::HashSet<_> = methods_info
+        .iter()
+        .filter(|m| m.has_connection_param())
+        .map(|m| m.name.to_string())
+        .collect();
+
+    output_impl.items.retain(|item| {
+        let ImplItem::Fn(method) = item else {
+            return true;
+        };
+        !methods_with_conn.contains(&method.sig.ident.to_string())
+    });
+
+    // Strip generics from the original impl block - they are only for the Service impl.
+    output_impl.generics = Default::default();
+
+    // Remove zlink attributes from method parameters.
+    remove_zlink_param_attrs(&mut output_impl);
+
+    // Output the original impl block plus the generated Service impl.
+    Ok(quote! {
+        #output_impl
+        #service_impl
+    })
+}
+
+fn validate_impl(item_impl: &ItemImpl) -> Result<(), Error> {
+    // The impl must be for a concrete type (not a trait impl).
+    if item_impl.trait_.is_some() {
+        return Err(Error::new_spanned(
+            item_impl,
+            "service macro cannot be applied to trait implementations",
+        ));
+    }
+
+    // Check that the impl has at least some items.
+    if item_impl.items.is_empty() {
+        return Err(Error::new_spanned(
+            item_impl,
+            "service impl block must have at least one method",
+        ));
+    }
+
+    Ok(())
+}
+
+/// Remove `#[zlink(...)]` attributes from method parameters.
+fn remove_zlink_param_attrs(item_impl: &mut ItemImpl) {
+    for item in &mut item_impl.items {
+        let ImplItem::Fn(method) = item else {
+            continue;
+        };
+
+        for arg in &mut method.sig.inputs {
+            let syn::FnArg::Typed(pat_type) = arg else {
+                continue;
+            };
+
+            pat_type.attrs.retain(|attr| !attr.path().is_ident("zlink"));
+        }
+    }
+}

--- a/zlink-macros/src/service/types.rs
+++ b/zlink-macros/src/service/types.rs
@@ -1,0 +1,35 @@
+//! Types used in service macro processing.
+
+use syn::{FnArg, Ident, Pat, Type};
+
+/// Information about a method parameter.
+#[derive(Clone)]
+pub(super) struct ParamInfo {
+    /// The parameter name.
+    pub name: Ident,
+    /// The parameter type.
+    pub ty: Type,
+    /// The serialized name (from `#[zlink(rename = "...")]`).
+    pub serialized_name: Option<String>,
+    /// Whether this parameter is marked with `#[zlink(connection)]`.
+    pub is_connection: bool,
+}
+
+impl ParamInfo {
+    /// Extract parameter information from a function argument.
+    pub(super) fn from_fn_arg(arg: &FnArg) -> Option<Self> {
+        let FnArg::Typed(pat_type) = arg else {
+            return None;
+        };
+        let Pat::Ident(pat_ident) = &*pat_type.pat else {
+            return None;
+        };
+
+        Some(Self {
+            name: pat_ident.ident.clone(),
+            ty: (*pat_type.ty).clone(),
+            serialized_name: None,
+            is_connection: false,
+        })
+    }
+}

--- a/zlink-smol/Cargo.toml
+++ b/zlink-smol/Cargo.toml
@@ -9,9 +9,10 @@ repository.workspace = true
 authors.workspace = true
 
 [features]
-default = ["server", "proxy", "tracing"]
+default = ["service", "proxy", "tracing"]
 server = ["zlink-core/server"]
 proxy = ["zlink-core/proxy"]
+service = ["server", "zlink-core/service"]
 idl = ["zlink-core/idl"]
 idl-parse = ["zlink-core/idl-parse"]
 introspection = ["zlink-core/introspection"]

--- a/zlink-tokio/Cargo.toml
+++ b/zlink-tokio/Cargo.toml
@@ -9,9 +9,10 @@ repository.workspace = true
 authors.workspace = true
 
 [features]
-default = ["server", "proxy", "tracing"]
+default = ["service", "proxy", "tracing"]
 server = ["zlink-core/server"]
 proxy = ["zlink-core/proxy"]
+service = ["server", "zlink-core/service"]
 idl = ["zlink-core/idl"]
 idl-parse = ["zlink-core/idl-parse"]
 introspection = ["zlink-core/introspection"]

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -9,11 +9,12 @@ repository.workspace = true
 authors.workspace = true
 
 [features]
-default = ["tokio", "server", "proxy", "tracing"]
+default = ["tokio", "service", "proxy", "tracing"]
 tokio = ["dep:zlink-tokio"]
 smol = ["dep:zlink-smol"]
 server = ["zlink-tokio?/server", "zlink-smol?/server"]
 proxy = ["zlink-tokio?/proxy", "zlink-smol?/proxy"]
+service = ["server", "zlink-tokio?/service", "zlink-smol?/service"]
 idl = ["zlink-tokio?/idl", "zlink-smol?/idl"]
 idl-parse = ["zlink-tokio?/idl-parse", "zlink-smol?/idl-parse"]
 introspection = ["zlink-tokio?/introspection", "zlink-smol?/introspection"]

--- a/zlink/tests/service-macro.rs
+++ b/zlink/tests/service-macro.rs
@@ -1,0 +1,439 @@
+//! Test the `#[service]` attribute macro.
+
+#![cfg(feature = "service")]
+
+use serde::{Deserialize, Serialize};
+use zlink::{
+    connection::socket::FetchPeerCredentials,
+    unix::{bind, connect},
+    Server,
+};
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn service_macro_basic() -> Result<(), Box<dyn std::error::Error>> {
+    // Remove the socket file if it exists (from a previous run of this test).
+    let socket_path = "/tmp/zlink-service-macro-test.sock";
+    if let Err(e) = tokio::fs::remove_file(socket_path).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            return Err(e.into());
+        }
+    }
+
+    // Setup the server and run it in a separate task.
+    let listener = bind(socket_path).unwrap();
+    let service = BankAccount::new(1000, false);
+    let server = Server::new(listener, service);
+    tokio::select! {
+        res = server.run() => res?,
+        res = run_client(socket_path) => res?,
+    }
+
+    Ok(())
+}
+
+async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = connect(socket_path).await?;
+
+    // Test GetBalance method - returns plain value, no Result.
+    let reply = conn.get_balance().await?.unwrap();
+    assert_eq!(reply.amount, 1000);
+
+    // Test successful Deposit (returns Result<Balance, BankError>).
+    let reply = conn.deposit(500).await?.unwrap();
+    assert_eq!(reply.amount, 1500);
+
+    // Test GetBalance again to verify state was updated.
+    let reply = conn.get_balance().await?.unwrap();
+    assert_eq!(reply.amount, 1500);
+
+    // Test successful Withdraw.
+    let reply = conn.withdraw(200).await?.unwrap();
+    assert_eq!(reply.amount, 1300);
+
+    // Test error: withdraw more than available (InsufficientFunds).
+    let err = conn.withdraw(5000).await?.unwrap_err();
+    assert_eq!(
+        err,
+        BankError::InsufficientFunds {
+            available: 1300,
+            requested: 5000,
+        }
+    );
+
+    // Verify balance unchanged after failed withdrawal.
+    let reply = conn.get_balance().await?.unwrap();
+    assert_eq!(reply.amount, 1300);
+
+    // Test error: invalid amount (negative deposit).
+    let err = conn.deposit(-100).await?.unwrap_err();
+    assert_eq!(err, BankError::InvalidAmount { amount: -100 });
+
+    // Test LockAccount - returns no value (void method).
+    conn.lock_account().await?.unwrap();
+
+    // Test error: operations on locked account.
+    let err = conn.deposit(100).await?.unwrap_err();
+    assert_eq!(err, BankError::AccountLocked);
+
+    let err = conn.withdraw(100).await?.unwrap_err();
+    assert_eq!(err, BankError::AccountLocked);
+
+    // GetBalance should still work on locked account.
+    let reply = conn.get_balance().await?.unwrap();
+    assert_eq!(reply.amount, 1300);
+
+    Ok(())
+}
+
+// Response type for balance operations.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Balance {
+    amount: i64,
+}
+
+// Error type with parameters - demonstrates error handling.
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError)]
+#[zlink(interface = "org.example.bank")]
+enum BankError {
+    InsufficientFunds { available: i64, requested: i64 },
+    InvalidAmount { amount: i64 },
+    AccountLocked,
+}
+
+// Define the service type.
+struct BankAccount {
+    balance: i64,
+    locked: bool,
+}
+
+impl BankAccount {
+    fn new(initial_balance: i64, locked: bool) -> Self {
+        Self {
+            balance: initial_balance,
+            locked,
+        }
+    }
+}
+
+// Apply the service macro.
+#[zlink::service]
+impl BankAccount {
+    // Method that returns a plain value (not Result).
+    #[zlink(interface = "org.example.bank")]
+    async fn get_balance(&self) -> Balance {
+        Balance {
+            amount: self.balance,
+        }
+    }
+
+    // Method that can fail - returns Result<Balance, BankError>.
+    async fn deposit(&mut self, amount: i64) -> Result<Balance, BankError> {
+        if self.locked {
+            return Err(BankError::AccountLocked);
+        }
+        if amount <= 0 {
+            return Err(BankError::InvalidAmount { amount });
+        }
+        self.balance += amount;
+        Ok(Balance {
+            amount: self.balance,
+        })
+    }
+
+    // Another method that can fail.
+    async fn withdraw(&mut self, amount: i64) -> Result<Balance, BankError> {
+        if self.locked {
+            return Err(BankError::AccountLocked);
+        }
+        if amount <= 0 {
+            return Err(BankError::InvalidAmount { amount });
+        }
+        if amount > self.balance {
+            return Err(BankError::InsufficientFunds {
+                available: self.balance,
+                requested: amount,
+            });
+        }
+        self.balance -= amount;
+        Ok(Balance {
+            amount: self.balance,
+        })
+    }
+
+    // Method returning Result<(), BankError> (void success, can fail).
+    async fn lock_account(&mut self) -> Result<(), BankError> {
+        if self.locked {
+            return Err(BankError::AccountLocked);
+        }
+        self.locked = true;
+        Ok(())
+    }
+}
+
+// Define a proxy for the client side.
+#[zlink::proxy("org.example.bank")]
+trait BankProxy {
+    async fn get_balance(&mut self) -> zlink::Result<Result<Balance, BankError>>;
+    async fn deposit(&mut self, amount: i64) -> zlink::Result<Result<Balance, BankError>>;
+    async fn withdraw(&mut self, amount: i64) -> zlink::Result<Result<Balance, BankError>>;
+    async fn lock_account(&mut self) -> zlink::Result<Result<(), BankError>>;
+}
+
+// ============================================================================
+// Test custom socket bounds via user-provided generics
+// ============================================================================
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn service_macro_with_custom_socket_bounds() -> Result<(), Box<dyn std::error::Error>> {
+    // Remove the socket file if it exists.
+    let socket_path = "/tmp/zlink-service-macro-creds-test.sock";
+    if let Err(e) = tokio::fs::remove_file(socket_path).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            return Err(e.into());
+        }
+    }
+
+    // Setup the server with the credential-checking service.
+    let listener = bind(socket_path).unwrap();
+    let service = CredentialCheckingService { balance: 1000 };
+    let server = Server::new(listener, service);
+    tokio::select! {
+        res = server.run() => res?,
+        res = async {
+            let mut conn = connect(socket_path).await?;
+            // Test that the service works and can check credentials.
+            let reply = conn.get_balance_with_creds().await?.unwrap();
+            assert_eq!(reply.amount, 1000);
+            Ok::<(), Box<dyn std::error::Error>>(())
+        } => res?,
+    }
+
+    Ok(())
+}
+
+/// Error type for credential-checking service.
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError)]
+#[zlink(interface = "org.example.creds")]
+enum CredsError {
+    CredentialCheckFailed,
+}
+
+/// A service that uses custom socket bounds to check peer credentials.
+struct CredentialCheckingService {
+    balance: i64,
+}
+
+// Service implementation with custom socket bounds using user-provided generics.
+// The first type parameter (Sock) is used as the socket type. The Socket bound is added
+// automatically, so we only specify additional bounds.
+#[zlink::service]
+impl<Sock> CredentialCheckingService
+where
+    Sock::ReadHalf: FetchPeerCredentials,
+{
+    #[zlink(interface = "org.example.creds")]
+    async fn get_balance_with_creds(
+        &self,
+        #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
+    ) -> Result<Balance, CredsError> {
+        // Actually check credentials using the connection parameter.
+        let creds = conn.peer_credentials().await.unwrap();
+        // Verify we got valid credentials (check that unix_user_id is returned).
+        let _ = creds.unix_user_id();
+        Ok(Balance {
+            amount: self.balance,
+        })
+    }
+}
+
+#[zlink::proxy("org.example.creds")]
+trait CredsProxy {
+    async fn get_balance_with_creds(&mut self) -> zlink::Result<Result<Balance, CredsError>>;
+}
+
+// ============================================================================
+// Test service implementing multiple interfaces (each with its own error type)
+// ============================================================================
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn service_macro_multiple_interfaces() -> Result<(), Box<dyn std::error::Error>> {
+    // Remove the socket file if it exists.
+    let socket_path = "/tmp/zlink-service-macro-multi-iface-test.sock";
+    if let Err(e) = tokio::fs::remove_file(socket_path).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            return Err(e.into());
+        }
+    }
+
+    // Setup the server with the multi-interface service.
+    let listener = bind(socket_path).unwrap();
+    let service = MultiInterfaceService {
+        user_authenticated: false,
+        items: vec!["apple".to_string(), "banana".to_string()],
+    };
+    let server = Server::new(listener, service);
+    tokio::select! {
+        res = server.run() => res?,
+        res = run_multi_interface_client(socket_path) => res?,
+    }
+
+    Ok(())
+}
+
+async fn run_multi_interface_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = connect(socket_path).await?;
+
+    // Test org.example.auth interface.
+
+    // Test AuthError: not authenticated.
+    let err = conn.get_user_info().await?.unwrap_err();
+    assert_eq!(err, AuthError::NotAuthenticated);
+
+    // Test successful authentication.
+    conn.authenticate("secret".to_string()).await?.unwrap();
+
+    // Test AuthError: invalid credentials.
+    let err = conn.authenticate("wrong".to_string()).await?.unwrap_err();
+    assert_eq!(
+        err,
+        AuthError::InvalidCredentials {
+            reason: "wrong password".to_string()
+        }
+    );
+
+    // After successful auth, get_user_info should work.
+    let info = conn.get_user_info().await?.unwrap();
+    assert_eq!(info.name, "TestUser");
+
+    // Test org.example.storage interface.
+
+    // Test method returning plain value (no error).
+    let count = conn.item_count().await?.unwrap();
+    assert_eq!(count.count, 2);
+
+    // Test StorageError: item not found.
+    let err = conn.get_item(10).await?.unwrap_err();
+    assert_eq!(err, StorageError::NotFound);
+
+    // Test successful item retrieval.
+    let item = conn.get_item(0).await?.unwrap();
+    assert_eq!(item.value, "apple");
+
+    // Test StorageError: quota exceeded.
+    let err = conn.add_item("cherry".to_string()).await?.unwrap_err();
+    assert_eq!(err, StorageError::QuotaExceeded { limit: 2 });
+
+    Ok(())
+}
+
+/// Response type for item count.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct ItemCount {
+    count: usize,
+}
+
+/// Response type for user info.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct UserInfo {
+    name: String,
+}
+
+/// Response type for item retrieval.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+struct Item {
+    value: String,
+}
+
+/// Authentication-related errors (for org.example.auth interface).
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError)]
+#[zlink(interface = "org.example.auth")]
+enum AuthError {
+    NotAuthenticated,
+    InvalidCredentials { reason: String },
+}
+
+/// Storage-related errors (for org.example.storage interface).
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError)]
+#[zlink(interface = "org.example.storage")]
+enum StorageError {
+    NotFound,
+    QuotaExceeded { limit: usize },
+}
+
+/// A service that implements multiple interfaces.
+struct MultiInterfaceService {
+    user_authenticated: bool,
+    items: Vec<String>,
+}
+
+#[zlink::service]
+impl MultiInterfaceService {
+    // ---- org.example.auth interface ----
+
+    /// Authenticate with a password.
+    #[zlink(interface = "org.example.auth")]
+    async fn authenticate(&mut self, password: String) -> Result<(), AuthError> {
+        if password == "secret" {
+            self.user_authenticated = true;
+            Ok(())
+        } else {
+            Err(AuthError::InvalidCredentials {
+                reason: "wrong password".to_string(),
+            })
+        }
+    }
+
+    /// Get user info (requires authentication).
+    async fn get_user_info(&self) -> Result<UserInfo, AuthError> {
+        if self.user_authenticated {
+            Ok(UserInfo {
+                name: "TestUser".to_string(),
+            })
+        } else {
+            Err(AuthError::NotAuthenticated)
+        }
+    }
+
+    // ---- org.example.storage interface ----
+
+    /// Get the number of items (returns plain value, no Result).
+    #[zlink(interface = "org.example.storage")]
+    async fn item_count(&self) -> ItemCount {
+        ItemCount {
+            count: self.items.len(),
+        }
+    }
+
+    /// Get an item by index.
+    async fn get_item(&self, index: usize) -> Result<Item, StorageError> {
+        self.items
+            .get(index)
+            .map(|v| Item { value: v.clone() })
+            .ok_or(StorageError::NotFound)
+    }
+
+    /// Add a new item.
+    async fn add_item(&mut self, item: String) -> Result<(), StorageError> {
+        if self.items.len() >= 2 {
+            Err(StorageError::QuotaExceeded { limit: 2 })
+        } else {
+            self.items.push(item);
+            Ok(())
+        }
+    }
+}
+
+/// Proxy for org.example.auth interface.
+#[zlink::proxy("org.example.auth")]
+trait AuthProxy {
+    async fn authenticate(&mut self, password: String) -> zlink::Result<Result<(), AuthError>>;
+    async fn get_user_info(&mut self) -> zlink::Result<Result<UserInfo, AuthError>>;
+}
+
+/// Proxy for org.example.storage interface.
+#[zlink::proxy("org.example.storage")]
+trait StorageProxy {
+    async fn item_count(&mut self) -> zlink::Result<Result<ItemCount, StorageError>>;
+    async fn get_item(&mut self, index: usize) -> zlink::Result<Result<Item, StorageError>>;
+    async fn add_item(&mut self, item: String) -> zlink::Result<Result<(), StorageError>>;
+}


### PR DESCRIPTION
This is similar to the `proxy` macro, that allows you to easily
implement a service. At the moment, it lacks support for introspection
(#213) and handling of `more` flag to return a reply stream (#211).
    
This is only enabled with the (default) `service` feature, which in turn
requires `server` feature.
    
Fixes #76.
