### PR TITLE
🐛 macros: Allow explicit lifetimes in service method args

### DIFF
--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -782,7 +782,7 @@ fn generate_interface_descriptions(
                         // uses `_name` for unused params, but Varlink IDL doesn't allow that).
                         let default_name = p.name.to_string().trim_start_matches('_').to_string();
                         let param_name = p.serialized_name.as_ref().unwrap_or(&default_name);
-                        let ty = &p.ty;
+                        let ty = convert_type_lifetimes(&p.ty, "'static");
                         quote! {
                             &#crate_path::idl::Parameter::new(
                                 #param_name,
@@ -849,6 +849,7 @@ fn generate_interface_descriptions(
                 seen_error_types.insert(type_str)
             })
             .map(|err_ty| {
+                let err_ty = convert_type_lifetimes(err_ty, "'static");
                 quote! {
                     <#err_ty as #crate_path::introspect::ReplyError>::VARIANTS
                 }

--- a/zlink-macros/tests/service.rs
+++ b/zlink-macros/tests/service.rs
@@ -9,6 +9,8 @@ mod basic;
 mod borrowed_types;
 #[path = "service/custom_bounds.rs"]
 mod custom_bounds;
+#[path = "service/explicit-lifetimes.rs"]
+mod explicit_lifetimes;
 #[path = "service/fd_passing.rs"]
 mod fd_passing;
 #[path = "service/introspection.rs"]

--- a/zlink-macros/tests/service/explicit-lifetimes.rs
+++ b/zlink-macros/tests/service/explicit-lifetimes.rs
@@ -1,0 +1,43 @@
+//! Build-only test: verifies that explicit lifetime parameters on service methods compile.
+//!
+//! Before the fix, `&'a str` in introspection `const` contexts caused a compilation error
+//! because `'a` was not in scope.
+
+use serde::{Deserialize, Serialize};
+use zlink::introspect::{self, CustomType};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct EchoReply {
+    message: String,
+}
+
+#[derive(Debug, PartialEq, zlink::ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.ExplicitLifetimes")]
+enum EchoError<'a> {
+    InvalidInput { reason: &'a str },
+}
+
+struct EchoService;
+
+#[zlink::service(types = [EchoReply])]
+impl EchoService {
+    #[zlink(interface = "org.example.ExplicitLifetimes")]
+    async fn echo<'a>(&self, msg: &'a str) -> Result<EchoReply, EchoError<'_>> {
+        if msg.is_empty() {
+            Err(EchoError::InvalidInput {
+                reason: "empty input",
+            })
+        } else {
+            Ok(EchoReply {
+                message: msg.to_string(),
+            })
+        }
+    }
+}
+
+#[test]
+fn explicit_lifetimes_compile() {
+    // Just verify the macro-generated code compiles — the service, its error type and the
+    // introspection constants all reference explicit lifetimes that must be normalized.
+    let _service = EchoService;
+}


### PR DESCRIPTION
This was previously failing when introspection was enabled because the
generated code didn't filter the lifetimes.

Fixes #231.
