### PR TITLE
🚸 Various improvements to `notified` API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,6 +2234,7 @@ name = "zlink-tokio"
 version = "0.4.0"
 dependencies = [
  "futures-util",
+ "pin-project-lite",
  "serde",
  "serde_repr",
  "tempfile",

--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -35,6 +35,9 @@ pub use server::{
     Server,
 };
 mod call;
+#[cfg(feature = "server")]
+#[doc(hidden)]
+pub mod notified;
 pub use call::Call;
 pub mod reply;
 pub use reply::Reply;

--- a/zlink-core/src/notified.rs
+++ b/zlink-core/src/notified.rs
@@ -1,0 +1,52 @@
+//! Notified state API traits.
+//!
+//! This module defines traits that document the expected API for notified types. Runtime crates
+//! (like `zlink-tokio` and `zlink-smol`) implement these traits on their concrete types.
+
+use core::{fmt::Debug, future::Future};
+
+use crate::Reply;
+
+/// Trait for a notified state that tracks a value and broadcasts changes.
+///
+/// This is useful for implementing service properties that notify subscribers when they change.
+pub trait State<T, ReplyParams>: Clone
+where
+    T: Into<ReplyParams> + Clone + Debug,
+    ReplyParams: Clone + Send + 'static + Debug,
+{
+    /// The stream type returned by [`stream`](Self::stream).
+    type Stream: futures_util::Stream<Item = Reply<ReplyParams>>;
+
+    /// Create a new notified state with the given initial value.
+    fn new(value: T) -> Self;
+
+    /// Set the value and notify all listeners.
+    fn set(&mut self, value: T) -> impl Future<Output = ()> + Send;
+
+    /// Get the current value.
+    fn get(&self) -> T;
+
+    /// Get a stream of replies for this state.
+    fn stream(&self) -> Self::Stream;
+}
+
+/// Trait for a one-shot notification (useful for method call handlers).
+///
+/// This is useful for handling method calls in a separate task/thread, where the result is sent
+/// back once.
+pub trait Once<ReplyParams>: Sized
+where
+    ReplyParams: Send + 'static + Debug,
+{
+    /// The stream type returned by [`new`](Self::new).
+    type Stream: futures_util::Stream<Item = Reply<ReplyParams>>;
+
+    /// Create a new one-shot notifier and its corresponding stream.
+    fn new() -> (Self, Self::Stream);
+
+    /// Send the notification value. Consumes self.
+    fn notify<T>(self, value: T)
+    where
+        T: Into<ReplyParams> + Debug;
+}

--- a/zlink-smol/src/lib.rs
+++ b/zlink-smol/src/lib.rs
@@ -11,5 +11,6 @@
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
 pub use zlink_core::*;
+#[cfg(feature = "server")]
 pub mod notified;
 pub mod unix;

--- a/zlink-smol/src/notified.rs
+++ b/zlink-smol/src/notified.rs
@@ -65,10 +65,8 @@ where
     /// A stream of replies for the notified field.
     pub fn stream(&self) -> Stream<ReplyParams> {
         Stream {
-            inner: StreamInner::Broadcast {
-                receiver: self.inactive_rx.activate_cloned(),
-                cached: None,
-            },
+            inner: self.inactive_rx.activate_cloned(),
+            cached: None,
         }
     }
 }
@@ -86,16 +84,14 @@ where
     ReplyParams: Send + 'static + Debug,
 {
     /// Create a new notified oneshot state.
-    pub fn new() -> (Self, Stream<ReplyParams>) {
+    pub fn new() -> (Self, OnceStream<ReplyParams>) {
         let (tx, rx) = bounded(1);
 
         (
             Self { tx },
-            Stream {
-                inner: StreamInner::Oneshot {
-                    receiver: rx,
-                    terminated: false,
-                },
+            OnceStream {
+                inner: rx,
+                terminated: false,
             },
         )
     }
@@ -113,11 +109,12 @@ where
 
 pin_project! {
     /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
-    /// using [`State`] or [`Once`].
+    /// using [`State`].
     #[derive(Debug)]
     pub struct Stream<ReplyParams> {
         #[pin]
-        inner: StreamInner<ReplyParams>,
+        inner: BroadcastReceiver<ReplyParams>,
+        cached: Option<ReplyParams>,
     }
 }
 
@@ -129,56 +126,51 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
-        match this.inner.project() {
-            StreamInnerProj::Broadcast {
-                mut receiver,
-                cached,
-            } => match futures_util::ready!(receiver.as_mut().poll_next(cx)) {
-                Some(reply) => {
-                    // Cache and yield immediately with continues=true.
-                    *cached = Some(reply.clone());
-                    Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(true))))
-                }
-                // Channel closed - yield cached value with continues=false.
-                None => Poll::Ready(
-                    cached
-                        .take()
-                        .map(|reply| Reply::new(Some(reply)).set_continues(Some(false))),
-                ),
-            },
-            StreamInnerProj::Oneshot {
-                receiver,
-                terminated,
-            } => {
-                if *terminated {
-                    return Poll::Ready(None);
-                }
-
-                match futures_util::ready!(receiver.poll_next(cx)) {
-                    Some(reply) => {
-                        *terminated = true;
-                        Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(false))))
-                    }
-                    None => Poll::Ready(None),
-                }
+        match futures_util::ready!(this.inner.poll_next(cx)) {
+            Some(reply) => {
+                // Cache and yield immediately with continues=true.
+                *this.cached = Some(reply.clone());
+                Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(true))))
             }
