### PR TITLE
service macro bugfixes & interface specification

### DIFF
--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1035,19 +1035,14 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///
 /// # Generated Code
 ///
-/// The macro generates:
-/// 1. A `{TypeName}MethodCall` enum for deserializing incoming method calls.
-/// 2. A `{TypeName}ReplyParams` enum for serializing outgoing replies.
-/// 3. A `{TypeName}ReplyError` combo enum that wraps all error types used by methods. This enum
-///    uses `#[serde(untagged)]` for transparent serialization.
-/// 4. An `impl<Sock: Socket> Service<Sock> for YourType` with the `handle` method.
+/// The macro generates an `impl<Sock: Socket> Service<Sock> for YourType` with the `handle` method,
+/// along with internal helper types for serialization/deserialization.
 ///
 /// # Error Handling
 ///
 /// Methods can return `Result<T, E>` with any error type `E` that implements `Serialize` and
-/// `Debug`. Different methods can use different error types - the macro automatically generates a
-/// combo enum (`{TypeName}ReplyError`) that wraps all unique error types, with `From` impls for
-/// each type.
+/// `Debug`. Different methods can use different error types - the macro automatically generates
+/// internal wrapper types to handle all unique error types.
 ///
 /// When a method returns `Err(e)`, the macro generates code that wraps it in the appropriate
 /// combo enum variant and returns `MethodReply::Error(...)`.

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1013,6 +1013,9 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// ## On the impl block:
 ///
 /// * `crate = "path"` - Specifies the crate path to use for zlink types. Defaults to `::zlink`.
+/// * `interface = "..."` - Sets the default interface name for all methods. Useful for services
+///   that implement a single interface. Methods can still override this with method-level
+///   `#[zlink(interface = "...")]`.
 /// * `types = [Type1, Type2, ...]` - Custom types to include in interface descriptions. These types
 ///   must implement `CustomType` (typically via `#[derive(CustomType)]`). The types are included in
 ///   the IDL for any interface that uses them.
@@ -1023,7 +1026,8 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///
 /// ## On methods:
 ///
-/// * `#[zlink(interface = "...")]` - Set the interface name for this and subsequent methods.
+/// * `#[zlink(interface = "...")]` - Set the interface name for this and subsequent methods. If an
+///   interface is specified at the impl block level, this overrides it for the current method.
 /// * `#[zlink(rename = "MethodName")]` - Custom Varlink method name.
 ///
 /// ## On parameters:
@@ -1355,8 +1359,14 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///
 /// # Interface Propagation
 ///
