### PR TITLE
📝 macros: Document streaming `more` methods on `service` macro

### DIFF
--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1130,9 +1130,9 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// - Take `more: bool` as the first parameter after `self`. This receives the value of the call's
 ///   `more` flag, allowing the method to behave differently when the client only wants a single
 ///   reply.
-/// - Return `impl Stream<Item = Reply<T>>` (or `impl Stream<Item = (Reply<T>, Vec<OwnedFd>)>`
-///   when combined with `#[zlink(return_fds)]`). A concrete stream type is also accepted; in that
-///   case the macro infers `Reply<T>` from the type's first generic parameter.
+/// - Return `impl Stream<Item = Reply<T>>` (or `impl Stream<Item = (Reply<T>, Vec<OwnedFd>)>` when
+///   combined with `#[zlink(return_fds)]`). A concrete stream type is also accepted; in that case
+///   the macro infers `Reply<T>` from the type's first generic parameter.
 /// - Set `Reply::set_continues(Some(true))` on every intermediate item and `Some(false)` on the
 ///   final one so that the client knows when the stream ends.
 ///

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1136,8 +1136,9 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// - Set `Reply::set_continues(Some(true))` on every intermediate item and `Some(false)` on the
 ///   final one so that the client knows when the stream ends.
 ///
-/// Streaming methods cannot return `Result<T, E>`: every stream item is a `Reply<T>`, so errors
-/// cannot be reported as stream items via this macro.
+/// Streaming methods cannot currently return `Result<T, E>`: every stream item is a `Reply<T>`,
+/// so errors cannot be reported as stream items via this macro yet. This is a temporary limitation
+/// that will be lifted in a future release.
 ///
 /// ## Example
 ///

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1122,6 +1122,55 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// Methods with connection parameters are only callable through the `Service` trait (not directly
 /// on the type), since they require the socket type to be known.
 ///
+/// # Streaming Methods
+///
+/// Methods that send multiple replies (the Varlink `more` flag) are marked with `#[zlink(more)]`.
+/// Such a method must:
+///
+/// - Take `more: bool` as the first parameter after `self`. This receives the value of the call's
+///   `more` flag, allowing the method to behave differently when the client only wants a single
+///   reply.
+/// - Return `impl Stream<Item = Reply<T>>` (or `impl Stream<Item = (Reply<T>, Vec<OwnedFd>)>`
+///   when combined with `#[zlink(return_fds)]`). A concrete stream type is also accepted; in that
+///   case the macro infers `Reply<T>` from the type's first generic parameter.
+/// - Set `Reply::set_continues(Some(true))` on every intermediate item and `Some(false)` on the
+///   final one so that the client knows when the stream ends.
+///
+/// Streaming methods cannot return `Result<T, E>`: every stream item is a `Reply<T>`, so errors
+/// cannot be reported as stream items via this macro.
+///
+/// ## Example
+///
+/// ```rust
+/// use futures_util::Stream;
+/// use serde::{Deserialize, Serialize};
+/// use zlink::{introspect::Type, service, Reply};
+///
+/// #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Type)]
+/// struct Tick {
+///     value: u32,
+/// }
+///
+/// struct Counter;
+///
+/// #[service(interface = "org.example.counter")]
+/// impl Counter {
+///     // Streams `Tick` values from 1 to `to`. If the caller did not set the `more` flag, only a
+///     // single tick is emitted.
+///     #[zlink(more)]
+///     async fn count(
+///         &self,
+///         more: bool,
+///         to: u32,
+///     ) -> impl Stream<Item = Reply<Tick>> + Unpin {
+///         let to = if more { to.max(1) } else { 1 };
+///         futures_util::stream::iter((1..=to).map(move |value| {
+///             Reply::new(Some(Tick { value })).set_continues(Some(value < to))
+///         }))
+///     }
+/// }
+/// ```
+///
 /// # Example
 ///
 /// ```rust


### PR DESCRIPTION
## Summary

- The `#[service]` macro docs covered every method flavor except the streaming (`#[zlink(more)]`) one, which the `#[proxy]` macro already documents.
- Add a dedicated "Streaming Methods" section explaining:
  - The `more: bool` first-parameter requirement.
  - The `Stream<Item = Reply<T>>` (and `(Reply<T>, Vec<OwnedFd>)`) return shape.
  - Using `Reply::set_continues` to terminate the stream.
  - That errors cannot be returned as stream items, since the macro requires `Reply<T>` rather than `Result<T, E>`.
- Include a small self-contained `Counter` example so the section stands on its own.

## Test plan

- [x] `cargo test --all-features` (all tests pass, including the new doctest at `zlink-macros/src/lib.rs:1144`)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-features -- -D warnings`

https://claude.ai/code/session_01QSBUjM9BZpgjAe3ApuqmrU

---
_Generated by [Claude Code](https://claude.ai/code/session_01QSBUjM9BZpgjAe3ApuqmrU)_