### PR TITLE
📝 Configure docs.rs to build for all supported targets

### DIFF
--- a/zlink-codegen/Cargo.toml
+++ b/zlink-codegen/Cargo.toml
@@ -26,3 +26,12 @@ anyhow = "1.0"
 [dev-dependencies]
 tempfile = "3.14"
 pretty_assertions = "1.4"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+]

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -71,3 +71,12 @@ criterion = { version = "4.0.4", package = "codspeed-criterion-compat", features
 [[bench]]
 name = "benchmarks"
 harness = false
+
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+]

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -56,3 +56,12 @@ test-log = { version = "0.2.17", default-features = false, features = [
     "trace",
     "color",
 ] }
+
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+]

--- a/zlink-smol/Cargo.toml
+++ b/zlink-smol/Cargo.toml
@@ -40,3 +40,12 @@ test-log = { version = "0.2.17", default-features = false, features = [
     "color",
 ] }
 tempfile = "3.14"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+]

--- a/zlink-tokio/Cargo.toml
+++ b/zlink-tokio/Cargo.toml
@@ -46,3 +46,12 @@ test-log = { version = "0.2.17", default-features = false, features = [
     "color",
 ] }
 tempfile = "3.14"
+
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+]

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -58,3 +58,12 @@ required-features = ["introspection", "idl-parse", "tokio"]
 [[example]]
 name = "resolved"
 required-features = ["proxy", "tokio"]
+
+[package.metadata.docs.rs]
+all-features = true
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "x86_64-unknown-freebsd",
+    "x86_64-unknown-netbsd",
+]


### PR DESCRIPTION
docs.rs now only builds for default targets (see
https://blog.rust-lang.org/2026/04/04/docsrs-only-default-targets).
Explicitly list all Unix targets we support (matching CI compile-time
checks) so platform-specific items remain visible in the generated
documentation.

Assisted-by: Claude Opus 4.7 (1M context)