-/// Once an interface is set with `#[zlink(interface = "...")]`, it applies to that method and
-/// all subsequent methods until another interface attribute is encountered.
+/// The interface for methods is determined in this order:
+/// 1. If the method has `#[zlink(interface = "...")]`, that interface is used.
+/// 2. Otherwise, the interface is inherited from the previous method or from the macro-level
+///    `interface = "..."` attribute.
+///
+/// For services implementing a single interface, specifying `interface = "..."` at the macro level
+/// is the simplest approach - all methods automatically use that interface without needing
+/// individual attributes.
 #[cfg(feature = "service")]
 #[proc_macro_attribute]
 pub fn service(

--- a/zlink-macros/src/service/attrs.rs
+++ b/zlink-macros/src/service/attrs.rs
@@ -13,6 +13,8 @@ pub(super) struct ServiceAttrs {
     pub crate_path: TokenStream,
     /// Custom types for introspection.
     pub custom_types: Vec<syn::Type>,
+    /// Default interface name for all methods.
+    pub interface: Option<String>,
     /// Service vendor name.
     pub vendor: Option<String>,
     /// Service product name.
@@ -28,6 +30,7 @@ impl ServiceAttrs {
     pub(super) fn parse(attr: &TokenStream, item_impl: &ItemImpl) -> Result<Self, Error> {
         let mut crate_path = None;
         let mut custom_types = Vec::new();
+        let mut interface = None;
         let mut vendor = None;
         let mut product = None;
         let mut version = None;
@@ -46,6 +49,9 @@ impl ServiceAttrs {
                     syn::bracketed!(content in meta.input);
                     let types = content.parse_terminated(syn::Type::parse, syn::Token![,])?;
                     custom_types = types.into_iter().collect();
+                } else if meta.path.is_ident("interface") {
+                    let value: syn::LitStr = meta.value()?.parse()?;
+                    interface = Some(value.value());
                 } else if meta.path.is_ident("vendor") {
                     let value: syn::LitStr = meta.value()?.parse()?;
                     vendor = Some(value.value());
@@ -70,8 +76,8 @@ impl ServiceAttrs {
                     format!(
                         "failed to parse service attributes: {e}. Expected: \
                          #[service], #[service(crate = \"path\")], \
-                         #[service(types = [T1, T2], vendor = \"...\", product = \"...\", \
-                         version = \"...\", url = \"...\")]"
+                         #[service(interface = \"...\", types = [T1, T2], vendor = \"...\", \
+                         product = \"...\", version = \"...\", url = \"...\")]"
                     ),
                 )
             })?;
@@ -80,6 +86,7 @@ impl ServiceAttrs {
         Ok(Self {
             crate_path: crate_path.unwrap_or_else(|| quote! { ::zlink }),
             custom_types,
+            interface,
             vendor,
             product,
             version,

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -56,11 +56,12 @@ pub(super) fn generate_service_impl(
     let self_ty = &item_impl.self_ty;
 
     // Extract the type name for generating auxiliary type names.
+    // All generated types use `__` prefix to indicate they are internal implementation details.
     let type_name = extract_type_name(self_ty).unwrap_or_else(|| "Service".to_string());
-    let method_call_name = format_ident!("{}MethodCall", type_name);
+    let method_call_name = format_ident!("__{}MethodCall", type_name);
     let user_methods_name = format_ident!("__{}UserMethods", type_name);
-    let reply_params_name = format_ident!("{}ReplyParams", type_name);
-    let reply_error_name = format_ident!("{}ReplyError", type_name);
+    let reply_params_name = format_ident!("__{}ReplyParams", type_name);
+    let reply_error_name = format_ident!("__{}ReplyError", type_name);
 
     // Collect interfaces for introspection.
     let interfaces = collect_interfaces(methods_info);
@@ -238,23 +239,22 @@ fn generate_method_call_enum(
     // Generate the inner user methods enum.
     let user_methods_enum = if variants.is_empty() {
         quote! {
+            #[allow(private_interfaces)]
             #[derive(::core::fmt::Debug, ::serde::Deserialize)]
             #[serde(tag = "method", content = "parameters")]
-            enum #user_methods_name<'__de> {
-                #[doc(hidden)]
+            pub enum #user_methods_name<'__de> {
                 #unused_variant(::core::marker::PhantomData<&'__de ()>),
             }
         }
     } else {
         // Note: #[serde(other)] must be on the last variant.
         quote! {
+            #[allow(private_interfaces)]
             #[derive(::core::fmt::Debug, ::serde::Deserialize)]
             #[serde(tag = "method", content = "parameters")]
-            enum #user_methods_name<'__de> {
-                #[doc(hidden)]
+            pub enum #user_methods_name<'__de> {
                 #unused_variant(::core::marker::PhantomData<&'__de ()>),
                 #(#variants,)*
-                #[doc(hidden)]
                 #[serde(other)]
                 #unknown_variant,
             }
@@ -264,9 +264,10 @@ fn generate_method_call_enum(
     // Generate the outer untagged wrapper enum.
     // VarlinkService is tried first (specific matches only), then UserMethods.
     let outer_enum = quote! {
+        #[allow(private_interfaces)]
         #[derive(::core::fmt::Debug, ::serde::Deserialize)]
         #[serde(untagged)]
-        enum #enum_name<'__de> {
+        pub enum #enum_name<'__de> {
             #[serde(borrow)]
             __VarlinkService(#crate_path::varlink_service::Method<'__de>),
             __UserMethods(#user_methods_name<'__de>),
@@ -369,9 +370,10 @@ fn generate_reply_error_enum(
     let varlink_error_variant = format_ident!("__{}VarlinkService", enum_name);
 
     let enum_def = quote! {
+        #[allow(private_interfaces)]
         #[derive(::core::fmt::Debug, ::serde::Serialize)]
         #[serde(untagged)]
-        enum #enum_name<'__ser> {
+        pub enum #enum_name<'__ser> {
             #varlink_error_variant(#crate_path::varlink_service::Error<'__ser>),
             #(#variants,)*
         }
@@ -428,23 +430,23 @@ fn generate_reply_params_enum(
 
     if variants.is_empty() {
         return Ok(quote! {
+            #[allow(private_interfaces)]
             #[derive(::core::fmt::Debug, ::serde::Serialize)]
             #[serde(untagged)]
-            enum #enum_name<'__ser> {
+            pub enum #enum_name<'__ser> {
                 #varlink_reply_variant(#crate_path::varlink_service::Reply<'__ser>),
-                #[doc(hidden)]
                 #unused_variant(::core::marker::PhantomData<&'__ser ()>),
             }
         });
     }
 
     Ok(quote! {
+        #[allow(private_interfaces)]
         #[derive(::core::fmt::Debug, ::serde::Serialize)]
         #[serde(untagged)]
-        enum #enum_name<'__ser> {
+        pub enum #enum_name<'__ser> {
             #varlink_reply_variant(#crate_path::varlink_service::Reply<'__ser>),
             #(#variants,)*
-            #[doc(hidden)]
             #unused_variant(::core::marker::PhantomData<&'__ser ()>),
         }
     })

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -661,7 +661,7 @@ fn generate_handle_body(
                 {
                     #(#conn_bindings)*
                     #(#param_bindings)*
-                    async #body
+                    async move #body
                 }.await
             }
         } else {

--- a/zlink-macros/src/service/mod.rs
+++ b/zlink-macros/src/service/mod.rs
@@ -33,7 +33,7 @@ fn service_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Er
 
     // Process methods and collect method information.
     let mut methods_info = Vec::new();
-    let mut current_interface: Option<String> = None;
+    let mut current_interface: Option<String> = service_attrs.interface.clone();
 
     for item in &mut item_impl.items {
         let ImplItem::Fn(method) = item else {
@@ -55,7 +55,8 @@ fn service_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Er
     if methods_info.iter().all(|m| m.interface.is_none()) {
         return Err(Error::new_spanned(
             &item_impl,
-            "at least one method must have an interface specified via #[zlink(interface = \"...\")]",
+            "an interface must be specified via #[zlink::service(interface = \"...\")] or \
+             #[zlink(interface = \"...\")] on the first method",
         ));
     }
 

--- a/zlink/tests/service-macro.rs
+++ b/zlink/tests/service-macro.rs
@@ -633,6 +633,17 @@ async fn service_macro_with_metadata() -> Result<(), Box<dyn std::error::Error>>
                 "Unexpected interfaces"
             );
 
+            // Test GetInterfaceDescription - verify both methods are exposed.
+            // This tests that the macro-level interface attribute applies to all methods.
+            let desc = conn.get_interface_description("org.example.metadata").await?.unwrap();
+            let interface = desc.parse()?;
+            let method_names: Vec<_> = interface.methods().map(|m| m.name()).collect();
+            assert_eq!(
+                method_names.as_slice(),
+                ["Ping", "Pong"],
+                "Expected both Ping and Pong methods from macro-level interface attribute"
+            );
+
             Ok::<(), Box<dyn std::error::Error>>(())
         } => res?,
     }
@@ -644,13 +655,17 @@ async fn service_macro_with_metadata() -> Result<(), Box<dyn std::error::Error>>
 /// This is `pub` to test that the generated types work with public service structs (issue #216).
 pub struct MetadataService;
 
+// Test the interface attribute at the macro level instead of on each method.
 #[zlink::service(
+    interface = "org.example.metadata",
     vendor = "Test Vendor",
     product = "Test Product",
     version = "1.0.0",
     url = "https://example.com"
 )]
 impl MetadataService {
-    #[zlink(interface = "org.example.metadata")]
     async fn ping(&self) {}
+
+    // Add another method to verify all methods get the interface.
+    async fn pong(&self) {}
 }

--- a/zlink/tests/service-macro.rs
+++ b/zlink/tests/service-macro.rs
@@ -209,8 +209,10 @@ async fn service_macro_with_custom_socket_bounds() -> Result<(), Box<dyn std::er
         res = async {
             let mut conn = connect(socket_path).await?;
             // Test that the service works and can check credentials.
-            let reply = conn.get_balance_with_creds().await?.unwrap();
-            assert_eq!(reply.amount, 1000);
+            // The multiplier parameter is used AFTER an await point in the service method,
+            // which tests the fix for issue #216 (parameters with #[zlink(connection)]).
+            let reply = conn.get_balance_with_creds(2).await?.unwrap();
+            assert_eq!(reply.amount, 2000); // 1000 * 2
             Ok::<(), Box<dyn std::error::Error>>(())
         } => res?,
     }
@@ -241,21 +243,28 @@ where
     #[zlink(interface = "org.example.creds")]
     async fn get_balance_with_creds(
         &self,
+        multiplier: i64,
         #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
     ) -> Result<Balance, CredsError> {
         // Actually check credentials using the connection parameter.
         let creds = conn.peer_credentials().await.unwrap();
         // Verify we got valid credentials (check that unix_user_id is returned).
         let _ = creds.unix_user_id();
+        // Use multiplier AFTER the await point - this tests the fix for issue #216.
+        // Without `async move`, the multiplier would be captured by reference and not live long
+        // enough.
         Ok(Balance {
-            amount: self.balance,
+            amount: self.balance * multiplier,
         })
     }
 }
 
 #[zlink::proxy("org.example.creds")]
 trait CredsProxy {
-    async fn get_balance_with_creds(&mut self) -> zlink::Result<Result<Balance, CredsError>>;
+    async fn get_balance_with_creds(
+        &mut self,
+        multiplier: i64,
+    ) -> zlink::Result<Result<Balance, CredsError>>;
 }
 
 // ============================================================================

--- a/zlink/tests/service-macro.rs
+++ b/zlink/tests/service-macro.rs
@@ -641,7 +641,8 @@ async fn service_macro_with_metadata() -> Result<(), Box<dyn std::error::Error>>
 }
 
 /// A simple service with metadata attributes.
-struct MetadataService;
+/// This is `pub` to test that the generated types work with public service structs (issue #216).
+pub struct MetadataService;
 
 #[zlink::service(
     vendor = "Test Vendor",


### PR DESCRIPTION
- **🚑️ macros: Fix a borrowing problem in service methods**
- **🐛 macros: Hide internal types generated by `service`**
- **✨ macros: Allow `interface` attribute on `service`**

Fixes #216.