### PR TITLE
🚸 macros: Allow expressions for values of `service` attributes

### DIFF
--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1019,10 +1019,11 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// * `types = [Type1, Type2, ...]` - Custom types to include in interface descriptions. These types
 ///   must implement `CustomType` (typically via `#[derive(CustomType)]`). The types are included in
 ///   the IDL for any interface that uses them.
-/// * `vendor = "..."` - The vendor name for `GetInfo` response. Defaults to empty string.
-/// * `product = "..."` - The product name for `GetInfo` response. Defaults to empty string.
-/// * `version = "..."` - The version string for `GetInfo` response. Defaults to empty string.
-/// * `url = "..."` - The URL for `GetInfo` response. Defaults to empty string.
+/// * `vendor = <expr>` - The vendor name for `GetInfo` response. Defaults to empty string.
+/// * `product = <expr>` - The product name for `GetInfo` response. Defaults to empty string.
+/// * `version = <expr>` - The version string for `GetInfo` response. Defaults to empty string. E.g.
+///   `version = env!("CARGO_PKG_VERSION")`.
+/// * `url = <expr>` - The URL for `GetInfo` response. Defaults to empty string.
 ///
 /// ## On methods:
 ///
@@ -1293,7 +1294,7 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///     types = [Balance],
 ///     vendor = "Example Corp",
 ///     product = "Bank Service",
-///     version = "1.0.0",
+///     version = env!("CARGO_PKG_VERSION"),
 ///     url = "https://example.com/bank"
 /// )]
 /// impl BankService {
@@ -1306,10 +1307,11 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
 /// # use zlink::test_utils::mock_socket::MockSocket;
 /// // GetInfo returns metadata and list of interfaces.
-/// # let responses = [
-/// #     r#"{"parameters":{"vendor":"Example Corp","product":"Bank Service","version":"1.0.0","url":"https://example.com/bank","interfaces":["org.example.bank","org.varlink.service"]}}"#,
-/// # ];
-/// # let socket = MockSocket::with_responses(&responses);
+/// # let response = format!(
+/// #     r#"{{"parameters":{{"vendor":"Example Corp","product":"Bank Service","version":"{}","url":"https://example.com/bank","interfaces":["org.example.bank","org.varlink.service"]}}}}"#,
+/// #     env!("CARGO_PKG_VERSION"),
+/// # );
+/// # let socket = MockSocket::with_responses(&[&response]);
 /// # let mut conn = zlink::Connection::new(socket);
 /// let info = conn.get_info().await?.unwrap();
 /// assert_eq!(info.vendor, "Example Corp");

--- a/zlink-macros/src/service/attrs.rs
+++ b/zlink-macros/src/service/attrs.rs
@@ -16,13 +16,13 @@ pub(super) struct ServiceAttrs {
     /// Default interface name for all methods.
     pub interface: Option<String>,
     /// Service vendor name.
-    pub vendor: Option<String>,
+    pub vendor: Option<syn::Expr>,
     /// Service product name.
-    pub product: Option<String>,
+    pub product: Option<syn::Expr>,
     /// Service version.
-    pub version: Option<String>,
+    pub version: Option<syn::Expr>,
     /// Service URL.
-    pub url: Option<String>,
+    pub url: Option<syn::Expr>,
 }
 
 impl ServiceAttrs {
@@ -53,17 +53,17 @@ impl ServiceAttrs {
                     let value: syn::LitStr = meta.value()?.parse()?;
                     interface = Some(value.value());
                 } else if meta.path.is_ident("vendor") {
-                    let value: syn::LitStr = meta.value()?.parse()?;
-                    vendor = Some(value.value());
+                    let value: syn::Expr = meta.value()?.parse()?;
+                    vendor = Some(value);
                 } else if meta.path.is_ident("product") {
-                    let value: syn::LitStr = meta.value()?.parse()?;
-                    product = Some(value.value());
+                    let value: syn::Expr = meta.value()?.parse()?;
+                    product = Some(value);
                 } else if meta.path.is_ident("version") {
-                    let value: syn::LitStr = meta.value()?.parse()?;
-                    version = Some(value.value());
+                    let value: syn::Expr = meta.value()?.parse()?;
+                    version = Some(value);
                 } else if meta.path.is_ident("url") {
-                    let value: syn::LitStr = meta.value()?.parse()?;
-                    url = Some(value.value());
+                    let value: syn::Expr = meta.value()?.parse()?;
+                    url = Some(value);
                 } else {
                     return Err(meta.error("unsupported service attribute"));
                 }
@@ -76,8 +76,9 @@ impl ServiceAttrs {
                     format!(
                         "failed to parse service attributes: {e}. Expected: \
                          #[service], #[service(crate = \"path\")], \
-                         #[service(interface = \"...\", types = [T1, T2], vendor = \"...\", \
-                         product = \"...\", version = \"...\", url = \"...\")]"
+                         #[service(interface = \"...\", types = [T1, T2], \
+                         vendor = <expr>, product = <expr>, version = <expr>, \
+                         url = <expr>)]"
                     ),
                 )
             })?;

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -1376,10 +1376,26 @@ fn generate_handle_body(
         interfaces.iter().map(|iface| quote! { #iface }).collect();
 
     // Service metadata.
-    let vendor = service_attrs.vendor.as_deref().unwrap_or("");
-    let product = service_attrs.product.as_deref().unwrap_or("");
-    let version = service_attrs.version.as_deref().unwrap_or("");
-    let url = service_attrs.url.as_deref().unwrap_or("");
+    let vendor = service_attrs
+        .vendor
+        .as_ref()
+        .map(|v| quote! { #v })
+        .unwrap_or_else(|| quote! { "" });
+    let product = service_attrs
+        .product
+        .as_ref()
+        .map(|v| quote! { #v })
+        .unwrap_or_else(|| quote! { "" });
+    let version = service_attrs
+        .version
+        .as_ref()
+        .map(|v| quote! { #v })
+        .unwrap_or_else(|| quote! { "" });
+    let url = service_attrs
+        .url
+        .as_ref()
+        .map(|v| quote! { #v })
+        .unwrap_or_else(|| quote! { "" });
 
     // Generate the varlink service methods match.
     let get_info_reply = wrap_handle_result_no_fds(quote! {

--- a/zlink-macros/tests/service/metadata.rs
+++ b/zlink-macros/tests/service/metadata.rs
@@ -30,8 +30,8 @@ async fn with_metadata() -> Result<(), Box<dyn std::error::Error>> {
             let info = conn.get_info().await?.unwrap();
             assert_eq!(info.vendor, "Test Vendor");
             assert_eq!(info.product, "Test Product");
-            assert_eq!(info.version, "1.0.0");
-            assert_eq!(info.url, "https://example.com");
+            assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+            assert_eq!(info.url, env!("CARGO_PKG_REPOSITORY"));
             let interfaces: Vec<&str> = info.interfaces.iter().map(|s| s.as_ref()).collect();
             assert_eq!(
                 interfaces.as_slice(),
@@ -66,8 +66,8 @@ pub struct MetadataService;
     interface = "org.example.metadata",
     vendor = "Test Vendor",
     product = "Test Product",
-    version = "1.0.0",
-    url = "https://example.com"
+    version = env!("CARGO_PKG_VERSION"),
+    url = env!("CARGO_PKG_REPOSITORY")
 )]
 impl MetadataService {
     async fn ping(&self) {}


### PR DESCRIPTION
Instead of only allowing string literals, allow any expression. This is
mainly to allow use of `env!` for these constants.

Fixes #237.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
