### PR TITLE
✨ core: Add (supplementary) groups to peer credentials

### DIFF
--- a/zlink-core/src/connection/credentials.rs
+++ b/zlink-core/src/connection/credentials.rs
@@ -1,11 +1,14 @@
 //! Connection credentials.
 
-use super::{Pid, Uid};
+use super::{Gid, Pid, Uid};
 
 /// Credentials of a peer connection.
 #[derive(Debug)]
 pub struct Credentials {
     unix_user_id: Uid,
+    unix_primary_group_id: Gid,
+    #[cfg(target_os = "linux")]
+    unix_supplementary_group_ids: Vec<Gid>,
     process_id: Pid,
     #[cfg(target_os = "linux")]
     process_fd: std::os::fd::OwnedFd,
@@ -20,11 +23,16 @@ impl Credentials {
     /// * `process_fd` (Linux only) - A file descriptor pinning the process.
     pub(crate) fn new(
         unix_user_id: Uid,
+        unix_primary_group_id: Gid,
+        #[cfg(target_os = "linux")] unix_supplementary_group_ids: Vec<Gid>,
         process_id: Pid,
         #[cfg(target_os = "linux")] process_fd: std::os::fd::OwnedFd,
     ) -> Self {
         Self {
             unix_user_id,
+            unix_primary_group_id,
+            #[cfg(target_os = "linux")]
+            unix_supplementary_group_ids,
             process_id,
             #[cfg(target_os = "linux")]
             process_fd,
@@ -41,6 +49,19 @@ impl Credentials {
     /// On Unix, this is the process ID defined by POSIX.
     pub fn process_id(&self) -> Pid {
         self.process_id
+    }
+
+    /// The numeric Unix group ID, as defined by POSIX.
+    pub fn unix_primary_group_id(&self) -> Gid {
+        self.unix_primary_group_id
+    }
+
+    /// The set of numeric supplementary Unix group IDs, as defined by POSIX.
+    ///
+    /// Currently, this method is only available for Linux targets.
+    #[cfg(target_os = "linux")]
+    pub fn unix_supplementary_group_ids(&self) -> &[Gid] {
+        &self.unix_supplementary_group_ids
     }
 
     /// A file descriptor pinning the process, on platforms that have this concept.

--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -49,7 +49,7 @@ mod read_connection;
 pub use credentials::Credentials;
 pub use read_connection::ReadConnection;
 #[cfg(feature = "std")]
-pub use rustix::{process::Pid, process::Uid};
+pub use rustix::{process::Gid, process::Pid, process::Uid};
 pub mod chain;
 pub mod socket;
 #[cfg(test)]

--- a/zlink-core/src/test_utils/mock_socket.rs
+++ b/zlink-core/src/test_utils/mock_socket.rs
@@ -181,18 +181,25 @@ impl connection::socket::FetchPeerCredentials for MockReadHalf {
         // For mock sockets, return credentials of the current process.
         let uid = rustix::process::getuid();
         let pid = rustix::process::getpid();
+        let gid = rustix::process::getgid();
 
         #[cfg(target_os = "linux")]
         {
             use rustix::process::PidfdFlags;
 
             let process_fd = rustix::process::pidfd_open(pid, PidfdFlags::empty())?;
-            Ok(connection::Credentials::new(uid, pid, process_fd))
+            Ok(connection::Credentials::new(
+                uid,
+                gid,
+                vec![],
+                pid,
+                process_fd,
+            ))
         }
 
         #[cfg(not(target_os = "linux"))]
         {
-            Ok(connection::Credentials::new(uid, pid))
+            Ok(connection::Credentials::new(uid, gid, pid))
         }
     }
 }

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -83,6 +83,47 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
         let ucred = rustix::net::sockopt::socket_peercred(fd)?;
         let uid = ucred.uid;
         let pid = ucred.pid;
+        let primary_gid = ucred.gid;
+
+        // Get SO_PEERGROUPS if available (Linux-only).
+        #[cfg(target_os = "linux")]
+        let supplementary_gids = {
+            use rustix::fs::Gid;
+
+            let mut nr_supp_gids = INITIAL_NUMBER_SUPPLEMENTARY_GROUPS;
+            let mut supp_gids: Vec<Gid> = Vec::with_capacity(nr_supp_gids as usize);
+
+            loop {
+                let ret = unsafe {
+                    libc::getsockopt(
+                        fd.as_raw_fd(),
+                        libc::SOL_SOCKET,
+                        libc::SO_PEERGROUPS,
+                        supp_gids.as_mut_ptr().cast(),
+                        &mut nr_supp_gids,
+                    )
+                };
+                let err = io::Error::last_os_error();
+
+                // We encountered an error which is not about the size of our passed container.
+                if ret == -1 && err.raw_os_error() != Some(libc::ERANGE) {
+                    return Err(err);
+                }
+
+                // If the number of groups returned is less than the requested size, we are done.
+                if nr_supp_gids as usize <= supp_gids.capacity() {
+                    supp_gids.shrink_to(nr_supp_gids as usize);
+                    break;
+                }
+
+                // Otherwise, the vector is too small. Resize and try again.
+                // We let the standard Vector speculation over-allocation take place here on
+                // purpose.
+                supp_gids.reserve(nr_supp_gids as usize - supp_gids.capacity());
+            }
+
+            supp_gids
+        };
 
         // Get SO_PEERPIDFD if available (Linux-only).
         #[cfg(target_os = "linux")]
@@ -120,9 +161,9 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
         };
 
         #[cfg(target_os = "android")]
-        let creds = Credentials::new(uid, pid);
+        let creds = Credentials::new(uid, primary_gid, pid);
         #[cfg(target_os = "linux")]
-        let creds = Credentials::new(uid, pid, process_fd);
+        let creds = Credentials::new(uid, primary_gid, supplementary_gids, pid, process_fd);
 
         Ok(creds)
     }
@@ -147,6 +188,7 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
         }
 
         let uid = rustix::process::Uid::from_raw(uid);
+        let gid = rustix::process::Gid::from_raw(gid);
 
         // Platform-specific PID fetching.
         #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -242,7 +284,7 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
         let pid = rustix::process::Pid::from_raw(0).unwrap();
 
-        Ok(Credentials::new(uid, pid))
+        Ok(Credentials::new(uid, gid, pid))
     }
 
     #[cfg(not(any(
