### PR TITLE
👷 ci: adopt shared commitlint config for `gimoji`

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -1,0 +1,3 @@
+export default {
+    extends: ["@gimoji/commitlint-config-gimoji"],
+};

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,24 @@
+# https://commitlint.js.org/guides/ci-setup.html
+
+name: commitlint
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: lts/*
+
+      - name: Validate PR commits with commitlint
+        if: github.event_name == 'pull_request'
+        run: npm exec --package @commitlint/cli --package @gimoji/commitlint-config-gimoji --package @gimoji/commitlint-plugin-gimoji --yes -- commitlint  --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose


### PR DESCRIPTION
- we've extracted our bespoke `commitlint` plugin/config for `gimoji` over here: https://github.com/zeenix/gimoji/pull/318
- so this PR adopts that approach for linting commit messages
- an alternative to the long `npm exec ...` line in the GitHub workflow would be to add a package.json file to this repository, but that seems a little unnecessary (probably more appropriate for a JavaScript/TypeScript project)
- the versions can also be pinned with e.g. `...@1.2.3` in the `npm exec ...` line or in the usual manner in a package.json file
- i've avoided pinning versions for now, as we're the maintainers of our commitlint plugin/config (this way we can make a change over in the central/shared config and have it take effect immediately without having to version bump everywhere, but this might not be how you're prefer that to work)