### PR TITLE
⬆️  Upgrade to Rust edition 2024

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
           ]
     env:
       RUSTFLAGS: -D warnings
-      MSRV: 1.83.0
+      MSRV: 1.85.0
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ members = [
 resolver = "2"
 
 [workspace.package]
-edition = "2021"
-rust-version = "1.83"
+edition = "2024"
+rust-version = "1.85"
 license = "MIT"
 repository = "https://github.com/z-galaxy/zlink/"
 authors = ["Zeeshan Ali Khan<zeenix@gmail.com>"]

--- a/zlink-codegen/test-integration/src/lib.rs
+++ b/zlink-codegen/test-integration/src/lib.rs
@@ -5,7 +5,7 @@ include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 mod tests {
     use super::*;
     use serde_json::json;
-    use zlink::{test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, test_utils::mock_socket::MockSocket};
 
     #[tokio::test]
     async fn test_example_proxy() {

--- a/zlink-core/benches/benchmarks.rs
+++ b/zlink-core/benches/benchmarks.rs
@@ -1,14 +1,14 @@
-use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use futures_util::{pin_mut, StreamExt};
+use criterion::{Criterion, Throughput, criterion_group, criterion_main};
+use futures_util::{StreamExt, pin_mut};
 use serde::{Deserialize, Serialize};
 use std::{hint::black_box, time::Duration};
 use tokio::{runtime::Runtime, time::sleep};
 use zlink_core::{
-    connection::{
-        socket::{ReadHalf, Socket, WriteHalf},
-        Connection,
-    },
     Call, Reply,
+    connection::{
+        Connection,
+        socket::{ReadHalf, Socket, WriteHalf},
+    },
 };
 
 criterion_group!(benches, client_sending, server_receiving);

--- a/zlink-core/src/call/de.rs
+++ b/zlink-core/src/call/de.rs
@@ -1,10 +1,10 @@
 use core::{cell::Cell, fmt, marker::PhantomData};
 
 use serde::{
-    de::{
-        self, value::MapAccessDeserializer, DeserializeSeed, IntoDeserializer, MapAccess, Visitor,
-    },
     Deserialize, Deserializer,
+    de::{
+        self, DeserializeSeed, IntoDeserializer, MapAccess, Visitor, value::MapAccessDeserializer,
+    },
 };
 
 use super::Call;

--- a/zlink-core/src/call/ser.rs
+++ b/zlink-core/src/call/ser.rs
@@ -1,6 +1,6 @@
 use serde::{
-    ser::{Error, Impossible, SerializeMap, SerializeStruct},
     Serialize, Serializer,
+    ser::{Error, Impossible, SerializeMap, SerializeStruct},
 };
 
 use super::Call;

--- a/zlink-core/src/connection/chain/mod.rs
+++ b/zlink-core/src/connection/chain/mod.rs
@@ -3,9 +3,9 @@
 mod reply_stream;
 pub use reply_stream::ReplyStream;
 
-use crate::{connection::Socket, Call, Connection, Result};
+use crate::{Call, Connection, Result, connection::Socket};
 use core::fmt::Debug;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 /// A chain of method calls that will be sent together.
 ///

--- a/zlink-core/src/connection/chain/reply_stream.rs
+++ b/zlink-core/src/connection/chain/reply_stream.rs
@@ -4,12 +4,13 @@ use core::{
     pin::Pin,
     task::{Context, Poll},
 };
-use futures_util::stream::{unfold, Stream};
+use futures_util::stream::{Stream, unfold};
 use serde::de::DeserializeOwned;
 
 use crate::{
-    connection::{socket::ReadHalf, ReadConnection},
-    reply, Result,
+    Result,
+    connection::{ReadConnection, socket::ReadHalf},
+    reply,
 };
 
 #[cfg(feature = "std")]

--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -56,8 +56,8 @@ pub mod socket;
 mod tests;
 mod write_connection;
 use crate::{
-    reply::{self, Reply},
     Call, Result,
+    reply::{self, Reply},
 };
 #[cfg(feature = "std")]
 use alloc::vec;

--- a/zlink-core/src/connection/read_connection.rs
+++ b/zlink-core/src/connection/read_connection.rs
@@ -2,12 +2,12 @@
 
 use core::{fmt::Debug, str::from_utf8_unchecked};
 
-use crate::{varlink_service, Result};
+use crate::{Result, varlink_service};
 
 use super::{
+    BUFFER_SIZE, Call, MAX_BUFFER_SIZE,
     reply::{self, Reply},
     socket::ReadHalf,
-    Call, BUFFER_SIZE, MAX_BUFFER_SIZE,
 };
 #[cfg(feature = "std")]
 use alloc::collections::VecDeque;

--- a/zlink-core/src/connection/tests/chain_fds_tests.rs
+++ b/zlink-core/src/connection/tests/chain_fds_tests.rs
@@ -3,12 +3,12 @@
 #![cfg(test)]
 
 use crate::{
+    Call, Result,
     connection::{
-        socket::{ReadHalf, Socket, WriteHalf},
         Connection,
+        socket::{ReadHalf, Socket, WriteHalf},
     },
     test_utils::mock_socket::{MockSocket, MockWriteHalf},
-    Call, Result,
 };
 use alloc::vec::Vec;
 use futures_util::{pin_mut, stream::StreamExt};

--- a/zlink-core/src/connection/tests/connection_tests.rs
+++ b/zlink-core/src/connection/tests/connection_tests.rs
@@ -1,6 +1,6 @@
 //! Tests for Connection-level functionality.
 
-use crate::{test_utils::mock_socket::MockSocket, Connection};
+use crate::{Connection, test_utils::mock_socket::MockSocket};
 
 #[tokio::test]
 #[cfg(feature = "std")]

--- a/zlink-core/src/connection/tests/write_connection_fds_tests.rs
+++ b/zlink-core/src/connection/tests/write_connection_fds_tests.rs
@@ -3,9 +3,9 @@
 #![cfg(test)]
 
 use crate::{
+    Call, Reply,
     connection::write_connection::WriteConnection,
     test_utils::mock_socket::{MockWriteHalf, TestWriteHalf},
-    Call, Reply,
 };
 use serde::{Deserialize, Serialize};
 use std::os::unix::net::UnixStream;

--- a/zlink-core/src/connection/tests/write_connection_tests.rs
+++ b/zlink-core/src/connection/tests/write_connection_tests.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::{
-    connection::{write_connection::WriteConnection, BUFFER_SIZE},
+    connection::{BUFFER_SIZE, write_connection::WriteConnection},
     test_utils::mock_socket::TestWriteHalf,
 };
 

--- a/zlink-core/src/connection/write_connection.rs
+++ b/zlink-core/src/connection/write_connection.rs
@@ -7,7 +7,7 @@ use alloc::collections::VecDeque;
 use alloc::vec::Vec;
 use serde::Serialize;
 
-use super::{socket::WriteHalf, Call, Reply, BUFFER_SIZE};
+use super::{BUFFER_SIZE, Call, Reply, socket::WriteHalf};
 
 #[cfg(feature = "std")]
 use std::os::fd::OwnedFd;

--- a/zlink-core/src/idl/interface.rs
+++ b/zlink-core/src/idl/interface.rs
@@ -202,12 +202,14 @@ mod tests {
         write!(idl, "{}", interface).unwrap();
         assert!(idl.as_str().starts_with("interface org.varlink.service"));
         assert!(idl.as_str().contains("method GetInfo()"));
-        assert!(idl
-            .as_str()
-            .contains("method GetInterfaceDescription(interface: string)"));
-        assert!(idl
-            .as_str()
-            .contains("error InterfaceNotFound (interface: string)"));
+        assert!(
+            idl.as_str()
+                .contains("method GetInterfaceDescription(interface: string)")
+        );
+        assert!(
+            idl.as_str()
+                .contains("error InterfaceNotFound (interface: string)")
+        );
         assert!(idl.as_str().contains("error PermissionDenied ()"));
 
         // Test parsing the official org.varlink.service IDL and compare with manually constructed
@@ -262,7 +264,7 @@ error ExpectedMore ()
     fn systemd_resolved_interface_parsing() {
         use alloc::vec::Vec;
 
-        use crate::idl::{parse, CustomObject, CustomType, TypeRef};
+        use crate::idl::{CustomObject, CustomType, TypeRef, parse};
 
         // Manually construct the systemd-resolved interface for comparison.
 

--- a/zlink-core/src/idl/method.rs
+++ b/zlink-core/src/idl/method.rs
@@ -191,6 +191,9 @@ mod tests {
         let method = Method::new("GetUser", &inputs, &outputs, &comments);
         let mut displayed = String::new();
         write!(&mut displayed, "{}", method).unwrap();
-        assert_eq!(displayed, "# Get user information\n# Returns user details by ID\nmethod GetUser(id: int) -> (user: User)");
+        assert_eq!(
+            displayed,
+            "# Get user information\n# Returns user details by ID\nmethod GetUser(id: int) -> (user: User)"
+        );
     }
 }

--- a/zlink-core/src/idl/parse/mod.rs
+++ b/zlink-core/src/idl/parse/mod.rs
@@ -4,11 +4,11 @@
 //! Rust types defined in the parent module. Uses byte-based parsing to avoid UTF-8 overhead.
 
 use winnow::{
+    ModalResult, Parser,
     ascii::multispace0,
     combinator::{alt, separated},
     error::{ErrMode, InputError, ParserError},
     token::{literal, take_while},
-    ModalResult, Parser,
 };
 
 use super::{

--- a/zlink-core/src/json_ser.rs
+++ b/zlink-core/src/json_ser.rs
@@ -400,9 +400,10 @@ where
     {
         match self {
             Compound::Map { ser, state } => {
-                tri!(ser
-                    .formatter
-                    .begin_array_value(&mut ser.writer, *state == State::First));
+                tri!(
+                    ser.formatter
+                        .begin_array_value(&mut ser.writer, *state == State::First)
+                );
                 *state = State::Rest;
                 tri!(value.serialize(&mut **ser));
                 ser.formatter.end_array_value(&mut ser.writer)
@@ -507,9 +508,10 @@ where
     {
         match self {
             Compound::Map { ser, state } => {
-                tri!(ser
-                    .formatter
-                    .begin_object_key(&mut ser.writer, *state == State::First));
+                tri!(
+                    ser.formatter
+                        .begin_object_key(&mut ser.writer, *state == State::First)
+                );
                 *state = State::Rest;
 
                 tri!(key.serialize(MapKeySerializer { ser: *ser }));

--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -30,9 +30,9 @@ pub use error::{Error, Result};
 mod server;
 #[cfg(feature = "server")]
 pub use server::{
+    Server,
     listener::{Listener, ReadyListener},
     service::{self, Service},
-    Server,
 };
 mod call;
 #[cfg(feature = "server")]

--- a/zlink-core/src/server/listener.rs
+++ b/zlink-core/src/server/listener.rs
@@ -1,6 +1,6 @@
 use core::future::Future;
 
-use crate::{connection::Socket, Connection, Result};
+use crate::{Connection, Result, connection::Socket};
 
 /// A listener is a server that listens for incoming connections.
 pub trait Listener: core::fmt::Debug {

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -7,7 +7,7 @@ use futures_util::{FutureExt, StreamExt};
 use select_all::SelectAll;
 use service::MethodReply;
 
-use crate::{connection::Socket, Call, Connection, Reply};
+use crate::{Call, Connection, Reply, connection::Socket};
 
 /// A server.
 ///

--- a/zlink-core/src/server/select_all.rs
+++ b/zlink-core/src/server/select_all.rs
@@ -34,7 +34,7 @@ where
     /// `SelectAll`. The use case here is the Future impls created for `async fn` methods that are
     /// in reality `Unpin` but the compiler assumes they're `!Unpin`.
     pub(super) unsafe fn push_unchecked(&mut self, fut: &'f mut Fut) {
-        self.futures.push(Pin::new_unchecked(fut))
+        self.futures.push(unsafe { Pin::new_unchecked(fut) })
     }
 }
 

--- a/zlink-core/src/server/service.rs
+++ b/zlink-core/src/server/service.rs
@@ -5,7 +5,7 @@ use core::{fmt::Debug, future::Future};
 use futures_util::Stream;
 use serde::{Deserialize, Serialize};
 
-use crate::{connection::Socket, Call, Connection, Reply};
+use crate::{Call, Connection, Reply, connection::Socket};
 
 /// The item type that a [`Service::ReplyStream`] yields.
 ///

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -16,7 +16,7 @@ use crate::connection::Credentials;
 /// This is a low-level helper that performs the `recvmsg` syscall.
 #[doc(hidden)]
 pub fn recvmsg(fd: impl AsFd, buf: &mut [u8]) -> io::Result<(usize, alloc::vec::Vec<OwnedFd>)> {
-    use rustix::net::{recvmsg, RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags};
+    use rustix::net::{RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, recvmsg};
     use std::io::IoSliceMut;
 
     let mut cmsg_buf = [MaybeUninit::<u8>::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS))];
@@ -42,7 +42,7 @@ pub fn recvmsg(fd: impl AsFd, buf: &mut [u8]) -> io::Result<(usize, alloc::vec::
 /// This is a low-level helper that performs the `sendmsg` syscall.
 #[doc(hidden)]
 pub fn sendmsg(fd: impl AsFd, buf: &[u8], fds: &[BorrowedFd<'_>]) -> io::Result<usize> {
-    use rustix::net::{sendmsg, SendAncillaryBuffer, SendAncillaryMessage, SendFlags};
+    use rustix::net::{SendAncillaryBuffer, SendAncillaryMessage, SendFlags, sendmsg};
     use std::io::IoSlice;
 
     let mut cmsg_buf = [MaybeUninit::<u8>::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS))];
@@ -130,7 +130,7 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
         let process_fd = {
             // FIXME: Replace `libc` usage with `rustix` API when it provides SO_PEERPIDFD
             // sockopt: https://github.com/bytecodealliance/rustix/pull/1474
-            use core::mem::{size_of, MaybeUninit};
+            use core::mem::{MaybeUninit, size_of};
 
             let mut pidfd = MaybeUninit::<libc::c_int>::zeroed();
             let mut len = size_of::<libc::c_int>() as libc::socklen_t;

--- a/zlink-core/src/varlink_service/proxy.rs
+++ b/zlink-core/src/varlink_service/proxy.rs
@@ -160,7 +160,7 @@ pub trait Proxy {
 #[cfg(test)]
 mod tests {
     use super::{super::OwnedReply, *};
-    use crate::{test_utils::mock_socket::MockSocket, Connection};
+    use crate::{Connection, test_utils::mock_socket::MockSocket};
     use futures_util::{pin_mut, stream::StreamExt};
 
     #[tokio::test]

--- a/zlink-macros/src/proxy.rs
+++ b/zlink-macros/src/proxy.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::collections::HashMap;
-use syn::{parse::Parser, parse2, Error, FnArg, ItemTrait, Lit, Pat, TraitItem};
+use syn::{Error, FnArg, ItemTrait, Lit, Pat, TraitItem, parse::Parser, parse2};
 
 mod chain_extension;
 mod chain_method;
@@ -13,7 +13,7 @@ use chain_extension::generate_chain_extension_method;
 use chain_method::generate_chain_method;
 use method_impl::generate_method_impl;
 use types::MethodAttrs;
-use utils::{build_combined_where_clause, extract_param_attrs, ParamAttrs};
+use utils::{ParamAttrs, build_combined_where_clause, extract_param_attrs};
 
 pub(crate) fn proxy(attr: TokenStream, input: TokenStream) -> TokenStream {
     match proxy_impl(attr, input) {

--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -5,8 +5,8 @@ use syn::{Error, FnArg, Pat};
 use super::{
     types::{ArgInfo, MethodAttrs},
     utils::{
-        convert_to_single_lifetime, parse_return_type, snake_case_to_pascal_case,
-        type_contains_lifetime, ParamAttrs,
+        ParamAttrs, convert_to_single_lifetime, parse_return_type, snake_case_to_pascal_case,
+        type_contains_lifetime,
     },
 };
 

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -5,8 +5,8 @@ use syn::{Error, FnArg, Pat};
 use super::{
     types::{ArgInfo, MethodAttrs},
     utils::{
-        convert_to_single_lifetime, parse_return_type, snake_case_to_pascal_case,
-        type_contains_lifetime, ParamAttrs,
+        ParamAttrs, convert_to_single_lifetime, parse_return_type, snake_case_to_pascal_case,
+        type_contains_lifetime,
     },
 };
 

--- a/zlink-macros/src/proxy/method_impl.rs
+++ b/zlink-macros/src/proxy/method_impl.rs
@@ -1,13 +1,13 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use std::collections::HashSet;
-use syn::{punctuated::Punctuated, Error, FnArg, Pat, Type};
+use syn::{Error, FnArg, Pat, Type, punctuated::Punctuated};
 
 use super::{
     types::{ArgInfo, MethodAttrs},
     utils::{
-        collect_used_type_params, convert_to_single_lifetime, parse_return_type,
-        snake_case_to_pascal_case, type_contains_lifetime, ParamAttrs,
+        ParamAttrs, collect_used_type_params, convert_to_single_lifetime, parse_return_type,
+        snake_case_to_pascal_case, type_contains_lifetime,
     },
 };
 use crate::utils::is_option_type;

--- a/zlink-macros/src/proxy/utils.rs
+++ b/zlink-macros/src/proxy/utils.rs
@@ -1,8 +1,8 @@
 use crate::utils::*;
 use std::collections::HashSet;
 use syn::{
-    punctuated::Punctuated, Attribute, Error, Expr, GenericArgument, Lit, Meta, PathArguments,
-    ReturnType, Type,
+    Attribute, Error, Expr, GenericArgument, Lit, Meta, PathArguments, ReturnType, Type,
+    punctuated::Punctuated,
 };
 
 /// Convert snake_case to PascalCase.
@@ -355,7 +355,7 @@ fn extract_inner_result_types(ty: &Type) -> Result<(Type, Type), Error> {
             return Err(Error::new_spanned(
                 ty,
                 "expected inner Result<ReplyType, ErrorType>",
-            ))
+            ));
         }
     };
 

--- a/zlink-macros/src/reply_error.rs
+++ b/zlink-macros/src/reply_error.rs
@@ -1,6 +1,6 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{parse_quote, Data, DataEnum, DeriveInput, Error, Fields, FieldsNamed};
+use syn::{Data, DataEnum, DeriveInput, Error, Fields, FieldsNamed, parse_quote};
 
 use crate::utils::{convert_type_lifetimes, has_zlink_bool_attr, parse_zlink_string_attr};
 

--- a/zlink-macros/src/service/attrs.rs
+++ b/zlink-macros/src/service/attrs.rs
@@ -3,8 +3,8 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{
-    parse::{Parse, Parser},
     Error, ItemImpl,
+    parse::{Parse, Parser},
 };
 
 /// Attributes parsed from the `#[service(...)]` macro invocation.

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, HashSet};
 
 use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote, ToTokens};
+use quote::{ToTokens, format_ident, quote};
 use syn::{Error, GenericParam, ItemImpl, Type};
 
 use super::{attrs::ServiceAttrs, method::MethodInfo};

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -137,7 +137,7 @@ impl MethodInfo {
                         &method.sig,
                         "streaming methods with return_fds must return \
                          a Stream<Item = (Reply<T>, Vec<OwnedFd>)>",
-                    ))
+                    ));
                 }
                 ReturnType::Type(_, ty) => {
                     let stream_item = extract_stream_item_type(ty).ok_or_else(|| {
@@ -189,7 +189,7 @@ impl MethodInfo {
                     return Err(Error::new_spanned(
                         &method.sig,
                         "streaming methods must return a Stream<Item = Reply<T>>",
-                    ))
+                    ));
                 }
                 ReturnType::Type(_, ty) => {
                     let stream_item = extract_stream_item_type(ty).ok_or_else(|| {
@@ -229,7 +229,7 @@ impl MethodInfo {
                     return Err(Error::new_spanned(
                         &method.sig,
                         "`return_fds` methods must have a return type",
-                    ))
+                    ));
                 }
                 ReturnType::Type(_, ty) => {
                     // Extract the first element of the tuple.

--- a/zlink-macros/src/service/mod.rs
+++ b/zlink-macros/src/service/mod.rs
@@ -10,7 +10,7 @@ mod types;
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{parse2, Error, ImplItem, ItemImpl};
+use syn::{Error, ImplItem, ItemImpl, parse2};
 
 use attrs::ServiceAttrs;
 use method::MethodInfo;

--- a/zlink-macros/tests/proxy/basic.rs
+++ b/zlink-macros/tests/proxy/basic.rs
@@ -1,7 +1,7 @@
 #[tokio::test]
 async fn proxy_no_in_or_out_params() {
     use serde::{Deserialize, Serialize};
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[proxy("org.example.Basic")]
     trait BasicProxy {
@@ -26,7 +26,7 @@ async fn proxy_no_in_or_out_params() {
 
 #[tokio::test]
 async fn proxy_oneway_method() {
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[proxy("org.example.Basic")]
     trait BasicProxy {
@@ -48,7 +48,7 @@ async fn proxy_oneway_method() {
 async fn proxy_parameter_rename() {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[proxy("org.example.Basic")]
     trait BasicProxy {

--- a/zlink-macros/tests/proxy/complex_lifetimes.rs
+++ b/zlink-macros/tests/proxy/complex_lifetimes.rs
@@ -3,7 +3,7 @@ async fn complex_lifetimes_test() {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
     use std::collections::HashMap;
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[proxy("org.example.Complex")]
     trait ComplexProxy {

--- a/zlink-macros/tests/proxy/fd_passing.rs
+++ b/zlink-macros/tests/proxy/fd_passing.rs
@@ -7,7 +7,7 @@ use std::{
         unix::net::UnixStream,
     },
 };
-use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
 #[proxy("org.example.FileService")]
 trait FileServiceProxy {

--- a/zlink-macros/tests/proxy/generics.rs
+++ b/zlink-macros/tests/proxy/generics.rs
@@ -6,7 +6,7 @@ struct Error;
 #[tokio::test]
 async fn generic_test() {
     use serde_json::json;
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[derive(Debug, Serialize, Deserialize)]
     struct ProcessReply<'a> {
@@ -50,7 +50,7 @@ async fn generic_test() {
 #[tokio::test]
 async fn where_clause_test() {
     use serde_json::json;
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[derive(Debug, Serialize, Deserialize)]
     struct GetReply<'a> {

--- a/zlink-macros/tests/proxy/lifetimes.rs
+++ b/zlink-macros/tests/proxy/lifetimes.rs
@@ -2,7 +2,7 @@
 async fn lifetimes_test() {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[proxy("org.example.Lifetimes")]
     trait LifetimeProxy {

--- a/zlink-macros/tests/proxy/optional_params.rs
+++ b/zlink-macros/tests/proxy/optional_params.rs
@@ -2,7 +2,7 @@
 async fn optional_params_test() {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[proxy("org.example.Optional")]
     trait OptionalProxy {

--- a/zlink-macros/tests/proxy/rename.rs
+++ b/zlink-macros/tests/proxy/rename.rs
@@ -2,7 +2,7 @@
 async fn rename_test() {
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[proxy("org.example.Rename")]
     trait RenameProxy {
@@ -65,7 +65,7 @@ async fn param_rename_chain_test() {
     use futures_util::{pin_mut, stream::StreamExt};
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     #[derive(Debug, Serialize, Deserialize)]
     struct Error;

--- a/zlink-macros/tests/proxy/streaming.rs
+++ b/zlink-macros/tests/proxy/streaming.rs
@@ -5,7 +5,7 @@ async fn streaming_test() {
     use futures_util::stream::Stream;
     use serde::{Deserialize, Serialize};
     use serde_json::json;
-    use zlink::{proxy, test_utils::mock_socket::MockSocket, Connection};
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
     // Non-streaming methods can use borrowed types.
     // Streaming methods must use owned types (DeserializeOwned) because the internal buffer may be

--- a/zlink-macros/tests/service/basic.rs
+++ b/zlink-macros/tests/service/basic.rs
@@ -2,9 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 use zlink::{
+    Server,
     introspect::{self, CustomType},
     unix::{bind, connect},
-    Server,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/borrowed-types.rs
+++ b/zlink-macros/tests/service/borrowed-types.rs
@@ -2,9 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 use zlink::{
+    Server,
     introspect::{self, CustomType},
     unix::{bind, connect},
-    Server,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/custom_bounds.rs
+++ b/zlink-macros/tests/service/custom_bounds.rs
@@ -2,10 +2,10 @@
 
 use super::basic::Balance;
 use zlink::{
+    Server,
     connection::socket::FetchPeerCredentials,
     introspect::{self},
     unix::{bind, connect},
-    Server,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/fd_passing.rs
+++ b/zlink-macros/tests/service/fd_passing.rs
@@ -2,9 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 use zlink::{
+    Server,
     introspect::{self},
     unix::{bind, connect},
-    Server,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/introspection.rs
+++ b/zlink-macros/tests/service/introspection.rs
@@ -2,8 +2,8 @@
 
 use super::basic::{BankAccount, BankError};
 use zlink::{
-    unix::{bind, connect},
     Server,
+    unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/metadata.rs
+++ b/zlink-macros/tests/service/metadata.rs
@@ -1,8 +1,8 @@
 //! Tests for service with metadata attributes.
 
 use zlink::{
-    unix::{bind, connect},
     Server,
+    unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/multiple_interfaces.rs
+++ b/zlink-macros/tests/service/multiple_interfaces.rs
@@ -2,9 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 use zlink::{
+    Server,
     introspect::{self, Type},
     unix::{bind, connect},
-    Server,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/streaming.rs
+++ b/zlink-macros/tests/service/streaming.rs
@@ -2,9 +2,8 @@
 
 use serde::{Deserialize, Serialize};
 use zlink::{
-    introspect,
+    Server, introspect,
     unix::{bind, connect},
-    Server,
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/streaming_fds.rs
+++ b/zlink-macros/tests/service/streaming_fds.rs
@@ -3,8 +3,8 @@
 use super::fd_passing::{FdError, FdHandle};
 use serde::{Deserialize, Serialize};
 use zlink::{
-    unix::{bind, connect},
     Server,
+    unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-smol/src/notified/state.rs
+++ b/zlink-smol/src/notified/state.rs
@@ -6,7 +6,7 @@ use std::{
 
 use crate::Reply;
 use async_broadcast::{
-    broadcast, InactiveReceiver, Receiver as BroadcastReceiver, Sender as BroadcastSender,
+    InactiveReceiver, Receiver as BroadcastReceiver, Sender as BroadcastSender, broadcast,
 };
 use pin_project_lite::pin_project;
 

--- a/zlink-smol/src/unix/mod.rs
+++ b/zlink-smol/src/unix/mod.rs
@@ -1,8 +1,8 @@
 //! Provides transport over Unix Domain Sockets.
 
 mod stream;
-pub use stream::{connect, Connection, Stream};
+pub use stream::{Connection, Stream, connect};
 #[cfg(feature = "server")]
 mod listener;
 #[cfg(feature = "server")]
-pub use listener::{bind, Listener};
+pub use listener::{Listener, bind};

--- a/zlink-smol/src/unix/stream.rs
+++ b/zlink-smol/src/unix/stream.rs
@@ -1,6 +1,6 @@
 use crate::{
-    connection::socket::{self, Socket},
     Result,
+    connection::socket::{self, Socket},
 };
 use async_io::Async;
 use std::{
@@ -65,16 +65,18 @@ impl socket::ReadHalf for ReadHalf {
     async fn read(&mut self, buf: &mut [u8]) -> Result<(usize, Vec<OwnedFd>)> {
         use std::{future::poll_fn, task::Poll};
 
-        poll_fn(|cx| loop {
-            match crate::unix_utils::recvmsg(self.0.as_ref(), buf) {
-                Ok(result) => return Poll::Ready(Ok(result)),
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    match self.0.poll_readable(cx) {
-                        Poll::Pending => return Poll::Pending,
-                        Poll::Ready(res) => res?,
+        poll_fn(|cx| {
+            loop {
+                match crate::unix_utils::recvmsg(self.0.as_ref(), buf) {
+                    Ok(result) => return Poll::Ready(Ok(result)),
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        match self.0.poll_readable(cx) {
+                            Poll::Pending => return Poll::Pending,
+                            Poll::Ready(res) => res?,
+                        }
                     }
+                    Err(e) => return Poll::Ready(Err(e.into())),
                 }
-                Err(e) => return Poll::Ready(Err(e.into())),
             }
         })
         .await
@@ -105,16 +107,18 @@ impl socket::WriteHalf for WriteHalf {
             // Use FDs on first write, empty slice on subsequent writes.
             let fds_to_send = if pos == 0 { &borrowed_fds[..] } else { &[] };
 
-            let n: usize = poll_fn(|cx| loop {
-                match crate::unix_utils::sendmsg(self.0.as_ref(), &buf[pos..], fds_to_send) {
-                    Ok(bytes_sent) => return Poll::Ready(Ok::<_, crate::Error>(bytes_sent)),
-                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        match self.0.poll_writable(cx) {
-                            Poll::Pending => return Poll::Pending,
-                            Poll::Ready(res) => res?,
+            let n: usize = poll_fn(|cx| {
+                loop {
+                    match crate::unix_utils::sendmsg(self.0.as_ref(), &buf[pos..], fds_to_send) {
+                        Ok(bytes_sent) => return Poll::Ready(Ok::<_, crate::Error>(bytes_sent)),
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            match self.0.poll_writable(cx) {
+                                Poll::Pending => return Poll::Pending,
+                                Poll::Ready(res) => res?,
+                            }
                         }
+                        Err(e) => return Poll::Ready(Err(e.into())),
                     }
-                    Err(e) => return Poll::Ready(Err(e.into())),
                 }
             })
             .await?;

--- a/zlink-tokio/src/notified/state.rs
+++ b/zlink-tokio/src/notified/state.rs
@@ -105,7 +105,7 @@ where
                         this.cached
                             .take()
                             .map(|reply| Reply::new(Some(reply)).set_continues(Some(false))),
-                    )
+                    );
                 }
             }
         }

--- a/zlink-tokio/src/unix/mod.rs
+++ b/zlink-tokio/src/unix/mod.rs
@@ -1,8 +1,8 @@
 //! Provides transport over Unix Domain Sockets.
 
 mod stream;
-pub use stream::{connect, Connection, Stream};
+pub use stream::{Connection, Stream, connect};
 #[cfg(feature = "server")]
 mod listener;
 #[cfg(feature = "server")]
-pub use listener::{bind, Listener};
+pub use listener::{Listener, bind};

--- a/zlink-tokio/src/unix/stream.rs
+++ b/zlink-tokio/src/unix/stream.rs
@@ -1,9 +1,9 @@
 use crate::{
-    connection::socket::{self, Socket},
     Result,
+    connection::socket::{self, Socket},
 };
 use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
-use tokio::net::{unix, UnixStream};
+use tokio::net::{UnixStream, unix};
 
 /// The connection type that uses Unix Domain Sockets for transport.
 pub type Connection = crate::Connection<Stream>;
@@ -59,18 +59,20 @@ impl socket::ReadHalf for ReadHalf {
     async fn read(&mut self, buf: &mut [u8]) -> Result<(usize, Vec<OwnedFd>)> {
         use std::{future::poll_fn, task::Poll};
 
-        poll_fn(|cx| loop {
-            let stream: &UnixStream = self.0.as_ref();
-            match stream.try_io(tokio::io::Interest::READABLE, || {
-                crate::unix_utils::recvmsg(stream, buf)
-            }) {
-                Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                    match stream.poll_read_ready(cx) {
-                        Poll::Pending => return Poll::Pending,
-                        Poll::Ready(res) => res?,
+        poll_fn(|cx| {
+            loop {
+                let stream: &UnixStream = self.0.as_ref();
+                match stream.try_io(tokio::io::Interest::READABLE, || {
+                    crate::unix_utils::recvmsg(stream, buf)
+                }) {
+                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                        match stream.poll_read_ready(cx) {
+                            Poll::Pending => return Poll::Pending,
+                            Poll::Ready(res) => res?,
+                        }
                     }
+                    v => return Poll::Ready(v.map_err(Into::into)),
                 }
-                v => return Poll::Ready(v.map_err(Into::into)),
             }
         })
         .await
@@ -102,19 +104,21 @@ impl socket::WriteHalf for WriteHalf {
             // Use FDs on first write, empty slice on subsequent writes.
             let fds_to_send = if pos == 0 { &borrowed_fds[..] } else { &[] };
 
-            let n: usize = poll_fn(|cx| loop {
-                let stream: &UnixStream = self.0.as_ref();
-                match stream.try_io(tokio::io::Interest::WRITABLE, || {
-                    crate::unix_utils::sendmsg(stream, &buf[pos..], fds_to_send)
-                }) {
-                    Ok(bytes_sent) => return Poll::Ready(Ok::<_, crate::Error>(bytes_sent)),
-                    Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                        match stream.poll_write_ready(cx) {
-                            Poll::Pending => return Poll::Pending,
-                            Poll::Ready(res) => res?,
+            let n: usize = poll_fn(|cx| {
+                loop {
+                    let stream: &UnixStream = self.0.as_ref();
+                    match stream.try_io(tokio::io::Interest::WRITABLE, || {
+                        crate::unix_utils::sendmsg(stream, &buf[pos..], fds_to_send)
+                    }) {
+                        Ok(bytes_sent) => return Poll::Ready(Ok::<_, crate::Error>(bytes_sent)),
+                        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                            match stream.poll_write_ready(cx) {
+                                Poll::Pending => return Poll::Pending,
+                                Poll::Ready(res) => res?,
+                            }
                         }
+                        Err(e) => return Poll::Ready(Err(e.into())),
                     }
-                    Err(e) => return Poll::Ready(Err(e.into())),
                 }
             })
             .await?;

--- a/zlink/examples/resolved.rs
+++ b/zlink/examples/resolved.rs
@@ -2,9 +2,9 @@
 // We use the proxy macro to generate a type-safe client API.
 use std::{env::args, fmt::Display, net::IpAddr};
 
-use futures_util::{pin_mut, StreamExt};
+use futures_util::{StreamExt, pin_mut};
 use serde_repr::{Deserialize_repr, Serialize_repr};
-use zlink::{proxy, ReplyError};
+use zlink::{ReplyError, proxy};
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/zlink/tests/ftl.rs
+++ b/zlink/tests/ftl.rs
@@ -6,7 +6,7 @@
 
 use std::{pin::pin, time::Duration};
 
-use futures_util::{pin_mut, stream::StreamExt, TryStreamExt};
+use futures_util::{TryStreamExt, pin_mut, stream::StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::{select, time::sleep};
 use zlink::{

--- a/zlink/tests/machined_proxy_e2e.rs
+++ b/zlink/tests/machined_proxy_e2e.rs
@@ -9,13 +9,13 @@
 
 mod mock_machined_service;
 
-use futures_util::{pin_mut, Stream, TryStreamExt};
+use futures_util::{Stream, TryStreamExt, pin_mut};
 use std::path::Path;
 #[cfg(feature = "server")]
 use tempfile::TempDir;
 #[cfg(feature = "server")]
 use tokio::select;
-use tokio::time::{timeout, Duration};
+use tokio::time::{Duration, timeout};
 use zlink::{
     proxy, unix,
     varlink_service::{self, Proxy},

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -6,8 +6,8 @@ use std::borrow::Cow;
 
 use serde::{Deserialize, Serialize};
 use zlink::{
-    introspect::{self, CustomType, Type},
     ReplyError,
+    introspect::{self, CustomType, Type},
 };
 
 // ============================================================================


### PR DESCRIPTION
This implies also bumping our MSRV to 1.85 but that's already more than a year old now so it shouldn't be an issue. Most of the changes here just formatting updates.

The motivation for this is mainly to avoid strange issues that arise from our tests checking our code against Rust 2021 and users using 2024. For example the issue resolved by #246.
