### PR TITLE
🚑️ core,macros: Don't assume futures_util dep

### DIFF
--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -53,6 +53,10 @@ pub use zlink_macros::proxy;
 #[cfg(feature = "service")]
 pub use zlink_macros::service;
 
+/// Re-export of futures-util for use in generated code.
+#[doc(hidden)]
+pub use futures_util;
+
 /// Re-export of pin-project-lite for use in generated service code.
 #[cfg(feature = "service")]
 #[doc(hidden)]

--- a/zlink-macros/src/proxy/method_impl.rs
+++ b/zlink-macros/src/proxy/method_impl.rs
@@ -461,7 +461,7 @@ fn generate_streaming_method(
     let return_type = if return_fds {
         quote! {
             #crate_path::Result<
-                impl ::futures_util::stream::Stream<
+                impl #crate_path::futures_util::stream::Stream<
                     Item = #crate_path::Result<(::core::result::Result<#reply_type, #error_type>, ::std::vec::Vec<::std::os::fd::OwnedFd>)>
                 >
             >
@@ -469,7 +469,7 @@ fn generate_streaming_method(
     } else {
         quote! {
             #crate_path::Result<
-                impl ::futures_util::stream::Stream<
+                impl #crate_path::futures_util::stream::Stream<
                     Item = #crate_path::Result<::core::result::Result<#reply_type, #error_type>>
                 >
             >
@@ -531,7 +531,7 @@ fn generate_streaming_method(
             1,
         );
 
-        use ::futures_util::stream::{Stream, StreamExt};
+        use #crate_path::futures_util::stream::{Stream, StreamExt};
         Ok(#map_stream)
     };
     (return_type, implementation)

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -176,7 +176,7 @@ pub(super) fn generate_service_impl(
             (
                 quote! {
                     ::std::boxed::Box<
-                        dyn ::futures_util::Stream<
+                        dyn #crate_path::futures_util::Stream<
                                 Item = #crate_path::service::ReplyStreamItem<#reply_stream_params_name>
                             > + ::core::marker::Unpin
                     >
@@ -202,7 +202,7 @@ pub(super) fn generate_service_impl(
     } else {
         // No streaming methods - use empty stream.
         (
-            quote! { ::futures_util::stream::Empty<#crate_path::service::ReplyStreamItem<()>> },
+            quote! { #crate_path::futures_util::stream::Empty<#crate_path::service::ReplyStreamItem<()>> },
             quote! { () },
             quote! {},
         )
@@ -666,7 +666,7 @@ fn generate_reply_stream_enum(
             }
         }
 
-        impl ::futures_util::Stream for #enum_name {
+        impl #crate_path::futures_util::Stream for #enum_name {
             type Item = #crate_path::service::ReplyStreamItem<#reply_stream_params_name>;
 
             fn poll_next(
@@ -1077,7 +1077,7 @@ fn generate_handle_body(
                     // Method's stream yields (Reply<T>, Vec<OwnedFd>).
                     quote! {
                         let __stream = #method_call;
-                        let __mapped = ::futures_util::StreamExt::map(
+                        let __mapped = #crate_path::futures_util::StreamExt::map(
                             __stream,
                             |(__reply, __fds)| {
                                 let __mapped_reply = __reply.map(|__params| {
@@ -1087,7 +1087,7 @@ fn generate_handle_body(
                             },
                         );
                         let __boxed: ::std::boxed::Box<
-                            dyn ::futures_util::Stream<
+                            dyn #crate_path::futures_util::Stream<
                                     Item = #crate_path::service::ReplyStreamItem<
                                         #reply_stream_params_name
                                     >
@@ -1099,14 +1099,14 @@ fn generate_handle_body(
                     // Method's stream yields Reply<T>, wrap with empty FDs.
                     quote! {
                         let __stream = #method_call;
-                        let __mapped = ::futures_util::StreamExt::map(__stream, |__reply| {
+                        let __mapped = #crate_path::futures_util::StreamExt::map(__stream, |__reply| {
                             let __mapped_reply = __reply.map(|__params| {
                                 #reply_stream_params_name::#stream_variant_name(__params)
                             });
                             (__mapped_reply, ::std::vec::Vec::new())
                         });
                         let __boxed: ::std::boxed::Box<
-                            dyn ::futures_util::Stream<
+                            dyn #crate_path::futures_util::Stream<
                                     Item = #crate_path::service::ReplyStreamItem<
                                         #reply_stream_params_name
                                     >
@@ -1118,13 +1118,13 @@ fn generate_handle_body(
                 #[cfg(not(feature = "std"))]
                 let boxed_stream = quote! {
                     let __stream = #method_call;
-                    let __mapped = ::futures_util::StreamExt::map(__stream, |__reply| {
+                    let __mapped = #crate_path::futures_util::StreamExt::map(__stream, |__reply| {
                         __reply.map(|__params| {
                             #reply_stream_params_name::#stream_variant_name(__params)
                         })
                     });
                     let __boxed: ::std::boxed::Box<
-                        dyn ::futures_util::Stream<
+                        dyn #crate_path::futures_util::Stream<
                                 Item = #crate_path::service::ReplyStreamItem<
                                     #reply_stream_params_name
                                 >


### PR DESCRIPTION
Instead of assuming futures_util to be a direct dep of the using crate
in the macros, re-export it in core and use it from there.

Fixes #230.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
