### PR TITLE
🐛 core: Don't hide `notified` mod from docs

### DIFF
--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -36,7 +36,6 @@ pub use server::{
 };
 mod call;
 #[cfg(feature = "server")]
-#[doc(hidden)]
 pub mod notified;
 pub use call::Call;
 pub mod reply;


### PR DESCRIPTION
Fixes #241.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
