### PR TITLE
 🔊  core: downgrade socket read warnings to debug

### DIFF
--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -133,7 +133,7 @@ where
                                     Err(e) => warn!("Error writing to connection: {:?}", e),
                                 }
                             }
-                            Err(e) => warn!("Error reading from socket: {:?}", e),
+                            Err(e) => debug!("Error reading from socket: {:?}", e),
                         }
 
                         if stream.is_some() || remove {


### PR DESCRIPTION
Once a client goes away after a call, a warning will be emitted while the future of the still-existing connection is being polled because the client went away.

To avoid unnecessary noise, this should be a debug.