### PR TITLE
Supplementary groups fixes

### DIFF
--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -113,6 +113,8 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
                 // If the number of groups returned is less than the requested size, we are done.
                 if nr_supp_gids as usize <= supp_gids.capacity() {
                     supp_gids.shrink_to(nr_supp_gids as usize);
+                    // SAFETY: `getsockopt` filled at least `nr_supp_gids` items in the buffer.
+                    unsafe { supp_gids.set_len(nr_supp_gids as usize) };
                     break;
                 }
 

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -91,6 +91,7 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
             use rustix::fs::Gid;
 
             let mut nr_supp_gids = INITIAL_NUMBER_SUPPLEMENTARY_GROUPS;
+            let mut nr_supp_gids_in_bytes = nr_supp_gids * (size_of::<Gid>() as u32);
             let mut supp_gids: Vec<Gid> = Vec::with_capacity(nr_supp_gids as usize);
 
             loop {
@@ -100,7 +101,7 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
                         libc::SOL_SOCKET,
                         libc::SO_PEERGROUPS,
                         supp_gids.as_mut_ptr().cast(),
-                        &mut nr_supp_gids,
+                        &mut nr_supp_gids_in_bytes,
                     )
                 };
                 let err = io::Error::last_os_error();
@@ -111,6 +112,7 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
                 }
 
                 // If the number of groups returned is less than the requested size, we are done.
+                nr_supp_gids = nr_supp_gids_in_bytes / size_of::<Gid>() as u32;
                 if nr_supp_gids as usize <= supp_gids.capacity() {
                     supp_gids.shrink_to(nr_supp_gids as usize);
                     // SAFETY: `getsockopt` filled at least `nr_supp_gids` items in the buffer.
@@ -122,6 +124,9 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
                 // We let the standard Vector speculation over-allocation take place here on
                 // purpose.
                 supp_gids.reserve(nr_supp_gids as usize - supp_gids.capacity());
+                // SAFETY: The number of supplementary GIDs on Linux is bounded 65k which fits in
+                // u32.
+                nr_supp_gids_in_bytes = (supp_gids.capacity() as u32) * (size_of::<Gid>() as u32);
             }
 
             supp_gids


### PR DESCRIPTION
Supplementary groups are unfortunately DoA in the previous release and this is largely my fault.

Details are in the commit messages. These fixes still do not introduce integration testing because I'm not sure how to achieve this.

If you are interested into having NixOS tests for zlink, I can arrange this and add integration testing in the project and catch this sort of issues (and more).