### PR TITLE
🚸 core: Add `ReadyListener`

### DIFF
--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -30,7 +30,7 @@ pub use error::{Error, Result};
 mod server;
 #[cfg(feature = "server")]
 pub use server::{
-    listener::Listener,
+    listener::{Listener, ReadyListener},
     service::{self, Service},
     Server,
 };

--- a/zlink-core/src/server/listener.rs
+++ b/zlink-core/src/server/listener.rs
@@ -10,3 +10,65 @@ pub trait Listener: core::fmt::Debug {
     /// Accept a new connection.
     fn accept(&mut self) -> impl Future<Output = Result<Connection<Self::Socket>>>;
 }
+
+/// A listener that already has a socket.
+///
+/// This is useful for services that get spawned by systemd and handed over a socket.
+#[derive(Debug)]
+pub struct ReadyListener<Sock: Socket> {
+    socket: Option<Sock>,
+}
+
+impl<Sock> ReadyListener<Sock>
+where
+    Sock: Socket,
+{
+    /// Create a new listener from a socket.
+    pub fn new(socket: Sock) -> Self {
+        Self {
+            socket: Some(socket),
+        }
+    }
+}
+
+impl<Sock> Listener for ReadyListener<Sock>
+where
+    Sock: Socket,
+{
+    type Socket = Sock;
+
+    /// This implementation simply returns the contained socket.
+    ///
+    /// After the first call, in simply never returns on subsequent calls.
+    async fn accept(&mut self) -> Result<Connection<Self::Socket>> {
+        match self.socket.take() {
+            Some(socket) => Ok(Connection::new(socket)),
+            None => core::future::pending().await,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use core::{future::poll_fn, task::Poll};
+
+    use super::*;
+    use crate::test_utils::mock_socket::MockSocket;
+
+    #[tokio::test]
+    async fn ready_listener() {
+        let socket = MockSocket::with_responses(&["test"]);
+        let mut listener = ReadyListener::new(socket);
+
+        // First call returns a connection with properly split read/write halves.
+        let conn = listener.accept().await.unwrap();
+        let (read, write) = conn.split();
+        assert_eq!(read.id(), write.id());
+
+        // Second call should be pending forever.
+        let accept_fut = listener.accept();
+        futures_util::pin_mut!(accept_fut);
+        let is_pending = poll_fn(|cx| Poll::Ready(accept_fut.as_mut().poll(cx).is_pending())).await;
+        assert!(is_pending);
+    }
+}


### PR DESCRIPTION
This is a listener that is given an already connected socket and doesn't
actually accept new connections. This is useful for systemd-launched
services, where the service is given a socket.