+            // Channel closed - yield cached value with continues=false.
+            None => Poll::Ready(
+                this.cached
+                    .take()
+                    .map(|reply| Reply::new(Some(reply)).set_continues(Some(false))),
+            ),
         }
     }
 }
 
 pin_project! {
-    #[project = StreamInnerProj]
+    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
+    /// using [`Once`].
     #[derive(Debug)]
-    enum StreamInner<ReplyParams> {
-        Broadcast {
-            #[pin]
-            receiver: BroadcastReceiver<ReplyParams>,
-            cached: Option<ReplyParams>,
-        },
-        Oneshot {
-            #[pin]
-            receiver: OneshotReceiver<ReplyParams>,
-            terminated: bool,
-        },
+    pub struct OnceStream<ReplyParams> {
+        #[pin]
+        inner: OneshotReceiver<ReplyParams>,
+        terminated: bool,
+    }
+}
+
+impl<ReplyParams> futures_util::Stream for OnceStream<ReplyParams>
+where
+    ReplyParams: Send + 'static,
+{
+    type Item = Reply<ReplyParams>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        if *this.terminated {
+            return Poll::Ready(None);
+        }
+
+        match futures_util::ready!(this.inner.poll_next(cx)) {
+            Some(reply) => {
+                *this.terminated = true;
+                Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(false))))
+            }
+            None => Poll::Ready(None),
+        }
     }
 }

--- a/zlink-smol/src/notified.rs
+++ b/zlink-smol/src/notified.rs
@@ -66,6 +66,7 @@ where
     pub fn stream(&self) -> Stream<ReplyParams> {
         Stream(Box::pin(StreamInner::Broadcast {
             receiver: self.inactive_rx.activate_cloned(),
+            cached: None,
         }))
     }
 }
@@ -130,14 +131,22 @@ where
         let this = self.get_mut();
         // Project through the Pin<Box<StreamInner>> to the receivers
         match this.0.as_mut().project() {
-            StreamInnerProj::Broadcast { receiver } => {
-                match futures_util::ready!(receiver.poll_next(cx)) {
-                    Some(reply) => {
-                        Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(true))))
-                    }
-                    None => Poll::Ready(None),
+            StreamInnerProj::Broadcast {
+                mut receiver,
+                cached,
+            } => match futures_util::ready!(receiver.as_mut().poll_next(cx)) {
+                Some(reply) => {
+                    // Cache and yield immediately with continues=true.
+                    *cached = Some(reply.clone());
+                    Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(true))))
                 }
-            }
+                // Channel closed - yield cached value with continues=false.
+                None => Poll::Ready(
+                    cached
+                        .take()
+                        .map(|reply| Reply::new(Some(reply)).set_continues(Some(false))),
+                ),
+            },
             StreamInnerProj::Oneshot {
                 receiver,
                 terminated,
@@ -165,6 +174,7 @@ pin_project! {
         Broadcast {
             #[pin]
             receiver: BroadcastReceiver<ReplyParams>,
+            cached: Option<ReplyParams>,
         },
         Oneshot {
             #[pin]

--- a/zlink-smol/src/notified.rs
+++ b/zlink-smol/src/notified.rs
@@ -64,10 +64,12 @@ where
 
     /// A stream of replies for the notified field.
     pub fn stream(&self) -> Stream<ReplyParams> {
-        Stream(Box::pin(StreamInner::Broadcast {
-            receiver: self.inactive_rx.activate_cloned(),
-            cached: None,
-        }))
+        Stream {
+            inner: StreamInner::Broadcast {
+                receiver: self.inactive_rx.activate_cloned(),
+                cached: None,
+            },
+        }
     }
 }
 
@@ -89,10 +91,12 @@ where
 
         (
             Self { tx },
-            Stream(Box::pin(StreamInner::Oneshot {
-                receiver: rx,
-                terminated: false,
-            })),
+            Stream {
+                inner: StreamInner::Oneshot {
+                    receiver: rx,
+                    terminated: false,
+                },
+            },
         )
     }
 
@@ -107,16 +111,13 @@ where
     }
 }
 
-/// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when using
-/// [`State`] or [`Once`].
-pub struct Stream<ReplyParams>(Pin<Box<StreamInner<ReplyParams>>>);
-
-impl<ReplyParams> std::fmt::Debug for Stream<ReplyParams>
-where
-    ReplyParams: std::fmt::Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Stream").field(&self.0).finish()
+pin_project! {
+    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
+    /// using [`State`] or [`Once`].
+    #[derive(Debug)]
+    pub struct Stream<ReplyParams> {
+        #[pin]
+        inner: StreamInner<ReplyParams>,
     }
 }
 
