### PR TITLE
⏪️ Revert "🚩 macros: Enable needed features on zlink dev-dep"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,11 @@ cargo check --all-features
 cargo check -p zlink-core --no-default-features --features idl-parse,proxy,defmt
 ```
 
+### Testing crates in isolation
+
+We only support running tests in isolation in `zlink`, `zlink-core` and `zlink-codegen` (e.g
+`cargo -p zlink-macros test` is not supported and allowed to fail).
+
 ### Git Hooks Setup
 ```bash
 # Enable git hooks for automatic formatting and clippy checks

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -30,7 +30,7 @@ syn = { version = "2.0", default-features = false, features = [
 ] }
 
 [dev-dependencies]
-zlink = { path = "../zlink", default-features = false, features = ["tokio", "introspection", "tracing", "proxy", "service"] }
+zlink = { path = "../zlink", default-features = false, features = ["tokio", "introspection"] }
 serde = "1.0"
 serde_json = "1.0"
 serde-json-core = { version = "0.6.0", default-features = false, features = [


### PR DESCRIPTION
This reverts commit df4e2283533aa976a89adbb54f116264fbb8b301.

We don't want all the features to be enabled when running `cargo test`.
