### PR TITLE
macros: Support custom types per interface in introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,6 +2205,7 @@ dependencies = [
  "serde-prefix-all",
  "serde_json",
  "syn",
+ "tempfile",
  "test-log",
  "tokio",
  "zlink",

--- a/zlink-core/src/idl/field.rs
+++ b/zlink-core/src/idl/field.rs
@@ -44,7 +44,7 @@ impl<'a> Field<'a> {
     }
 
     /// Returns the type of the field.
-    pub fn ty(&self) -> &Type<'a> {
+    pub const fn ty(&self) -> &Type<'a> {
         self.ty.inner()
     }
 

--- a/zlink-core/src/introspect/assert.rs
+++ b/zlink-core/src/introspect/assert.rs
@@ -1,0 +1,154 @@
+//! Compile-time assertions for custom type declarations.
+//!
+//! These const functions are used by the `#[service]` macro to verify at compile time that
+//! any custom types referenced in method signatures are declared in `types = [...]`.
+
+use crate::idl;
+
+/// Assert at compile time that every parameter in `params` whose type is a custom type
+/// reference has its name listed in `declared`.
+///
+/// This is the batch version of [`assert_type_declared`] used for checking method output
+/// parameters, where the full `&[&Parameter]` slice is available as a const.
+///
+/// # Panics
+///
+/// Panics at compile time if any parameter type is (or contains) a `Custom(name)` that
+/// is not in `declared`.
+pub const fn assert_params_declared(params: &[&idl::Parameter<'_>], declared: &[&str]) {
+    let mut i = 0;
+    while i < params.len() {
+        assert_type_declared(params[i].ty(), declared);
+        i += 1;
+    }
+}
+
+/// Assert at compile time that if a type is a custom type reference, its name appears in
+/// the declared types list.
+///
+/// This is called by generated code from the `#[service]` macro. If the assertion fails,
+/// compilation stops with a message telling the user to add the type to `types = [...]`.
+///
+/// # Panics
+///
+/// Panics at compile time if `ty` is (or contains) a `Custom(name)` that is not in
+/// `declared`.
+pub const fn assert_type_declared(ty: &idl::Type<'_>, declared: &[&str]) {
+    if let Some(name) = custom_type_name(ty) {
+        if !name_in_list(name, declared) {
+            panic!(
+                "custom type used in method signature is not declared in `types = [...]`; \
+                 add it to the `types` list on the `#[zlink(interface = \"...\", types = [...])]` \
+                 attribute"
+            );
+        }
+    }
+}
+
+/// Extract the custom type name from an [`idl::Type`], if it is a custom type reference.
+///
+/// Returns `None` for primitive, optional, array, map, inline enum/object types.
+pub const fn custom_type_name<'a>(ty: &'a idl::Type<'a>) -> Option<&'a str> {
+    match ty {
+        idl::Type::Custom(name) => Some(name),
+        idl::Type::Optional(inner) | idl::Type::Array(inner) | idl::Type::Map(inner) => {
+            custom_type_name(inner.inner())
+        }
+        _ => None,
+    }
+}
+
+// Manual const-compatible string comparison helpers.
+//
+// `PartialEq` for `[u8]`/`str` is not yet const-stable (see
+// https://github.com/rust-lang/rust/issues/143874), so we roll our own
+// byte-by-byte comparison. Remove these once const `PartialEq` is stabilized.
+const fn bytes_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+const fn str_eq(a: &str, b: &str) -> bool {
+    bytes_eq(a.as_bytes(), b.as_bytes())
+}
+
+const fn name_in_list(name: &str, declared: &[&str]) -> bool {
+    let mut i = 0;
+    while i < declared.len() {
+        if str_eq(name, declared[i]) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::idl::{Type, TypeRef};
+
+    #[test]
+    fn primitive_types_always_pass() {
+        // Primitives should never trigger the assertion, even with an empty declared list.
+        const _: () = {
+            assert_type_declared(&Type::Bool, &[]);
+            assert_type_declared(&Type::Int, &[]);
+            assert_type_declared(&Type::Float, &[]);
+            assert_type_declared(&Type::String, &[]);
+            assert_type_declared(&Type::ForeignObject, &[]);
+            assert_type_declared(&Type::Any, &[]);
+        };
+    }
+
+    #[test]
+    fn custom_type_passes_when_declared() {
+        const _: () = {
+            assert_type_declared(&Type::Custom("Book"), &["Book", "Album"]);
+            assert_type_declared(&Type::Custom("Album"), &["Book", "Album"]);
+        };
+    }
+
+    #[test]
+    fn nested_custom_type_passes_when_declared() {
+        // Optional<Custom>, Array<Custom>, Map<Custom> should all be checked.
+        // These can't be const because TypeRef contains a Box variant with Drop.
+        static BOOK: Type<'static> = Type::Custom("Book");
+        assert_type_declared(&Type::Optional(TypeRef::new(&BOOK)), &["Book"]);
+        assert_type_declared(&Type::Array(TypeRef::new(&BOOK)), &["Book"]);
+        assert_type_declared(&Type::Map(TypeRef::new(&BOOK)), &["Book"]);
+    }
+
+    #[test]
+    fn custom_type_name_extracts_correctly() {
+        assert!(custom_type_name(&Type::Custom("Book")).is_some());
+        assert!(custom_type_name(&Type::Int).is_none());
+        assert!(custom_type_name(&Type::String).is_none());
+
+        static BOOK: Type<'static> = Type::Custom("Book");
+        assert!(custom_type_name(&Type::Optional(TypeRef::new(&BOOK))).is_some());
+        assert!(custom_type_name(&Type::Array(TypeRef::new(&BOOK))).is_some());
+    }
+
+    #[test]
+    #[should_panic(expected = "not declared in `types = [...]`")]
+    fn undeclared_custom_type_panics() {
+        assert_type_declared(&Type::Custom("Missing"), &["Book", "Album"]);
+    }
+
+    #[test]
+    #[should_panic(expected = "not declared in `types = [...]`")]
+    fn undeclared_nested_custom_type_panics() {
+        static MISSING: Type<'static> = Type::Custom("Missing");
+        assert_type_declared(&Type::Optional(TypeRef::new(&MISSING)), &["Book"]);
+    }
+}

--- a/zlink-core/src/introspect/mod.rs
+++ b/zlink-core/src/introspect/mod.rs
@@ -14,6 +14,9 @@ pub use custom_type::CustomType;
 mod reply_error;
 pub use reply_error::ReplyError;
 
+#[doc(hidden)]
+pub mod assert;
+
 // Re-export the the derive macro so it's available alongside the traits.
 pub use zlink_macros::{
     IntrospectCustomType as CustomType, IntrospectReplyError as ReplyError, IntrospectType as Type,

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -53,6 +53,7 @@ tokio = { version = "1.42.0", features = [
     "rt-multi-thread",
     "fs",
 ] }
+tempfile = "3.14"
 test-log = { version = "0.2.17", default-features = false, features = [
     "trace",
     "color",

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1017,8 +1017,10 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///   that implement a single interface. Methods can still override this with method-level
 ///   `#[zlink(interface = "...")]`.
 /// * `types = [Type1, Type2, ...]` - Custom types to include in interface descriptions. These types
-///   must implement `CustomType` (typically via `#[derive(CustomType)]`). The types are included in
-///   the IDL for any interface that uses them.
+///   must implement `CustomType` (typically via `#[derive(CustomType)]`). For single-interface
+///   services, these types are included in that interface's IDL output. For multi-interface
+///   services, prefer specifying types per interface using the method-level `#[zlink(interface =
+///   "...", types = [...])]` attribute instead.
 /// * `vendor = <expr>` - The vendor name for `GetInfo` response. Defaults to empty string.
 /// * `product = <expr>` - The product name for `GetInfo` response. Defaults to empty string.
 /// * `version = <expr>` - The version string for `GetInfo` response. Defaults to empty string. E.g.
@@ -1029,6 +1031,9 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///
 /// * `#[zlink(interface = "...")]` - Set the interface name for this and subsequent methods. If an
 ///   interface is specified at the impl block level, this overrides it for the current method.
+/// * `#[zlink(interface = "...", types = [Type1, ...])]` - Set the interface and associate custom
+///   types with it. This scopes the types to the specified interface so they only appear in that
+///   interface's introspection output. Particularly useful for multi-interface services.
 /// * `#[zlink(rename = "MethodName")]` - Custom Varlink method name.
 ///
 /// ## On parameters:
@@ -1037,6 +1042,33 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// * `#[zlink(connection)]` - Mark this parameter to receive a mutable reference to the connection.
 ///   This is useful for accessing peer credentials or other connection-specific functionality.
 ///   **Requires an explicit generic socket type parameter** (e.g., `impl<Sock> MyService`).
+///
+/// # Compile-time Type Checking
+///
+/// The macro verifies at compile time that any custom type referenced in a method's input *or*
+/// output parameters is declared in `types = [...]`. If you forget to list a type, you'll get
+/// a compile error:
+///
+/// ```rust,compile_fail
+/// use serde::{Deserialize, Serialize};
+/// use zlink::{introspect::CustomType, service};
+///
+/// #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+/// struct Book { title: String }
+///
+/// #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+/// struct BookList { books: Vec<Book> }
+///
+/// struct LibraryService;
+///
+/// // Missing `BookList` in `types = [...]` even though it's returned by `list_books`.
+/// #[service(interface = "org.example.library", types = [Book])]
+/// impl LibraryService {
+///     async fn list_books(&self) -> BookList {
+///         BookList { books: vec![] }
+///     }
+/// }
+/// ```
 ///
 /// # Generated Code
 ///

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -923,6 +923,44 @@ fn generate_interface_descriptions(
             .filter(|m| m.interface.as_ref() == Some(interface))
             .collect();
 
+        // Collect custom types scoped to this interface from method-level `types = [...]`,
+        // deduplicating by type path string representation.
+        let mut seen_custom_types = HashSet::new();
+        let per_interface_types: Vec<&Type> = methods_info
+            .iter()
+            .filter(|m| m.interface.as_ref() == Some(interface))
+            .flat_map(|m| m.custom_types.iter())
+            .filter(|ty| {
+                let type_str = ty.to_token_stream().to_string();
+                seen_custom_types.insert(type_str)
+            })
+            .collect();
+
+        // Use per-interface types if any were specified; otherwise fall back to the global list.
+        // This maintains backward compatibility for single-interface services that use the
+        // top-level `types = [...]` attribute.
+        let types_source: Vec<&Type> = if !per_interface_types.is_empty() {
+            per_interface_types
+        } else if interfaces.len() == 1 {
+            service_attrs.custom_types.iter().collect()
+        } else {
+            Vec::new()
+        };
+
+        // Pre-compute the declared-names token slice used in const assertions for both
+        // input parameters (outer block) and output parameters (inner per-method block).
+        let declared_names: Vec<TokenStream> = types_source
+            .iter()
+            .map(|ty| {
+                let ty = convert_type_lifetimes(ty, "'static");
+                quote! {
+                    #crate_path::introspect::assert::custom_type_name(
+                        <#ty as #crate_path::introspect::Type>::TYPE,
+                    ).expect("types = [...] entry is not a custom type")
+                }
+            })
+            .collect();
+
         // Generate inner const method definitions.
         // Each method needs its own const to avoid destructor issues.
         let method_consts: Vec<TokenStream> = interface_methods
@@ -963,27 +1001,50 @@ fn generate_interface_descriptions(
                     }
                 };
 
+                // Collect all custom types visible to this method: service-level types
+                // plus any per-interface types declared on the method itself.
+                let all_custom_types: Vec<&Type> = service_attrs
+                    .custom_types
+                    .iter()
+                    .chain(method.custom_types.iter())
+                    .collect();
+
+                // TODO: Varlink methods natively express flat named outputs (`-> (field: type, …)`),
+                // but Rust lacks anonymous named structs. Today, users must wrap their output in a
+                // named struct (e.g. `struct Reply { books: Vec<Book> }`), which the macro then
+                // "unwraps" by emitting the struct fields as the method's out-params. This causes
+                // wrapper structs to appear redundantly as top-level type definitions in the IDL.
+                // A future enhancement could let users write `-> (field: type)` directly in the
+                // method attribute to sidestep the wrapper-struct requirement.
                 let out_params_const = if method.is_streaming {
                     method.stream_item_type.clone()
                 } else {
                     method.return_type.clone()
                 }
                 .map(|ty| {
-                    if service_attrs.custom_types.contains(&ty) {
+                    if all_custom_types.contains(&&ty) {
+                        // Declared custom type: must be an object (struct) so its fields
+                        // can be emitted as named out-params. Custom enums are not valid
+                        // Varlink return types — the spec requires `-> (field: type, …)`.
                         quote! {
                             const __OUT_PARAMS: &[&#crate_path::idl::Parameter<'static>] =
                                 <#ty as #crate_path::introspect::CustomType>::CUSTOM_TYPE
                                     .as_object()
-                                    .expect("Return type has to be an object")
+                                    .expect("Varlink method return type must be a struct (object); \
+                                             enums and other types are not valid Varlink return types")
                                     .fields_as_slice()
                                     .unwrap();
                         }
                     } else {
+                        // Inline/anonymous object type via introspect::Type.
                         quote! {
                             const __OUT_PARAMS: &[&#crate_path::idl::Parameter<'static>] =
                                 <#ty as #crate_path::introspect::Type>::TYPE
                                     .as_object()
-                                    .expect("Return type has to be an object")
+                                    .expect("Varlink method return type must be a struct (object); \
+                                             arrays, primitives and other types cannot be used \
+                                             as top-level return types — wrap them in a struct, \
+                                             e.g. `struct Reply { items: Vec<T> }`")
                                     .as_borrowed()
                                     .unwrap();
                         }
@@ -999,6 +1060,14 @@ fn generate_interface_descriptions(
                     const #method_const_name: &#crate_path::idl::Method<'static> = &{
                         #in_params_const
                         #out_params_const
+                        // Verify all custom types in method output parameters are declared.
+                        const _: () = {
+                            const __DECLARED: &[&str] = &[#(#declared_names),*];
+                            #crate_path::introspect::assert::assert_params_declared(
+                                __OUT_PARAMS,
+                                __DECLARED,
+                            );
+                        };
                         #crate_path::idl::Method::new(
                             #method_name,
                             __IN_PARAMS,
@@ -1018,9 +1087,7 @@ fn generate_interface_descriptions(
             })
             .collect();
 
-        // Collect custom types for this interface.
-        let custom_types: Vec<TokenStream> = service_attrs
-            .custom_types
+        let custom_types: Vec<TokenStream> = types_source
             .iter()
             .map(|ty| {
                 quote! {
@@ -1063,6 +1130,27 @@ fn generate_interface_descriptions(
             quote! { #first_err }
         };
 
+        // Generate compile-time assertions that custom types referenced in method input
+        // parameters are declared in `types = [...]`.  Output parameters are asserted
+        // inside each __METHOD_N block (where __OUT_PARAMS is in scope).
+        let type_assertions: Vec<TokenStream> = interface_methods
+            .iter()
+            .flat_map(|method| {
+                method
+                    .serialized_params()
+                    .map(|p| {
+                        let ty = convert_type_lifetimes(&p.ty, "'static");
+                        quote! {
+                            #crate_path::introspect::assert::assert_type_declared(
+                                <#ty as #crate_path::introspect::Type>::TYPE,
+                                __DECLARED,
+                            );
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect();
+
         descriptions.push(quote! {
             #[doc(hidden)]
             const #const_name: &#crate_path::idl::Interface<'static> = &{
@@ -1074,6 +1162,12 @@ fn generate_interface_descriptions(
                     #error_variants_expr,
                     &[],
                 )
+            };
+
+            // Verify all custom types in method parameters are declared.
+            const _: () = {
+                const __DECLARED: &[&str] = &[#(#declared_names),*];
+                #(#type_assertions)*
             };
         });
     }

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -3,7 +3,7 @@
 use proc_macro2::TokenStream;
 use syn::{
     Attribute, Error, Expr, GenericArgument, Ident, ImplItemFn, Lit, Meta, PathArguments,
-    ReturnType, Type,
+    ReturnType, Type, parse::Parse,
 };
 
 use super::types::ParamInfo;
@@ -16,6 +16,8 @@ pub(super) struct MethodInfo {
     pub varlink_name: String,
     /// The interface name for this method.
     pub interface: Option<String>,
+    /// Custom types scoped to this method's interface (from `#[zlink(types = [...])]`).
+    pub custom_types: Vec<Type>,
     /// Parameters for this method (excluding self).
     pub params: Vec<ParamInfo>,
     /// The return type for serialization (the `T` in `Result<T, E>`, or the type itself).
@@ -289,6 +291,7 @@ impl MethodInfo {
             name,
             varlink_name,
             interface: current_interface.clone(),
+            custom_types: method_attrs.custom_types,
             params,
             return_type,
             returns_result,
@@ -328,6 +331,8 @@ impl MethodInfo {
 struct MethodAttrs {
     /// The interface name for this method.
     interface: Option<String>,
+    /// Custom types scoped to this method's interface.
+    custom_types: Vec<Type>,
     /// Custom method name.
     rename: Option<String>,
     /// Whether this method returns a stream of replies.
@@ -357,62 +362,38 @@ impl MethodAttrs {
                 continue;
             }
 
-            let nested = list.parse_args_with(
-                syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
-            )?;
-
-            for meta in nested {
-                match &meta {
-                    Meta::NameValue(nv) if nv.path.is_ident("interface") => {
-                        let Expr::Lit(expr_lit) = &nv.value else {
-                            return Err(Error::new_spanned(
-                                &nv.value,
-                                "interface value must be a string literal",
-                            ));
-                        };
-                        let Lit::Str(lit_str) = &expr_lit.lit else {
-                            return Err(Error::new_spanned(
-                                &nv.value,
-                                "interface value must be a string literal",
-                            ));
-                        };
-                        result.interface = Some(lit_str.value());
+            // Use syn::meta::parser to handle both standard Meta items and custom
+            // `types = [...]` syntax.
+            let parser = syn::meta::parser(|meta| {
+                if meta.path.is_ident("interface") {
+                    let value: syn::LitStr = meta.value()?.parse()?;
+                    result.interface = Some(value.value());
+                } else if meta.path.is_ident("rename") {
+                    let value: syn::LitStr = meta.value()?.parse()?;
+                    result.rename = Some(value.value());
+                } else if meta.path.is_ident("types") {
+                    meta.input.parse::<syn::Token![=]>()?;
+                    let content;
+                    syn::bracketed!(content in meta.input);
+                    let types = content.parse_terminated(Type::parse, syn::Token![,])?;
+                    result.custom_types = types.into_iter().collect();
+                } else if meta.path.is_ident("more") {
+                    if result.is_streaming {
+                        return Err(meta.error("duplicate `more` attribute"));
                     }
-                    Meta::NameValue(nv) if nv.path.is_ident("rename") => {
-                        let Expr::Lit(expr_lit) = &nv.value else {
-                            return Err(Error::new_spanned(
-                                &nv.value,
-                                "rename value must be a string literal",
-                            ));
-                        };
-                        let Lit::Str(lit_str) = &expr_lit.lit else {
-                            return Err(Error::new_spanned(
-                                &nv.value,
-                                "rename value must be a string literal",
-                            ));
-                        };
-                        result.rename = Some(lit_str.value());
+                    result.is_streaming = true;
+                } else if meta.path.is_ident("return_fds") {
+                    if result.return_fds {
+                        return Err(meta.error("duplicate `return_fds` attribute"));
                     }
-                    Meta::Path(path) if path.is_ident("more") => {
-                        if result.is_streaming {
-                            return Err(Error::new_spanned(&meta, "duplicate `more` attribute"));
-                        }
-                        result.is_streaming = true;
-                    }
-                    Meta::Path(path) if path.is_ident("return_fds") => {
-                        if result.return_fds {
-                            return Err(Error::new_spanned(
-                                &meta,
-                                "duplicate `return_fds` attribute",
-                            ));
-                        }
-                        result.return_fds = true;
-                    }
-                    _ => {
-                        return Err(Error::new_spanned(&meta, "unknown zlink attribute"));
-                    }
+                    result.return_fds = true;
+                } else {
+                    return Err(meta.error("unknown zlink attribute"));
                 }
-            }
+                Ok(())
+            });
+
+            syn::parse::Parser::parse2(parser, list.tokens.clone())?;
         }
 
         // Remove zlink attributes in reverse order to preserve indices.

--- a/zlink-macros/tests/service.rs
+++ b/zlink-macros/tests/service.rs
@@ -19,6 +19,8 @@ mod introspection;
 mod metadata;
 #[path = "service/multiple_interfaces.rs"]
 mod multiple_interfaces;
+#[path = "service/per_interface_types.rs"]
+mod per_interface_types;
 #[path = "service/streaming.rs"]
 mod streaming;
 #[path = "service/streaming_errors.rs"]

--- a/zlink-macros/tests/service/basic.rs
+++ b/zlink-macros/tests/service/basic.rs
@@ -9,27 +9,22 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn service_macro_basic() -> Result<(), Box<dyn std::error::Error>> {
-    // Remove the socket file if it exists (from a previous run of this test).
-    let socket_path = "/tmp/zlink-service-macro-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
     // Setup the server and run it in a separate task.
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = BankAccount::new(1000, false);
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,
-        res = run_client(socket_path) => res?,
+        res = run_client(&socket_path) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = connect(socket_path).await?;
 
     // Test GetBalance method - returns plain value, no Result.

--- a/zlink-macros/tests/service/borrowed-types.rs
+++ b/zlink-macros/tests/service/borrowed-types.rs
@@ -9,25 +9,21 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn service_macro_borrowed_types() -> Result<(), Box<dyn std::error::Error>> {
-    let socket_path = "/tmp/zlink-service-borrowed-types-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = Calculator;
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,
-        res = run_client(socket_path) => res?,
+        res = run_client(&socket_path) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = connect(socket_path).await?;
 
     // Test successful operation.

--- a/zlink-macros/tests/service/custom_bounds.rs
+++ b/zlink-macros/tests/service/custom_bounds.rs
@@ -10,22 +10,17 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn with_custom_socket_bounds() -> Result<(), Box<dyn std::error::Error>> {
-    // Remove the socket file if it exists.
-    let socket_path = "/tmp/zlink-service-macro-creds-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
     // Setup the server with the credential-checking service.
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = CredentialCheckingService { balance: 1000 };
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,
         res = async {
-            let mut conn = connect(socket_path).await?;
+            let mut conn = connect(&socket_path).await?;
             // Test that the service works and can check credentials.
             // The multiplier parameter is used AFTER an await point in the service method,
             // which tests the fix for issue #216 (parameters with #[zlink(connection)]).

--- a/zlink-macros/tests/service/fd_passing.rs
+++ b/zlink-macros/tests/service/fd_passing.rs
@@ -9,25 +9,21 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn fd_passing() -> Result<(), Box<dyn std::error::Error>> {
-    let socket_path = "/tmp/zlink-service-macro-fd-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = FdService;
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,
-        res = run_client(socket_path) => res?,
+        res = run_client(&socket_path) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     use std::{
         io::{Read, Write},
         os::unix::net::UnixStream,

--- a/zlink-macros/tests/service/introspection.rs
+++ b/zlink-macros/tests/service/introspection.rs
@@ -9,27 +9,22 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn introspection() -> Result<(), Box<dyn std::error::Error>> {
-    // Remove the socket file if it exists.
-    let socket_path = "/tmp/zlink-service-macro-introspection-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
     // Setup the server with metadata.
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = BankAccount::new(1000, false);
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,
-        res = run_client(socket_path) => res?,
+        res = run_client(&socket_path) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     use zlink::varlink_service::Proxy as VarlinkProxy;
 
     let mut conn = connect(socket_path).await?;

--- a/zlink-macros/tests/service/metadata.rs
+++ b/zlink-macros/tests/service/metadata.rs
@@ -9,22 +9,17 @@ use zlink::{
 async fn with_metadata() -> Result<(), Box<dyn std::error::Error>> {
     use zlink::varlink_service::Proxy as VarlinkProxy;
 
-    // Remove the socket file if it exists.
-    let socket_path = "/tmp/zlink-service-macro-metadata-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
     // Setup the server with a service that has metadata.
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = MetadataService;
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,
         res = async {
-            let mut conn = connect(socket_path).await?;
+            let mut conn = connect(&socket_path).await?;
 
             // Test GetInfo - should return service metadata.
             let info = conn.get_info().await?.unwrap();

--- a/zlink-macros/tests/service/multiple_interfaces.rs
+++ b/zlink-macros/tests/service/multiple_interfaces.rs
@@ -9,16 +9,11 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn multiple_interfaces() -> Result<(), Box<dyn std::error::Error>> {
-    // Remove the socket file if it exists.
-    let socket_path = "/tmp/zlink-service-macro-multi-iface-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
     // Setup the server with the multi-interface service.
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = MultiInterfaceService {
         user_authenticated: false,
         items: vec!["apple".to_string(), "banana".to_string()],
@@ -26,13 +21,13 @@ async fn multiple_interfaces() -> Result<(), Box<dyn std::error::Error>> {
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,
-        res = run_client(socket_path) => res?,
+        res = run_client(&socket_path) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = connect(socket_path).await?;
 
     // Test org.example.auth interface.

--- a/zlink-macros/tests/service/per_interface_types.rs
+++ b/zlink-macros/tests/service/per_interface_types.rs
@@ -1,0 +1,223 @@
+//! Tests for per-interface custom type scoping in introspection.
+//!
+//! When a service implements multiple interfaces, custom types specified via
+//! `#[zlink(interface = "...", types = [...])]` should only appear in the IDL
+//! output for that specific interface, not in all interfaces.
+//!
+//! Varlink method return types must always be structs (objects) so that the
+//! response can be expressed as named fields: `-> (field: type, …)`.  Arrays
+//! and primitives cannot be top-level return types; wrap them in a struct.
+
+use serde::{Deserialize, Serialize};
+use zlink::{
+    Server,
+    introspect::{self, CustomType},
+    unix::{bind, connect},
+};
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn per_interface_types() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("per-iface-types.sock");
+
+    let listener = bind(&socket_path).unwrap();
+    let service = CatalogService::default();
+    let server = Server::new(listener, service);
+    tokio::select! {
+        res = server.run() => res?,
+        res = run_client(&socket_path) => res?,
+    }
+
+    Ok(())
+}
+
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    use zlink::varlink_service::Proxy as VarlinkProxy;
+
+    let mut conn = connect(socket_path).await?;
+
+    // Smoke-test the methods.
+    let reply = conn.list_books().await?.unwrap();
+    assert_eq!(reply.books.len(), 1);
+    assert_eq!(reply.books[0].title, "The Rust Programming Language");
+
+    let reply = conn.list_albums().await?.unwrap();
+    assert_eq!(reply.albums.len(), 1);
+    assert_eq!(reply.albums[0].artist, "Ferris & The Crabs");
+
+    // --- Introspection: verify types are scoped per interface ---
+
+    // org.example.books should have Book and BookList but NOT Album/AlbumList.
+    let desc = conn
+        .get_interface_description("org.example.books")
+        .await?
+        .unwrap();
+    let interface = desc.parse()?;
+    assert_eq!(interface.name(), "org.example.books");
+
+    let type_names: Vec<_> = interface.custom_types().map(|t| t.name()).collect();
+    assert!(
+        type_names.contains(&"Book"),
+        "org.example.books should contain Book, got: {type_names:?}"
+    );
+    assert!(
+        type_names.contains(&"BookList"),
+        "org.example.books should contain BookList, got: {type_names:?}"
+    );
+    assert!(
+        !type_names.contains(&"Album"),
+        "org.example.books should NOT contain Album, got: {type_names:?}"
+    );
+    assert!(
+        !type_names.contains(&"AlbumList"),
+        "org.example.books should NOT contain AlbumList, got: {type_names:?}"
+    );
+    // Book is listed in types = [] on two methods; verify it appears only once.
+    assert_eq!(
+        type_names.iter().filter(|&&n| n == "Book").count(),
+        1,
+        "Book should appear exactly once despite being listed on multiple methods, got: {type_names:?}"
+    );
+
+    // Verify list_books method has the correct out-params (fields of BookList).
+    let list_books_method = interface
+        .methods()
+        .find(|m| m.name() == "ListBooks")
+        .expect("ListBooks method should be present");
+    let out_param_names: Vec<_> = list_books_method.outputs().map(|p| p.name()).collect();
+    assert!(
+        out_param_names.contains(&"books"),
+        "ListBooks should have 'books' as an out-param, got: {out_param_names:?}"
+    );
+
+    // org.example.music should have Album and AlbumList but NOT Book/BookList.
+    let desc = conn
+        .get_interface_description("org.example.music")
+        .await?
+        .unwrap();
+    let interface = desc.parse()?;
+    assert_eq!(interface.name(), "org.example.music");
+
+    let type_names: Vec<_> = interface.custom_types().map(|t| t.name()).collect();
+    assert!(
+        type_names.contains(&"Album"),
+        "org.example.music should contain Album, got: {type_names:?}"
+    );
+    assert!(
+        type_names.contains(&"AlbumList"),
+        "org.example.music should contain AlbumList, got: {type_names:?}"
+    );
+    assert!(
+        !type_names.contains(&"Book"),
+        "org.example.music should NOT contain Book, got: {type_names:?}"
+    );
+    assert!(
+        !type_names.contains(&"BookList"),
+        "org.example.music should NOT contain BookList, got: {type_names:?}"
+    );
+
+    Ok(())
+}
+
+/// A book entry (belongs to org.example.books).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct Book {
+    title: String,
+    author: String,
+}
+
+/// Wrapper struct for list_books reply — Varlink requires a named-field object
+/// as the return type, so `Vec<Book>` must be wrapped.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct BookList {
+    books: Vec<Book>,
+}
+
+/// A music album entry (belongs to org.example.music).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct Album {
+    title: String,
+    artist: String,
+}
+
+/// Wrapper struct for list_albums reply.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct AlbumList {
+    albums: Vec<Album>,
+}
+
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.books")]
+enum BookError {
+    NotFound,
+}
+
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.music")]
+enum MusicError {
+    NotFound,
+}
+
+/// A service exposing two catalog interfaces with distinct custom types.
+#[derive(Default)]
+struct CatalogService;
+
+#[zlink::service]
+impl CatalogService {
+    #[zlink(interface = "org.example.books", types = [Book, BookList])]
+    async fn list_books(&self) -> BookList {
+        BookList {
+            books: vec![Book {
+                title: "The Rust Programming Language".to_string(),
+                author: "Steve Klabnik & Carol Nichols".to_string(),
+            }],
+        }
+    }
+
+    // Book is listed again here to verify deduplication (should only appear once in IDL).
+    #[zlink(types = [Book])]
+    async fn get_book(&self, title: String) -> Result<Book, BookError> {
+        if title == "The Rust Programming Language" {
+            Ok(Book {
+                title,
+                author: "Steve Klabnik & Carol Nichols".to_string(),
+            })
+        } else {
+            Err(BookError::NotFound)
+        }
+    }
+
+    #[zlink(interface = "org.example.music", types = [Album, AlbumList])]
+    async fn list_albums(&self) -> AlbumList {
+        AlbumList {
+            albums: vec![Album {
+                title: "Oxidized Beats".to_string(),
+                artist: "Ferris & The Crabs".to_string(),
+            }],
+        }
+    }
+
+    #[zlink(types = [Album])]
+    async fn get_album(&self, title: String) -> Result<Album, MusicError> {
+        if title == "Oxidized Beats" {
+            Ok(Album {
+                title,
+                artist: "Ferris & The Crabs".to_string(),
+            })
+        } else {
+            Err(MusicError::NotFound)
+        }
+    }
+}
+
+#[zlink::proxy("org.example.books")]
+trait BookProxy {
+    async fn list_books(&mut self) -> zlink::Result<Result<BookList, BookError>>;
+    async fn get_book(&mut self, title: String) -> zlink::Result<Result<Book, BookError>>;
+}
+
+#[zlink::proxy("org.example.music")]
+trait MusicProxy {
+    async fn list_albums(&mut self) -> zlink::Result<Result<AlbumList, MusicError>>;
+    async fn get_album(&mut self, title: String) -> zlink::Result<Result<Album, MusicError>>;
+}

--- a/zlink-macros/tests/service/streaming.rs
+++ b/zlink-macros/tests/service/streaming.rs
@@ -8,29 +8,24 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn streaming() -> Result<(), Box<dyn std::error::Error>> {
-    // Remove the socket file if it exists.
-    let socket_path = "/tmp/zlink-service-macro-streaming-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
     // Setup the server with a streaming service.
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = StreamingService {
         values: vec![10, 20, 30, 40, 50],
     };
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,
-        res = run_client(socket_path) => res?,
+        res = run_client(&socket_path) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     use futures_util::StreamExt;
 
     let mut conn = connect(socket_path).await?;

--- a/zlink-macros/tests/service/streaming_fds.rs
+++ b/zlink-macros/tests/service/streaming_fds.rs
@@ -10,25 +10,21 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn streaming_with_fds() -> Result<(), Box<dyn std::error::Error>> {
-    let socket_path = "/tmp/zlink-service-macro-streaming-fd-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = StreamingFdService;
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,
-        res = run_client(socket_path) => res?,
+        res = run_client(&socket_path) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     use futures_util::StreamExt;
     use std::{
         io::{Read, Write},


### PR DESCRIPTION
I was looking at adding varlink support to bcvk (see https://github.com/bootc-dev/bcvk/pull/222 ) and looking at the introspection, I noticed there were a lot of duplicated types because I want to create a clean API with multiple interfaces.

This adds support for `#[zlink(interface = "...", types = [...])]` on methods, which scopes custom types to the interface being declared. This way, introspecting interface A only shows types belonging to A.

Assisted-by: OpenCode (Claude claude-opus-4-6)