@@ -127,10 +128,8 @@ where
     type Item = Reply<ReplyParams>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        // Since Stream is Unpin, we can get mutable access
-        let this = self.get_mut();
-        // Project through the Pin<Box<StreamInner>> to the receivers
-        match this.0.as_mut().project() {
+        let this = self.project();
+        match this.inner.project() {
             StreamInnerProj::Broadcast {
                 mut receiver,
                 cached,

--- a/zlink-smol/src/notified/mod.rs
+++ b/zlink-smol/src/notified/mod.rs
@@ -5,3 +5,4 @@ mod state;
 
 pub use once::{Once, Stream as OnceStream};
 pub use state::{State, Stream};
+pub use zlink_core::notified as traits;

--- a/zlink-smol/src/notified/mod.rs
+++ b/zlink-smol/src/notified/mod.rs
@@ -1,0 +1,7 @@
+//! Convenience API for maintaining state, that notifies on changes.
+
+mod once;
+mod state;
+
+pub use once::{Once, Stream as OnceStream};
+pub use state::{State, Stream};

--- a/zlink-smol/src/notified/once.rs
+++ b/zlink-smol/src/notified/once.rs
@@ -16,12 +16,14 @@ pub struct Once<ReplyParams> {
     tx: OneshotSender<ReplyParams>,
 }
 
-impl<ReplyParams> Once<ReplyParams>
+impl<ReplyParams> zlink_core::notified::Once<ReplyParams> for Once<ReplyParams>
 where
     ReplyParams: Send + 'static + Debug,
 {
+    type Stream = Stream<ReplyParams>;
+
     /// Create a new notified oneshot state.
-    pub fn new() -> (Self, Stream<ReplyParams>) {
+    fn new() -> (Self, Stream<ReplyParams>) {
         let (tx, rx) = bounded(1);
 
         (
@@ -34,7 +36,7 @@ where
     }
 
     /// Set the value of the notified field and notify all listeners.
-    pub fn notify<T>(self, value: T)
+    fn notify<T>(self, value: T)
     where
         T: Into<ReplyParams> + Debug,
     {

--- a/zlink-smol/src/notified/once.rs
+++ b/zlink-smol/src/notified/once.rs
@@ -1,0 +1,78 @@
+use std::{
+    fmt::Debug,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::Reply;
+use async_channel::{bounded, Receiver as OneshotReceiver, Sender as OneshotSender};
+use pin_project_lite::pin_project;
+
+/// A one-shot notified state of a service implementation.
+///
+/// This is useful for handling method calls in a separate task/thread.
+#[derive(Debug)]
+pub struct Once<ReplyParams> {
+    tx: OneshotSender<ReplyParams>,
+}
+
+impl<ReplyParams> Once<ReplyParams>
+where
+    ReplyParams: Send + 'static + Debug,
+{
+    /// Create a new notified oneshot state.
+    pub fn new() -> (Self, Stream<ReplyParams>) {
+        let (tx, rx) = bounded(1);
+
+        (
+            Self { tx },
+            Stream {
+                inner: rx,
+                terminated: false,
+            },
+        )
+    }
+
+    /// Set the value of the notified field and notify all listeners.
+    pub fn notify<T>(self, value: T)
+    where
+        T: Into<ReplyParams> + Debug,
+    {
+        // Failure means that we dropped the receiver stream internally before it received anything
+        // and that's a big bug that must not happen.
+        self.tx.try_send(value.into()).unwrap();
+    }
+}
+
+pin_project! {
+    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
+    /// using [`Once`].
+    #[derive(Debug)]
+    pub struct Stream<ReplyParams> {
+        #[pin]
+        inner: OneshotReceiver<ReplyParams>,
+        terminated: bool,
+    }
+}
+
+impl<ReplyParams> futures_util::Stream for Stream<ReplyParams>
+where
+    ReplyParams: Send + 'static,
+{
+    type Item = Reply<ReplyParams>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        if *this.terminated {
+            return Poll::Ready(None);
+        }
+
+        match futures_util::ready!(this.inner.poll_next(cx)) {
+            Some(reply) => {
+                *this.terminated = true;
+                Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(false))))
+            }
+            None => Poll::Ready(None),
+        }
+    }
+}

--- a/zlink-smol/src/notified/state.rs
+++ b/zlink-smol/src/notified/state.rs
@@ -1,5 +1,3 @@
-//! Convenience API for maintaining state, that notifies on changes.
-
 use std::{
     fmt::Debug,
     pin::Pin,
@@ -10,7 +8,6 @@ use crate::Reply;
 use async_broadcast::{
     broadcast, InactiveReceiver, Receiver as BroadcastReceiver, Sender as BroadcastSender,
 };
-use async_channel::{bounded, Receiver as OneshotReceiver, Sender as OneshotSender};
 use pin_project_lite::pin_project;
 
 /// A notified state (e.g a field) of a service implementation.
@@ -71,42 +68,6 @@ where
     }
 }
 
-/// A one-shot notified state of a service implementation.
-///
-/// This is useful for handling method calls in a separate task/thread.
-#[derive(Debug)]
-pub struct Once<ReplyParams> {
-    tx: OneshotSender<ReplyParams>,
-}
-
-impl<ReplyParams> Once<ReplyParams>
-where
-    ReplyParams: Send + 'static + Debug,
-{
-    /// Create a new notified oneshot state.
-    pub fn new() -> (Self, OnceStream<ReplyParams>) {
-        let (tx, rx) = bounded(1);
-
-        (
-            Self { tx },
-            OnceStream {
-                inner: rx,
-                terminated: false,
-            },
-        )
-    }
-
-    /// Set the value of the notified field and notify all listeners.
-    pub fn notify<T>(self, value: T)
-    where
-        T: Into<ReplyParams> + Debug,
-    {
-        // Failure means that we dropped the receiver stream internally before it received anything
-        // and that's a big bug that must not happen.
-        self.tx.try_send(value.into()).unwrap();
-    }
-}
-
 pin_project! {
     /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
     /// using [`State`].
@@ -138,39 +99,6 @@ where
                     .take()
                     .map(|reply| Reply::new(Some(reply)).set_continues(Some(false))),
             ),
-        }
-    }
-}
-
-pin_project! {
-    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
-    /// using [`Once`].
-    #[derive(Debug)]
-    pub struct OnceStream<ReplyParams> {
-        #[pin]
-        inner: OneshotReceiver<ReplyParams>,
-        terminated: bool,
-    }
-}
-
-impl<ReplyParams> futures_util::Stream for OnceStream<ReplyParams>
-where
-    ReplyParams: Send + 'static,
-{
-    type Item = Reply<ReplyParams>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
-        if *this.terminated {
-            return Poll::Ready(None);
-        }
-
-        match futures_util::ready!(this.inner.poll_next(cx)) {
-            Some(reply) => {
-                *this.terminated = true;
-                Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(false))))
-            }
-            None => Poll::Ready(None),
         }
     }
 }