@@ -267,3 +309,9 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
 ///
 /// The value is based on what is used in `zbus`, which comes from sdbus.
 const MAX_FDS: usize = 1024;
+
+// Linux can go up to NGROUPS_MAX supplementary groups (65K). It is safe to assume that
+// most users will have a couple of supplementary groups by default. We allocate 128
+// because integers are tiny.
+#[cfg(target_os = "linux")]
+const INITIAL_NUMBER_SUPPLEMENTARY_GROUPS: libc::socklen_t = 128 as libc::socklen_t;

--- a/zlink/tests/creds-utils.rs
+++ b/zlink/tests/creds-utils.rs
@@ -11,6 +11,7 @@ use zlink::connection::Credentials;
 pub fn verify_credentials(creds: &Credentials) -> Result<(), &'static str> {
     verify_uid(creds)?;
     verify_pid(creds)?;
+    verify_gid(creds)?;
     #[cfg(target_os = "linux")]
     verify_pidfd(creds)?;
     Ok(())
@@ -21,6 +22,15 @@ pub fn verify_uid(creds: &Credentials) -> Result<(), &'static str> {
     let expected_uid = rustix::process::getuid();
     if creds.unix_user_id() != expected_uid {
         return Err("UID does not match current process");
+    }
+    Ok(())
+}
+
+/// Verify GID matches current process.
+pub fn verify_gid(creds: &Credentials) -> Result<(), &'static str> {
+    let expected_gid = rustix::process::getgid();
+    if creds.unix_primary_group_id() != expected_gid {
+        return Err("GID does not match current process");
     }
     Ok(())
 }

--- a/zlink/tests/peer_credentials.rs
+++ b/zlink/tests/peer_credentials.rs
@@ -37,18 +37,32 @@ async fn peer_credentials_unix_socket() {
     // Save values for comparison.
     let uid1 = creds.unix_user_id();
     let pid1 = creds.process_id();
+    let gid1 = creds.unix_primary_group_id();
     #[cfg(target_os = "linux")]
     let pidfd1 = creds.process_fd().as_raw_fd();
+    #[cfg(target_os = "linux")]
+    let gids1 = creds.unix_supplementary_group_ids().to_owned();
 
     // Verify caching works - calling again should return the same values.
     let creds2 = connection.peer_credentials().await.unwrap();
     assert_eq!(uid1, creds2.unix_user_id(), "Cached UID should match");
     assert_eq!(pid1, creds2.process_id(), "Cached PID should match");
+    assert_eq!(
+        gid1,
+        creds2.unix_primary_group_id(),
+        "Cached GID should match"
+    );
     #[cfg(target_os = "linux")]
     assert_eq!(
         pidfd1,
         creds2.process_fd().as_raw_fd(),
         "Cached pidfd should match"
+    );
+    #[cfg(target_os = "linux")]
+    assert_eq!(
+        gids1,
+        creds2.unix_supplementary_group_ids(),
+        "Cached supplementary GIDs should match"
     );
 
     let _stream = connect_task.await.unwrap();


### PR DESCRIPTION
Fixes #238.

I wanted to add `SO_PEERGROUPS` to rustix but well well well, I'm not sure the resize logic deserves to be there. This is inspired from the chain in https://gerrit.lix.systems/c/lix/+/5019. I did not implement the other platform bits as I do not use them.

Testing supplementary GIDs is hard without a proper E2E test harness, so I left it out of unit testing.