--- a/zlink-smol/src/notified/state.rs
+++ b/zlink-smol/src/notified/state.rs
@@ -19,13 +19,15 @@ pub struct State<T, ReplyParams> {
     inactive_rx: InactiveReceiver<ReplyParams>,
 }
 
-impl<T, ReplyParams> State<T, ReplyParams>
+impl<T, ReplyParams> zlink_core::notified::State<T, ReplyParams> for State<T, ReplyParams>
 where
-    T: Into<ReplyParams> + Clone + Debug,
+    T: Into<ReplyParams> + Clone + Debug + Send,
     ReplyParams: Clone + Send + 'static + Debug,
 {
+    type Stream = Stream<ReplyParams>;
+
     /// Create a new notified field.
-    pub fn new(value: T) -> Self {
+    fn new(value: T) -> Self {
         let (mut tx, rx) = broadcast(1);
         // Notification broadcast shouldn't await active subscribers.
         tx.set_await_active(false);
@@ -45,7 +47,7 @@ where
     }
 
     /// Set the value of the notified field and notify all listeners.
-    pub async fn set(&mut self, value: T) {
+    async fn set(&mut self, value: T) {
         self.value = value.clone();
         self.tx
             .broadcast_direct(value.into())
@@ -55,12 +57,12 @@ where
     }
 
     /// The value of the notified field.
-    pub fn get(&self) -> T {
+    fn get(&self) -> T {
         self.value.clone()
     }
 
     /// A stream of replies for the notified field.
-    pub fn stream(&self) -> Stream<ReplyParams> {
+    fn stream(&self) -> Stream<ReplyParams> {
         Stream {
             inner: self.inactive_rx.activate_cloned(),
             cached: None,

--- a/zlink-tokio/Cargo.toml
+++ b/zlink-tokio/Cargo.toml
@@ -29,6 +29,7 @@ futures-util = { version = "0.3.31", default-features = false, features = [
 tokio-stream = { version = "0.1.17", default-features = false, features = [
     "sync",
 ] }
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1.44.0", features = [

--- a/zlink-tokio/src/lib.rs
+++ b/zlink-tokio/src/lib.rs
@@ -11,5 +11,6 @@
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
 pub use zlink_core::*;
+#[cfg(feature = "server")]
 pub mod notified;
 pub mod unix;

--- a/zlink-tokio/src/notified.rs
+++ b/zlink-tokio/src/notified.rs
@@ -44,7 +44,10 @@ where
 
     /// Get a stream of replies for the notified field.
     pub fn stream(&self) -> Stream<ReplyParams> {
-        Stream(StreamInner::Broadcast(self.tx.subscribe().into()))
+        Stream(StreamInner::Broadcast {
+            stream: self.tx.subscribe().into(),
+            cached: None,
+        })
     }
 }
 
@@ -64,7 +67,7 @@ where
     pub fn new() -> (Self, Stream<ReplyParams>) {
         let (tx, rx) = oneshot::channel();
 
-        (Self { tx }, Stream(StreamInner::Oneshot(rx)))
+        (Self { tx }, Stream(StreamInner::Oneshot { receiver: rx }))
     }
 
     /// Set the value of the notified field and notify all listeners.
@@ -85,33 +88,39 @@ pub struct Stream<ReplyParams>(StreamInner<ReplyParams>);
 
 impl<ReplyParams> futures_util::Stream for Stream<ReplyParams>
 where
-    ReplyParams: Clone + Send + 'static,
+    ReplyParams: Clone + Send + Unpin + 'static,
 {
     type Item = Reply<ReplyParams>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        match &mut self.0 {
-            StreamInner::Broadcast(stream) => {
-                let reply = loop {
-                    match ready!(Pin::new(&mut *stream).poll_next(cx)) {
-                        Some(Ok(reply)) => {
-                            break Some(Reply::new(Some(reply)).set_continues(Some(true)));
-                        }
-                        // Some intermediate values were missed. That's OK, as long as we get the
-                        // latest value.
-                        Some(Err(_)) => continue,
-                        None => break None,
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.get_mut();
+        match &mut this.0 {
+            StreamInner::Broadcast { stream, cached } => loop {
+                match ready!(Pin::new(&mut *stream).poll_next(cx)) {
+                    Some(Ok(reply)) => {
+                        // Cache and yield immediately with continues=true.
+                        *cached = Some(reply.clone());
+                        break Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(true))));
                     }
-                };
-
-                Poll::Ready(reply)
-            }
-            StreamInner::Oneshot(stream) => {
-                if stream.is_terminated() {
+                    // Some intermediate values were missed. That's OK, as long as we get the
+                    // latest value.
+                    Some(Err(_)) => continue,
+                    // Channel closed - yield cached value with continues=false.
+                    None => {
+                        break Poll::Ready(
+                            cached
+                                .take()
+                                .map(|reply| Reply::new(Some(reply)).set_continues(Some(false))),
+                        )
+                    }
+                }
+            },
+            StreamInner::Oneshot { receiver } => {
+                if receiver.is_terminated() {
                     return Poll::Ready(None);
                 }
 
-                Pin::new(&mut *stream).poll(cx).map(|reply| {
+                Pin::new(&mut *receiver).poll(cx).map(|reply| {
                     reply
                         .map(|reply| Reply::new(Some(reply)).set_continues(Some(false)))
                         .ok()
@@ -123,6 +132,11 @@ where
 
 #[derive(Debug)]
 enum StreamInner<ReplyParams> {
-    Broadcast(BroadcastStream<ReplyParams>),
-    Oneshot(oneshot::Receiver<ReplyParams>),
+    Broadcast {
+        stream: BroadcastStream<ReplyParams>,
+        cached: Option<ReplyParams>,
+    },
+    Oneshot {
+        receiver: oneshot::Receiver<ReplyParams>,
+    },
 }

--- a/zlink-tokio/src/notified.rs
+++ b/zlink-tokio/src/notified.rs
@@ -4,10 +4,11 @@ use std::{
     fmt::Debug,
     future::Future,
     pin::Pin,
-    task::{ready, Context, Poll},
+    task::{Context, Poll},
 };
 
 use crate::Reply;
+use pin_project_lite::pin_project;
 use tokio::sync::{broadcast, oneshot};
 use tokio_stream::wrappers::BroadcastStream;
 
@@ -44,10 +45,12 @@ where
 
     /// Get a stream of replies for the notified field.
     pub fn stream(&self) -> Stream<ReplyParams> {
-        Stream(StreamInner::Broadcast {
-            stream: self.tx.subscribe().into(),
-            cached: None,
-        })
+        Stream {
+            inner: StreamInner::Broadcast {
+                stream: self.tx.subscribe().into(),
+                cached: None,
+            },
+        }
     }
 }
 
@@ -67,7 +70,12 @@ where
     pub fn new() -> (Self, Stream<ReplyParams>) {
         let (tx, rx) = oneshot::channel();
 
-        (Self { tx }, Stream(StreamInner::Oneshot { receiver: rx }))
+        (
+            Self { tx },
+            Stream {
+                inner: StreamInner::Oneshot { receiver: rx },
+            },
+        )
     }
 
     /// Set the value of the notified field and notify all listeners.
@@ -81,22 +89,27 @@ where
     }
 }
 
-/// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when using
-/// [`State`] or [`Once`].
-#[derive(Debug)]
-pub struct Stream<ReplyParams>(StreamInner<ReplyParams>);
+pin_project! {
+    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
+    /// using [`State`] or [`Once`].
+    #[derive(Debug)]
+    pub struct Stream<ReplyParams> {
+        #[pin]
+        inner: StreamInner<ReplyParams>,
+    }
+}
 
 impl<ReplyParams> futures_util::Stream for Stream<ReplyParams>
 where
-    ReplyParams: Clone + Send + Unpin + 'static,
+    ReplyParams: Clone + Send + 'static,
 {
     type Item = Reply<ReplyParams>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.get_mut();
-        match &mut this.0 {
-            StreamInner::Broadcast { stream, cached } => loop {
-                match ready!(Pin::new(&mut *stream).poll_next(cx)) {
+        let this = self.project();
+        match this.inner.project() {
+            StreamInnerProj::Broadcast { mut stream, cached } => loop {
+                match futures_util::ready!(stream.as_mut().poll_next(cx)) {
                     Some(Ok(reply)) => {
                         // Cache and yield immediately with continues=true.
                         *cached = Some(reply.clone());
@@ -115,12 +128,12 @@ where
                     }
                 }
             },
-            StreamInner::Oneshot { receiver } => {
+            StreamInnerProj::Oneshot { receiver } => {
                 if receiver.is_terminated() {
                     return Poll::Ready(None);
                 }
 
-                Pin::new(&mut *receiver).poll(cx).map(|reply| {
+                receiver.poll(cx).map(|reply| {
                     reply
                         .map(|reply| Reply::new(Some(reply)).set_continues(Some(false)))
                         .ok()
@@ -130,13 +143,18 @@ where
     }
 }
 
-#[derive(Debug)]
-enum StreamInner<ReplyParams> {
-    Broadcast {
-        stream: BroadcastStream<ReplyParams>,
-        cached: Option<ReplyParams>,
-    },
-    Oneshot {
-        receiver: oneshot::Receiver<ReplyParams>,
-    },
+pin_project! {
+    #[project = StreamInnerProj]
+    #[derive(Debug)]
+    enum StreamInner<ReplyParams> {
+        Broadcast {
+            #[pin]
+            stream: BroadcastStream<ReplyParams>,
+            cached: Option<ReplyParams>,
+        },
+        Oneshot {
+            #[pin]
+            receiver: oneshot::Receiver<ReplyParams>,
+        },
+    }
 }

--- a/zlink-tokio/src/notified.rs
+++ b/zlink-tokio/src/notified.rs
@@ -46,10 +46,8 @@ where
     /// Get a stream of replies for the notified field.
     pub fn stream(&self) -> Stream<ReplyParams> {
         Stream {
-            inner: StreamInner::Broadcast {
-                stream: self.tx.subscribe().into(),
-                cached: None,
-            },
+            inner: self.tx.subscribe().into(),
+            cached: None,
         }
     }
 }
@@ -67,15 +65,10 @@ where
     ReplyParams: Send + 'static + Debug,
 {
     /// Create a new notified oneshot state.
-    pub fn new() -> (Self, Stream<ReplyParams>) {
+    pub fn new() -> (Self, OnceStream<ReplyParams>) {
         let (tx, rx) = oneshot::channel();
 
-        (
-            Self { tx },
-            Stream {
-                inner: StreamInner::Oneshot { receiver: rx },
-            },
-        )
+        (Self { tx }, OnceStream { inner: rx })
     }
 
     /// Set the value of the notified field and notify all listeners.
@@ -91,11 +84,12 @@ where
 
 pin_project! {
     /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
-    /// using [`State`] or [`Once`].
+    /// using [`State`].
     #[derive(Debug)]
     pub struct Stream<ReplyParams> {
         #[pin]
-        inner: StreamInner<ReplyParams>,
+        inner: BroadcastStream<ReplyParams>,
+        cached: Option<ReplyParams>,
     }
 }
 
@@ -107,54 +101,56 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let this = self.project();
-        match this.inner.project() {
-            StreamInnerProj::Broadcast { mut stream, cached } => loop {
-                match futures_util::ready!(stream.as_mut().poll_next(cx)) {
-                    Some(Ok(reply)) => {
-                        // Cache and yield immediately with continues=true.
-                        *cached = Some(reply.clone());
-                        break Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(true))));
-                    }
-                    // Some intermediate values were missed. That's OK, as long as we get the
-                    // latest value.
-                    Some(Err(_)) => continue,
-                    // Channel closed - yield cached value with continues=false.
-                    None => {
-                        break Poll::Ready(
-                            cached
-                                .take()
-                                .map(|reply| Reply::new(Some(reply)).set_continues(Some(false))),
-                        )
-                    }
+        let mut stream = this.inner;
+        loop {
+            match futures_util::ready!(stream.as_mut().poll_next(cx)) {
+                Some(Ok(reply)) => {
+                    // Cache and yield immediately with continues=true.
+                    *this.cached = Some(reply.clone());
+                    break Poll::Ready(Some(Reply::new(Some(reply)).set_continues(Some(true))));
                 }
-            },
-            StreamInnerProj::Oneshot { receiver } => {
-                if receiver.is_terminated() {
-                    return Poll::Ready(None);
+                // Some intermediate values were missed. That's OK, as long as we get the
+                // latest value.
+                Some(Err(_)) => continue,
+                // Channel closed - yield cached value with continues=false.
+                None => {
+                    break Poll::Ready(
+                        this.cached
+                            .take()
+                            .map(|reply| Reply::new(Some(reply)).set_continues(Some(false))),
+                    )
                 }
-
-                receiver.poll(cx).map(|reply| {
-                    reply
-                        .map(|reply| Reply::new(Some(reply)).set_continues(Some(false)))
-                        .ok()
-                })
             }
         }
     }
 }
 
 pin_project! {
-    #[project = StreamInnerProj]
+    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
+    /// using [`Once`].
     #[derive(Debug)]
-    enum StreamInner<ReplyParams> {
-        Broadcast {
-            #[pin]
-            stream: BroadcastStream<ReplyParams>,
-            cached: Option<ReplyParams>,
-        },
-        Oneshot {
-            #[pin]
-            receiver: oneshot::Receiver<ReplyParams>,
-        },
+    pub struct OnceStream<ReplyParams> {
+        #[pin]
+        inner: oneshot::Receiver<ReplyParams>,
+    }
+}
+
+impl<ReplyParams> futures_util::Stream for OnceStream<ReplyParams>
+where
+    ReplyParams: Send + 'static,
+{
+    type Item = Reply<ReplyParams>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        if this.inner.is_terminated() {
+            return Poll::Ready(None);
+        }
+
+        this.inner.poll(cx).map(|reply| {
+            reply
+                .map(|reply| Reply::new(Some(reply)).set_continues(Some(false)))
+                .ok()
+        })
     }
 }

--- a/zlink-tokio/src/notified/mod.rs
+++ b/zlink-tokio/src/notified/mod.rs
@@ -5,3 +5,4 @@ mod state;
 
 pub use once::{Once, Stream as OnceStream};
 pub use state::{State, Stream};
+pub use zlink_core::notified as traits;

--- a/zlink-tokio/src/notified/mod.rs
+++ b/zlink-tokio/src/notified/mod.rs
@@ -1,0 +1,7 @@
+//! Convenience API for maintaining state, that notifies on changes.
+
+mod once;
+mod state;
+
+pub use once::{Once, Stream as OnceStream};
+pub use state::{State, Stream};

--- a/zlink-tokio/src/notified/once.rs
+++ b/zlink-tokio/src/notified/once.rs
@@ -17,19 +17,21 @@ pub struct Once<ReplyParams> {
     tx: oneshot::Sender<ReplyParams>,
 }
 
-impl<ReplyParams> Once<ReplyParams>
+impl<ReplyParams> zlink_core::notified::Once<ReplyParams> for Once<ReplyParams>
 where
     ReplyParams: Send + 'static + Debug,
 {
+    type Stream = Stream<ReplyParams>;
+
     /// Create a new notified oneshot state.
-    pub fn new() -> (Self, Stream<ReplyParams>) {
+    fn new() -> (Self, Stream<ReplyParams>) {
         let (tx, rx) = oneshot::channel();
 
         (Self { tx }, Stream { inner: rx })
     }
 
     /// Set the value of the notified field and notify all listeners.
-    pub fn notify<T>(self, value: T)
+    fn notify<T>(self, value: T)
     where
         T: Into<ReplyParams> + Debug,
     {

--- a/zlink-tokio/src/notified/once.rs
+++ b/zlink-tokio/src/notified/once.rs
@@ -1,0 +1,70 @@
+use std::{
+    fmt::Debug,
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use crate::Reply;
+use pin_project_lite::pin_project;
+use tokio::sync::oneshot;
+
+/// A one-shot notified state of a service implementation.
+///
+/// This is useful for handling method calls in a separate task/thread.
+#[derive(Debug)]
+pub struct Once<ReplyParams> {
+    tx: oneshot::Sender<ReplyParams>,
+}
+
+impl<ReplyParams> Once<ReplyParams>
+where
+    ReplyParams: Send + 'static + Debug,
+{
+    /// Create a new notified oneshot state.
+    pub fn new() -> (Self, Stream<ReplyParams>) {
+        let (tx, rx) = oneshot::channel();
+
+        (Self { tx }, Stream { inner: rx })
+    }
+
+    /// Set the value of the notified field and notify all listeners.
+    pub fn notify<T>(self, value: T)
+    where
+        T: Into<ReplyParams> + Debug,
+    {
+        // Failure means that we dropped the receiver stream internally before it received anything
+        // and that's a big bug that must not happen.
+        self.tx.send(value.into()).unwrap();
+    }
+}
+
+pin_project! {
+    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
+    /// using [`Once`].
+    #[derive(Debug)]
+    pub struct Stream<ReplyParams> {
+        #[pin]
+        inner: oneshot::Receiver<ReplyParams>,
+    }
+}
+
+impl<ReplyParams> futures_util::Stream for Stream<ReplyParams>
+where
+    ReplyParams: Send + 'static,
+{
+    type Item = Reply<ReplyParams>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
+        if this.inner.is_terminated() {
+            return Poll::Ready(None);
+        }
+
+        this.inner.poll(cx).map(|reply| {
+            reply
+                .map(|reply| Reply::new(Some(reply)).set_continues(Some(false)))
+                .ok()
+        })
+    }
+}

--- a/zlink-tokio/src/notified/state.rs
+++ b/zlink-tokio/src/notified/state.rs
@@ -16,32 +16,34 @@ pub struct State<T, ReplyParams> {
     tx: broadcast::Sender<ReplyParams>,
 }
 
-impl<T, ReplyParams> State<T, ReplyParams>
+impl<T, ReplyParams> zlink_core::notified::State<T, ReplyParams> for State<T, ReplyParams>
 where
-    T: Into<ReplyParams> + Clone + Debug,
+    T: Into<ReplyParams> + Clone + Debug + Send,
     ReplyParams: Clone + Send + 'static + Debug,
 {
+    type Stream = Stream<ReplyParams>;
+
     /// Create a new notified field.
-    pub fn new(value: T) -> Self {
+    fn new(value: T) -> Self {
         let (tx, _) = broadcast::channel(1);
 
         Self { value, tx }
     }
 
     /// Set the value of the notified field and notify all listeners.
-    pub async fn set(&mut self, value: T) {
+    async fn set(&mut self, value: T) {
         self.value = value.clone();
         // Failure means that there are currently no receivers and that's ok.
         let _ = self.tx.send(value.into());
     }
 
     /// Get the value of the notified field.
-    pub fn get(&self) -> T {
+    fn get(&self) -> T {
         self.value.clone()
     }
 
     /// Get a stream of replies for the notified field.
-    pub fn stream(&self) -> Stream<ReplyParams> {
+    fn stream(&self) -> Stream<ReplyParams> {
         Stream {
             inner: self.tx.subscribe().into(),
             cached: None,

--- a/zlink-tokio/src/notified/state.rs
+++ b/zlink-tokio/src/notified/state.rs
@@ -1,15 +1,12 @@
-//! Convenience API for maintaining state, that notifies on changes.
-
 use std::{
     fmt::Debug,
-    future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
 
 use crate::Reply;
 use pin_project_lite::pin_project;
-use tokio::sync::{broadcast, oneshot};
+use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 
 /// A notified state (e.g a field) of a service implementation.
@@ -49,36 +46,6 @@ where
             inner: self.tx.subscribe().into(),
             cached: None,
         }
-    }
-}
-
-/// A one-shot notified state of a service implementation.
-///
-/// This is useful for handling method calls in a separate task/thread.
-#[derive(Debug)]
-pub struct Once<ReplyParams> {
-    tx: oneshot::Sender<ReplyParams>,
-}
-
-impl<ReplyParams> Once<ReplyParams>
-where
-    ReplyParams: Send + 'static + Debug,
-{
-    /// Create a new notified oneshot state.
-    pub fn new() -> (Self, OnceStream<ReplyParams>) {
-        let (tx, rx) = oneshot::channel();
-
-        (Self { tx }, OnceStream { inner: rx })
-    }
-
-    /// Set the value of the notified field and notify all listeners.
-    pub fn notify<T>(self, value: T)
-    where
-        T: Into<ReplyParams> + Debug,
-    {
-        // Failure means that we dropped the receiver stream internally before it received anything
-        // and that's a big bug that must not happen.
-        self.tx.send(value.into()).unwrap();
     }
 }
 
@@ -122,35 +89,5 @@ where
                 }
             }
         }
-    }
-}
-
-pin_project! {
-    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
-    /// using [`Once`].
-    #[derive(Debug)]
-    pub struct OnceStream<ReplyParams> {
-        #[pin]
-        inner: oneshot::Receiver<ReplyParams>,
-    }
-}
-
-impl<ReplyParams> futures_util::Stream for OnceStream<ReplyParams>
-where
-    ReplyParams: Send + 'static,
-{
-    type Item = Reply<ReplyParams>;
-
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
-        if this.inner.is_terminated() {
-            return Poll::Ready(None);
-        }
-
-        this.inner.poll(cx).map(|reply| {
-            reply
-                .map(|reply| Reply::new(Some(reply)).set_continues(Some(false)))
-                .ok()
-        })
     }
 }

--- a/zlink/tests/lowlevel-ftl.rs
+++ b/zlink/tests/lowlevel-ftl.rs
@@ -10,7 +10,7 @@ use zlink::{
     connection::Socket,
     idl::Interface,
     introspect::{self, CustomType, ReplyError as _, Type},
-    notified,
+    notified::{self, traits::State as _},
     service::MethodReply,
     unix::{bind, connect},
     varlink_service::{


### PR DESCRIPTION
- **✨ smol,tokio: notified::Stream now handles notified::State drop**
- **➕ tokio: Add direct dep on pin-project-lite**
- **🏗️ smol,tokio: Use pin-project-lite to consolidate notified**
- **✨ smol,tokio: Split stream types for `notified`**
- **♻️  smol,tokio: Split `notified` module into a hierarchy**
- **🚩 smol,tokio: `notified` now gated behind `server` feature**
- **🏗️ core: Provide traits for `notified` API**

Fixes #86.
