### PR TITLE
✨ macros: Allow streaming methods to return method errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "zlink"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "clap",
  "colored 3.0.0",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-codegen"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2169,7 +2169,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-core"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-macros"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "futures-util",
  "proc-macro2",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-smol"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-tokio"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "futures-util",
  "pin-project-lite",

--- a/zlink-codegen/Cargo.toml
+++ b/zlink-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-codegen"
-version = "0.4.2"
+version = "0.5.0"
 description = "Utility to generate zlink code from varlink IDL files"
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ name = "zlink-codegen"
 path = "src/main.rs"
 
 [dependencies]
-zlink = { path = "../zlink", version = "0.4.2", features = [
+zlink = { path = "../zlink", version = "0.5.0", features = [
     "idl",
     "idl-parse",
 ] }

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-core"
-version = "0.4.2"
+version = "0.5.0"
 description = "The core crate of the zlink project"
 edition.workspace = true
 rust-version.workspace = true
@@ -21,7 +21,7 @@ introspection = ["idl", "zlink-macros/introspection"]
 
 [dependencies]
 serde = { version = "1.0.218", default-features = false, features = ["derive", "alloc"] }
-zlink-macros = { path = "../zlink-macros", version = "=0.4.2" }
+zlink-macros = { path = "../zlink-macros", version = "=0.5.0" }
 serde_json = { version = "1.0.139", default-features = false, features = ["alloc"] }
 itoa = { version = "1.0", default-features = false }
 ryu = { version = "1.0", default-features = false }

--- a/zlink-core/src/server/infallible.rs
+++ b/zlink-core/src/server/infallible.rs
@@ -1,0 +1,32 @@
+//! [`serde::Serialize`]-carrying wrapper around [`core::convert::Infallible`].
+
+use core::fmt::Debug;
+
+use serde::{Serialize, Serializer};
+
+/// [`serde::Serialize`]-carrying wrapper around [`core::convert::Infallible`].
+///
+/// Recommended choice for [`Service::ReplyError`] and [`Service::ReplyStreamError`] when the
+/// corresponding methods cannot fail. The [`service`] macro also picks it for
+/// [`Service::ReplyStreamError`] when no streaming method declares an error type.
+///
+/// It exists because of [serde-rs/serde#2740]: `core::convert::Infallible` has no `Serialize`
+/// impl in `serde`, which makes it unusable for trait associated types bounded by `Serialize`.
+/// This wrapper carries the missing impl. The inner [`core::convert::Infallible`] cannot be
+/// constructed, so neither can this — the `Serialize` impl is statically unreachable.
+///
+/// Once serde lands a built-in `Serialize` impl for `Infallible`, this wrapper will be
+/// deprecated in favor of `core::convert::Infallible`.
+///
+/// [`Service::ReplyError`]: super::service::Service::ReplyError
+/// [`Service::ReplyStreamError`]: super::service::Service::ReplyStreamError
+/// [`service`]: macro@crate::service
+/// [serde-rs/serde#2740]: https://github.com/serde-rs/serde/issues/2740
+#[derive(Debug)]
+pub struct Infallible(core::convert::Infallible);
+
+impl Serialize for Infallible {
+    fn serialize<S: Serializer>(&self, _serializer: S) -> Result<S::Ok, S::Error> {
+        unreachable!("`Infallible` is uninhabited, so this method can never run")
+    }
+}

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -2,6 +2,8 @@ pub(crate) mod listener;
 mod select_all;
 pub mod service;
 
+mod infallible;
+
 use alloc::vec::Vec;
 use futures_util::{FutureExt, StreamExt};
 use select_all::SelectAll;

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -155,15 +155,23 @@ where
                     match item {
                         Some(item) => {
                             #[cfg(feature = "std")]
-                            let (reply, fds) = item;
-                            #[cfg(not(feature = "std"))]
-                            let reply = item;
-
+                            let (item, fds) = item;
                             #[cfg(feature = "std")]
-                            let send_result =
-                                reply_streams[idx].conn.send_reply(&reply, fds).await;
+                            let send_result = match item {
+                                Ok(reply) => reply_streams[idx]
+                                    .conn
+                                    .send_reply(&reply, fds)
+                                    .await,
+                                Err(error) => reply_streams[idx]
+                                    .conn
+                                    .send_error(&error, fds)
+                                    .await,
+                            };
                             #[cfg(not(feature = "std"))]
-                            let send_result = reply_streams[idx].conn.send_reply(&reply).await;
+                            let send_result = match item {
+                                Ok(reply) => reply_streams[idx].conn.send_reply(&reply).await,
+                                Err(error) => reply_streams[idx].conn.send_error(&error).await,
+                            };
                             if let Err(e) = send_result {
                                 warn!("Error writing to client {}: {:?}", id, e);
                                 reply_streams.swap_remove(idx);

--- a/zlink-core/src/server/service.rs
+++ b/zlink-core/src/server/service.rs
@@ -5,6 +5,7 @@ use core::{fmt::Debug, future::Future};
 use futures_util::Stream;
 use serde::{Deserialize, Serialize};
 
+pub use super::infallible::Infallible;
 use crate::{Call, Connection, Reply, connection::Socket};
 
 /// The item type that a [`Service::ReplyStream`] yields.

--- a/zlink-core/src/server/service.rs
+++ b/zlink-core/src/server/service.rs
@@ -10,16 +10,27 @@ use crate::{Call, Connection, Reply, connection::Socket};
 
 /// The item type that a [`Service::ReplyStream`] yields.
 ///
-/// On `std`, this is a tuple of the reply and the file descriptors to send with it. On `no_std`,
-/// this is just the reply.
+/// Each item is either an [`Ok`] success [`Reply`] or an [`Err`] error reply. Services whose
+/// streaming methods never fail should set [`Service::ReplyStreamError`] to [`Infallible`], in
+/// which case the `Err` arm is statically unreachable.
+///
+/// On `std`, the alias additionally pairs the result with the file descriptors to send. On
+/// `no_std`, it is just the result.
 #[cfg(feature = "std")]
-pub type ReplyStreamItem<Params> = (Reply<Params>, Vec<std::os::fd::OwnedFd>);
+pub type ReplyStreamItem<Params, Error> = (
+    core::result::Result<Reply<Params>, Error>,
+    Vec<std::os::fd::OwnedFd>,
+);
 /// The item type that a [`Service::ReplyStream`] yields.
 ///
-/// On `std`, this is a tuple of the reply and the file descriptors to send with it. On `no_std`,
-/// this is just the reply.
+/// Each item is either an [`Ok`] success [`Reply`] or an [`Err`] error reply. Services whose
+/// streaming methods never fail should set [`Service::ReplyStreamError`] to [`Infallible`], in
+/// which case the `Err` arm is statically unreachable.
+///
+/// On `std`, the alias additionally pairs the result with the file descriptors to send. On
+/// `no_std`, it is just the result.
 #[cfg(not(feature = "std"))]
-pub type ReplyStreamItem<Params> = Reply<Params>;
+pub type ReplyStreamItem<Params, Error> = core::result::Result<Reply<Params>, Error>;
 
 /// Service trait for handling method calls.
 ///
@@ -51,16 +62,26 @@ where
     ///
     /// This should be a type that can serialize itself as the `parameters` field of the reply.
     type ReplyStreamParams: Serialize + Debug;
+    /// The type of an error reply produced by a streaming method.
+    ///
+    /// Unlike [`Self::ReplyError`], this type cannot borrow from `&self` (the stream outlives the
+    /// `handle` call). Services whose streaming methods never fail should set this to
+    /// [`Infallible`] — the `Err` arm of [`ReplyStreamItem`] then becomes statically unreachable.
+    type ReplyStreamError: Serialize + Debug;
     /// The type of the multi-reply stream.
     ///
-    /// If the client asks for multiple replies, this stream will be used to send them.
-    type ReplyStream: Stream<Item = ReplyStreamItem<Self::ReplyStreamParams>> + Unpin;
+    /// If the client asks for multiple replies, this stream will be used to send them. Each
+    /// stream item is either a success [`Reply`] or an error of type [`Self::ReplyStreamError`].
+    type ReplyStream: Stream<Item = ReplyStreamItem<Self::ReplyStreamParams, Self::ReplyStreamError>>
+        + Unpin;
     /// The type of the error reply.
     ///
     /// This should be a type that can serialize itself to the whole reply object, containing
     /// `error` and `parameter` fields. This can be easily achieved using the `serde::Serialize`
     /// derive (See the code snippet in [`crate::connection::ReadConnection::receive_reply`]
     /// documentation for an example).
+    ///
+    /// Services whose methods never fail can use [`Infallible`] for this type as well.
     type ReplyError<'ser>: Serialize + Debug
     where
         Self: 'ser;

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-macros"
-version = "0.4.2"
+version = "0.5.0"
 description = "Macros providing the high-level zlink API"
 edition.workspace = true
 rust-version.workspace = true

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1136,9 +1136,20 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// - Set `Reply::set_continues(Some(true))` on every intermediate item and `Some(false)` on the
 ///   final one so that the client knows when the stream ends.
 ///
-/// Streaming methods cannot currently return `Result<T, E>`: every stream item is a `Reply<T>`,
-/// so errors cannot be reported as stream items via this macro yet. This is a temporary limitation
-/// that will be lifted in a future release.
+/// ## Returning Method Errors From Streams
+///
+/// Streaming methods can also opt in to emitting Varlink error replies as stream items. To do so,
+/// return a stream whose item is `Result<Reply<T>, E>` (or `(Result<Reply<T>, E>, Vec<OwnedFd>)`
+/// for `#[zlink(return_fds)]`). When the stream yields `Err(e)`, the server sends an error reply
+/// to the client. The error type `E` must implement `serde::Serialize` and `Debug`, just like for
+/// non-streaming methods, and (because the stream outlives `&self`) cannot borrow from the
+/// service. Different streaming methods may use different error types; the macro combines them
+/// into a single internal enum exposed as `Service::ReplyStreamError`.
+///
+/// Note that, on the wire, an error reply terminates the stream — a client that receives an
+/// error reply should not expect any further items. The macro does not enforce this on the
+/// server side, so callers can still drain the rest of the stream if the server emits more items
+/// after an error.
 ///
 /// ## Example
 ///
@@ -1168,6 +1179,46 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///         futures_util::stream::iter((1..=to).map(move |value| {
 ///             Reply::new(Some(Tick { value })).set_continues(Some(value < to))
 ///         }))
+///     }
+/// }
+/// ```
+///
+/// ## Streaming With Errors
+///
+/// ```rust
+/// use futures_util::Stream;
+/// use serde::{Deserialize, Serialize};
+/// use zlink::{introspect, service, Reply};
+///
+/// #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, introspect::Type)]
+/// struct Tick { value: u32 }
+///
+/// #[derive(Debug, Clone, PartialEq, zlink::ReplyError, introspect::ReplyError)]
+/// #[zlink(interface = "org.example.counter")]
+/// enum CountError {
+///     AtZero,
+/// }
+///
+/// struct Counter;
+///
+/// #[service(interface = "org.example.counter")]
+/// impl Counter {
+///     #[zlink(more)]
+///     async fn count(
+///         &self,
+///         _more: bool,
+///         to: u32,
+///     ) -> impl Stream<Item = Result<Reply<Tick>, CountError>> + Unpin {
+///         if to == 0 {
+///             return futures_util::stream::iter(vec![Err(CountError::AtZero)]);
+///         }
+///         let last = to;
+///         let items: Vec<Result<Reply<Tick>, CountError>> = (1..=to)
+///             .map(move |value| {
+///                 Ok(Reply::new(Some(Tick { value })).set_continues(Some(value < last)))
+///             })
+///             .collect();
+///         futures_util::stream::iter(items)
 ///     }
 /// }
 /// ```

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -17,6 +17,9 @@ struct HandleBodyContext<'a> {
     reply_params_name: &'a Ident,
     reply_error_name: &'a Ident,
     reply_stream_params_name: &'a Ident,
+    /// The token stream for the resolved `ReplyStreamError` type (either the generated enum or
+    /// the [`Infallible`](crate::service::Infallible) sentinel).
+    reply_stream_error_ty: &'a TokenStream,
     reply_stream_name: &'a Ident,
     error_type_map: &'a HashMap<String, usize>,
     stream_item_type_map: &'a HashMap<String, Ident>,
@@ -69,6 +72,7 @@ pub(super) fn generate_service_impl(
     let reply_params_name = format_ident!("__{}ReplyParams", type_name);
     let reply_error_name = format_ident!("__{}ReplyError", type_name);
     let reply_stream_params_name = format_ident!("__{}ReplyStreamParams", type_name);
+    let reply_stream_error_name = format_ident!("__{}ReplyStreamError", type_name);
     let reply_stream_name = format_ident!("__{}ReplyStream", type_name);
 
     // Collect interfaces for introspection.
@@ -111,6 +115,15 @@ pub(super) fn generate_service_impl(
     let (reply_stream_params_enum, stream_item_type_map) =
         generate_reply_stream_params_enum(methods_info, &reply_stream_params_name);
 
+    // Generate the ReplyStreamError enum (only when at least one streaming method emits errors).
+    let (reply_stream_error_enum, stream_error_type_map) =
+        generate_reply_stream_error_enum(methods_info, &reply_stream_error_name);
+    let reply_stream_error_ty = if stream_error_type_map.is_empty() {
+        quote! { #crate_path::service::Infallible }
+    } else {
+        quote! { #reply_stream_error_name }
+    };
+
     // Check if any streaming method uses `impl Trait` (requires boxing).
     let needs_stream_boxing = methods_info
         .iter()
@@ -124,6 +137,7 @@ pub(super) fn generate_service_impl(
         reply_params_name: &reply_params_name,
         reply_error_name: &reply_error_name,
         reply_stream_params_name: &reply_stream_params_name,
+        reply_stream_error_ty: &reply_stream_error_ty,
         reply_stream_name: &reply_stream_name,
         error_type_map: &error_type_map,
         stream_item_type_map: &stream_item_type_map,
@@ -168,9 +182,7 @@ pub(super) fn generate_service_impl(
     // Check for streaming methods and determine stream types.
     let has_streaming_methods = methods_info.iter().any(|m| m.is_streaming);
 
-    // Generate the ReplyStream type and enum (if using concrete types). Streaming methods
-    // currently always use `service::Infallible` as the error type — the macro doesn't yet detect
-    // `Stream<Item = Result<Reply<T>, E>>` shapes, so every item is mechanically wrapped in `Ok`.
+    // Generate the ReplyStream type and enum (if using concrete types).
     let (reply_stream_type, reply_stream_params_type, reply_stream_enum) = if has_streaming_methods
     {
         if needs_stream_boxing {
@@ -181,7 +193,7 @@ pub(super) fn generate_service_impl(
                         dyn #crate_path::futures_util::Stream<
                                 Item = #crate_path::service::ReplyStreamItem<
                                     #reply_stream_params_name,
-                                    #crate_path::service::Infallible,
+                                    #reply_stream_error_ty,
                                 >
                             > + ::core::marker::Unpin
                     >
@@ -195,6 +207,7 @@ pub(super) fn generate_service_impl(
                 methods_info,
                 &reply_stream_name,
                 &reply_stream_params_name,
+                &reply_stream_error_ty,
                 &stream_item_type_map,
                 crate_path,
             );
@@ -210,7 +223,10 @@ pub(super) fn generate_service_impl(
         (
             quote! {
                 #crate_path::futures_util::stream::Empty<
-                    #crate_path::service::ReplyStreamItem<(), #crate_path::service::Infallible>
+                    #crate_path::service::ReplyStreamItem<
+                        (),
+                        #crate_path::service::Infallible,
+                    >
                 >
             },
             quote! { () },
@@ -233,7 +249,7 @@ pub(super) fn generate_service_impl(
             type ReplyParams<'ser> = #reply_params_name<'ser> where Self: 'ser;
             type ReplyStream = #reply_stream_type;
             type ReplyStreamParams = #reply_stream_params_type;
-            type ReplyStreamError = #crate_path::service::Infallible;
+            type ReplyStreamError = #reply_stream_error_ty;
             type ReplyError<'ser> = #error_type where Self: 'ser;
 
             async fn handle<'__zlink_ser>(
@@ -259,6 +275,8 @@ pub(super) fn generate_service_impl(
         #reply_params_enum
 
         #reply_stream_params_enum
+
+        #reply_stream_error_enum
 
         #reply_stream_enum
 
@@ -411,6 +429,31 @@ fn build_error_type_variant_map(methods_info: &[MethodInfo]) -> HashMap<String, 
     type_to_variant
 }
 
+/// Build a mapping from stream error type string representation to variant index.
+/// This ensures consistent variant naming for the stream error enum.
+fn build_stream_error_type_variant_map(methods_info: &[MethodInfo]) -> HashMap<String, usize> {
+    let mut type_to_variant: HashMap<String, usize> = HashMap::new();
+    let mut variant_idx = 0;
+
+    for method in methods_info {
+        if !method.is_streaming {
+            continue;
+        }
+
+        let Some(ref err_type) = method.stream_error_type else {
+            continue;
+        };
+
+        let type_str = err_type.to_token_stream().to_string();
+        if let std::collections::hash_map::Entry::Vacant(e) = type_to_variant.entry(type_str) {
+            e.insert(variant_idx);
+            variant_idx += 1;
+        }
+    }
+
+    type_to_variant
+}
+
 /// Build a mapping from stream item type string representation to variant name.
 /// This ensures consistent variant naming for the stream params enum.
 fn build_stream_item_type_variant_map(methods_info: &[MethodInfo]) -> HashMap<String, Ident> {
@@ -507,6 +550,66 @@ fn generate_reply_error_enum(
     (enum_def, error_type_map)
 }
 
+/// Generate the ReplyStreamError enum for errors emitted as streaming method items.
+///
+/// Returns the (optional) enum definition and the type map. When no streaming method emits
+/// errors, the enum is omitted and `Infallible` is used as the associated type.
+fn generate_reply_stream_error_enum(
+    methods_info: &[MethodInfo],
+    enum_name: &Ident,
+) -> (TokenStream, HashMap<String, usize>) {
+    let type_map = build_stream_error_type_variant_map(methods_info);
+
+    if type_map.is_empty() {
+        return (quote! {}, type_map);
+    }
+
+    let mut type_variant_pairs: Vec<_> = type_map.iter().collect();
+    type_variant_pairs.sort_by_key(|(_, idx)| *idx);
+
+    let mut variants: Vec<TokenStream> = Vec::new();
+    let mut from_impls: Vec<TokenStream> = Vec::new();
+
+    for (type_str, idx) in type_variant_pairs {
+        for method in methods_info {
+            if !method.is_streaming {
+                continue;
+            }
+            let Some(ref err_type) = method.stream_error_type else {
+                continue;
+            };
+            if &err_type.to_token_stream().to_string() == type_str {
+                let variant_name = format_ident!("__{}Variant{}", enum_name, idx);
+                variants.push(quote! {
+                    #variant_name(#err_type)
+                });
+
+                from_impls.push(quote! {
+                    impl ::core::convert::From<#err_type> for #enum_name {
+                        fn from(e: #err_type) -> Self {
+                            #enum_name::#variant_name(e)
+                        }
+                    }
+                });
+                break;
+            }
+        }
+    }
+
+    let enum_def = quote! {
+        #[allow(private_interfaces)]
+        #[derive(::core::fmt::Debug, ::serde::Serialize)]
+        #[serde(untagged)]
+        pub enum #enum_name {
+            #(#variants,)*
+        }
+
+        #(#from_impls)*
+    };
+
+    (enum_def, type_map)
+}
+
 /// Generate the ReplyStreamParams enum for streaming method replies.
 /// Returns the enum definition, From impls, and the type map.
 fn generate_reply_stream_params_enum(
@@ -572,11 +675,82 @@ fn generate_reply_stream_params_enum(
 }
 
 /// Generate the ReplyStream enum for concrete stream types (using pin-project-lite).
+/// Build the body that maps `__r` (the user stream's item) into the trait's required
+/// `Result<Reply<ReplyStreamParams>, ReplyStreamError>` shape.
+///
+/// Used by both the boxed (`impl Trait`) and concrete-type stream wrappers.
+fn build_stream_map_body(
+    has_err: bool,
+    params_variant: &Ident,
+    reply_stream_params_name: &Ident,
+    reply_stream_error_ty: &TokenStream,
+    crate_path: &TokenStream,
+) -> TokenStream {
+    let result_ty = quote! {
+        ::core::result::Result::<
+            #crate_path::Reply<#reply_stream_params_name>,
+            #reply_stream_error_ty,
+        >
+    };
+    let wrap_ok = quote! {
+        #result_ty::Ok(__rep.map(|__p| #reply_stream_params_name::#params_variant(__p)))
+    };
+    if has_err {
+        quote! {
+            match __r {
+                ::core::result::Result::Ok(__rep) => { #wrap_ok }
+                ::core::result::Result::Err(__err) => {
+                    #result_ty::Err(::core::convert::Into::into(__err))
+                }
+            }
+        }
+    } else {
+        // Alias `__rep` so the `wrap_ok` template above is identical in both arms.
+        quote! { { let __rep = __r; #wrap_ok } }
+    }
+}
+
+/// Build the closure that adapts a stream item from the user's stream into the trait's stream
+/// item shape (`ReplyStreamItem<P, E>`).
+///
+/// On `std`:
+///   * `return_fds` → `|(__r, __fds)| (#map_body, __fds)`
+///   * otherwise    → `|__r| (#map_body, Vec::new())`
+///
+/// On `no_std`: `|__r| #map_body` (no FDs).
+fn build_stream_item_map_closure(map_body: &TokenStream, return_fds: bool) -> TokenStream {
+    #[cfg(feature = "std")]
+    {
+        let fds_expr = if return_fds {
+            quote! { __fds }
+        } else {
+            quote! { ::std::vec::Vec::new() }
+        };
+        let arg_pat = if return_fds {
+            quote! { (__r, __fds) }
+        } else {
+            quote! { __r }
+        };
+        quote! {
+            |#arg_pat| {
+                let __mapped = #map_body;
+                (__mapped, #fds_expr)
+            }
+        }
+    }
+    #[cfg(not(feature = "std"))]
+    {
+        let _ = return_fds;
+        quote! { |__r| { #map_body } }
+    }
+}
+
 /// This avoids boxing when all streaming methods return concrete types.
 fn generate_reply_stream_enum(
     methods_info: &[MethodInfo],
     enum_name: &Ident,
     reply_stream_params_name: &Ident,
+    reply_stream_error_ty: &TokenStream,
     stream_item_type_map: &HashMap<String, Ident>,
     crate_path: &TokenStream,
 ) -> TokenStream {
@@ -604,10 +778,14 @@ fn generate_reply_stream_enum(
         })
         .collect();
 
-    // Generate poll_next match arms.
-    // On std, stream items are (Reply<T>, Vec<OwnedFd>) tuples.
-    // On no_std, stream items are just Reply<T>.
-    #[cfg(feature = "std")]
+    // Generate poll_next match arms. The user method's stream might yield:
+    //   * `Reply<T>`                                       — wrap in `Ok(...)`
+    //   * `Result<Reply<T>, E>`                             — convert error via `Into`
+    //   * `(Reply<T>, Vec<OwnedFd>)`        (return_fds)    — wrap in `Ok(...)` (with FDs)
+    //   * `(Result<Reply<T>, E>, Vec<OwnedFd>)` (return_fds + error)
+    //
+    // The trait's stream item shape is built by `build_stream_map_body` /
+    // `build_stream_item_map_closure`.
     let poll_arms: Vec<TokenStream> = streaming_methods
         .iter()
         .map(|method| {
@@ -618,53 +796,17 @@ fn generate_reply_stream_enum(
                 .get(&type_str)
                 .cloned()
                 .unwrap_or_else(|| format_ident!("__Unknown"));
-
-            if method.return_fds {
-                // Method's stream yields (Reply<T>, Vec<OwnedFd>).
-                quote! {
-                    #projection_name::#variant_name { stream } => {
-                        stream.poll_next(cx).map(|opt| opt.map(|(reply, fds)| {
-                            let mapped_reply = reply.map(|params| {
-                                #reply_stream_params_name::#params_variant(params)
-                            });
-                            (::core::result::Result::Ok(mapped_reply), fds)
-                        }))
-                    }
-                }
-            } else {
-                // Method's stream yields Reply<T>, wrap with empty FDs.
-                quote! {
-                    #projection_name::#variant_name { stream } => {
-                        stream.poll_next(cx).map(|opt| opt.map(|reply| {
-                            let mapped_reply = reply.map(|params| {
-                                #reply_stream_params_name::#params_variant(params)
-                            });
-                            (::core::result::Result::Ok(mapped_reply), ::std::vec::Vec::new())
-                        }))
-                    }
-                }
-            }
-        })
-        .collect();
-    #[cfg(not(feature = "std"))]
-    let poll_arms: Vec<TokenStream> = streaming_methods
-        .iter()
-        .map(|method| {
-            let variant_name = format_ident!("{}", method.varlink_name);
-            let item_type = method.stream_item_type.as_ref().unwrap();
-            let type_str = item_type.to_token_stream().to_string();
-            let params_variant = stream_item_type_map
-                .get(&type_str)
-                .cloned()
-                .unwrap_or_else(|| format_ident!("__Unknown"));
-
+            let map_body = build_stream_map_body(
+                method.stream_error_type.is_some(),
+                &params_variant,
+                reply_stream_params_name,
+                reply_stream_error_ty,
+                crate_path,
+            );
+            let item_map = build_stream_item_map_closure(&map_body, method.return_fds);
             quote! {
                 #projection_name::#variant_name { stream } => {
-                    stream.poll_next(cx).map(|opt| opt.map(|reply| {
-                        ::core::result::Result::Ok(
-                            reply.map(|params| #reply_stream_params_name::#params_variant(params)),
-                        )
-                    }))
+                    stream.poll_next(cx).map(|__opt| __opt.map(#item_map))
                 }
             }
         })
@@ -682,7 +824,7 @@ fn generate_reply_stream_enum(
         impl #crate_path::futures_util::Stream for #enum_name {
             type Item = #crate_path::service::ReplyStreamItem<
                 #reply_stream_params_name,
-                #crate_path::service::Infallible,
+                #reply_stream_error_ty,
             >;
 
             fn poll_next(
@@ -854,12 +996,18 @@ fn generate_interface_descriptions(
             })
             .collect();
 
-        // Collect error types for this interface (deduplicate using string representation).
+        // Collect error types for this interface, including those raised by streaming method
+        // items. Deduplicate using string representation.
         let mut seen_error_types = HashSet::new();
         let error_types: Vec<TokenStream> = methods_info
             .iter()
             .filter(|m| m.interface.as_ref() == Some(interface))
-            .filter_map(|m| m.error_type.as_ref())
+            .flat_map(|m| {
+                m.error_type
+                    .as_ref()
+                    .into_iter()
+                    .chain(m.stream_error_type.as_ref())
+            })
             .filter(|err_ty| {
                 let type_str = err_ty.to_token_stream().to_string();
                 seen_error_types.insert(type_str)
@@ -953,6 +1101,7 @@ fn generate_handle_body(
         reply_params_name,
         reply_error_name,
         reply_stream_params_name,
+        reply_stream_error_ty,
         reply_stream_name,
         error_type_map,
         stream_item_type_map,
@@ -1088,73 +1237,29 @@ fn generate_handle_body(
 
             let streaming_reply = if *needs_stream_boxing {
                 // Use boxing when any streaming method uses `impl Trait`.
-                #[cfg(feature = "std")]
-                let boxed_stream = if method.return_fds {
-                    // Method's stream yields (Reply<T>, Vec<OwnedFd>).
-                    quote! {
-                        let __stream = #method_call;
-                        let __mapped = #crate_path::futures_util::StreamExt::map(
-                            __stream,
-                            |(__reply, __fds)| {
-                                let __mapped_reply = __reply.map(|__params| {
-                                    #reply_stream_params_name::#stream_variant_name(__params)
-                                });
-                                (::core::result::Result::Ok(__mapped_reply), __fds)
-                            },
-                        );
-                        let __boxed: ::std::boxed::Box<
-                            dyn #crate_path::futures_util::Stream<
-                                    Item = #crate_path::service::ReplyStreamItem<
-                                        #reply_stream_params_name,
-                                        #crate_path::service::Infallible,
-                                    >
-                                > + ::core::marker::Unpin
-                        > = ::std::boxed::Box::new(__mapped);
-                        #crate_path::service::MethodReply::Multi(__boxed)
-                    }
-                } else {
-                    // Method's stream yields Reply<T>, wrap with empty FDs.
-                    quote! {
-                        let __stream = #method_call;
-                        let __mapped = #crate_path::futures_util::StreamExt::map(__stream, |__reply| {
-                            let __mapped_reply = __reply.map(|__params| {
-                                #reply_stream_params_name::#stream_variant_name(__params)
-                            });
-                            (
-                                ::core::result::Result::Ok(__mapped_reply),
-                                ::std::vec::Vec::new(),
-                            )
-                        });
-                        let __boxed: ::std::boxed::Box<
-                            dyn #crate_path::futures_util::Stream<
-                                    Item = #crate_path::service::ReplyStreamItem<
-                                        #reply_stream_params_name,
-                                        #crate_path::service::Infallible,
-                                    >
-                                > + ::core::marker::Unpin
-                        > = ::std::boxed::Box::new(__mapped);
-                        #crate_path::service::MethodReply::Multi(__boxed)
-                    }
-                };
-                #[cfg(not(feature = "std"))]
-                let boxed_stream = quote! {
+                let map_body = build_stream_map_body(
+                    method.stream_error_type.is_some(),
+                    &stream_variant_name,
+                    reply_stream_params_name,
+                    reply_stream_error_ty,
+                    crate_path,
+                );
+                let item_map = build_stream_item_map_closure(&map_body, method.return_fds);
+
+                quote! {
                     let __stream = #method_call;
-                    let __mapped = #crate_path::futures_util::StreamExt::map(__stream, |__reply| {
-                        ::core::result::Result::Ok(__reply.map(|__params| {
-                            #reply_stream_params_name::#stream_variant_name(__params)
-                        }))
-                    });
+                    let __mapped =
+                        #crate_path::futures_util::StreamExt::map(__stream, #item_map);
                     let __boxed: ::std::boxed::Box<
                         dyn #crate_path::futures_util::Stream<
                                 Item = #crate_path::service::ReplyStreamItem<
                                     #reply_stream_params_name,
-                                    #crate_path::service::Infallible,
+                                    #reply_stream_error_ty,
                                 >
                             > + ::core::marker::Unpin
                     > = ::std::boxed::Box::new(__mapped);
                     #crate_path::service::MethodReply::Multi(__boxed)
-                };
-                boxed_stream
+                }
             } else {
                 // Use enum variant when all streaming methods return concrete types.
                 quote! {

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -168,7 +168,9 @@ pub(super) fn generate_service_impl(
     // Check for streaming methods and determine stream types.
     let has_streaming_methods = methods_info.iter().any(|m| m.is_streaming);
 
-    // Generate the ReplyStream type and enum (if using concrete types).
+    // Generate the ReplyStream type and enum (if using concrete types). Streaming methods
+    // currently always use `service::Infallible` as the error type — the macro doesn't yet detect
+    // `Stream<Item = Result<Reply<T>, E>>` shapes, so every item is mechanically wrapped in `Ok`.
     let (reply_stream_type, reply_stream_params_type, reply_stream_enum) = if has_streaming_methods
     {
         if needs_stream_boxing {
@@ -177,7 +179,10 @@ pub(super) fn generate_service_impl(
                 quote! {
                     ::std::boxed::Box<
                         dyn #crate_path::futures_util::Stream<
-                                Item = #crate_path::service::ReplyStreamItem<#reply_stream_params_name>
+                                Item = #crate_path::service::ReplyStreamItem<
+                                    #reply_stream_params_name,
+                                    #crate_path::service::Infallible,
+                                >
                             > + ::core::marker::Unpin
                     >
                 },
@@ -200,9 +205,14 @@ pub(super) fn generate_service_impl(
             )
         }
     } else {
-        // No streaming methods - use empty stream.
+        // No streaming methods - use empty stream. The error type is `Infallible` (uninhabited)
+        // so the `Err` arm of the stream item is statically unreachable.
         (
-            quote! { #crate_path::futures_util::stream::Empty<#crate_path::service::ReplyStreamItem<()>> },
+            quote! {
+                #crate_path::futures_util::stream::Empty<
+                    #crate_path::service::ReplyStreamItem<(), #crate_path::service::Infallible>
+                >
+            },
             quote! { () },
             quote! {},
         )
@@ -223,6 +233,7 @@ pub(super) fn generate_service_impl(
             type ReplyParams<'ser> = #reply_params_name<'ser> where Self: 'ser;
             type ReplyStream = #reply_stream_type;
             type ReplyStreamParams = #reply_stream_params_type;
+            type ReplyStreamError = #crate_path::service::Infallible;
             type ReplyError<'ser> = #error_type where Self: 'ser;
 
             async fn handle<'__zlink_ser>(
@@ -616,7 +627,7 @@ fn generate_reply_stream_enum(
                             let mapped_reply = reply.map(|params| {
                                 #reply_stream_params_name::#params_variant(params)
                             });
-                            (mapped_reply, fds)
+                            (::core::result::Result::Ok(mapped_reply), fds)
                         }))
                     }
                 }
@@ -628,7 +639,7 @@ fn generate_reply_stream_enum(
                             let mapped_reply = reply.map(|params| {
                                 #reply_stream_params_name::#params_variant(params)
                             });
-                            (mapped_reply, ::std::vec::Vec::new())
+                            (::core::result::Result::Ok(mapped_reply), ::std::vec::Vec::new())
                         }))
                     }
                 }
@@ -650,7 +661,9 @@ fn generate_reply_stream_enum(
             quote! {
                 #projection_name::#variant_name { stream } => {
                     stream.poll_next(cx).map(|opt| opt.map(|reply| {
-                        reply.map(|params| #reply_stream_params_name::#params_variant(params))
+                        ::core::result::Result::Ok(
+                            reply.map(|params| #reply_stream_params_name::#params_variant(params)),
+                        )
                     }))
                 }
             }
@@ -667,7 +680,10 @@ fn generate_reply_stream_enum(
         }
 
         impl #crate_path::futures_util::Stream for #enum_name {
-            type Item = #crate_path::service::ReplyStreamItem<#reply_stream_params_name>;
+            type Item = #crate_path::service::ReplyStreamItem<
+                #reply_stream_params_name,
+                #crate_path::service::Infallible,
+            >;
 
             fn poll_next(
                 self: ::core::pin::Pin<&mut Self>,
@@ -1072,7 +1088,6 @@ fn generate_handle_body(
 
             let streaming_reply = if *needs_stream_boxing {
                 // Use boxing when any streaming method uses `impl Trait`.
-                // On std, stream items are (Reply<T>, Vec<OwnedFd>) tuples.
                 #[cfg(feature = "std")]
                 let boxed_stream = if method.return_fds {
                     // Method's stream yields (Reply<T>, Vec<OwnedFd>).
@@ -1084,13 +1099,14 @@ fn generate_handle_body(
                                 let __mapped_reply = __reply.map(|__params| {
                                     #reply_stream_params_name::#stream_variant_name(__params)
                                 });
-                                (__mapped_reply, __fds)
+                                (::core::result::Result::Ok(__mapped_reply), __fds)
                             },
                         );
                         let __boxed: ::std::boxed::Box<
                             dyn #crate_path::futures_util::Stream<
                                     Item = #crate_path::service::ReplyStreamItem<
-                                        #reply_stream_params_name
+                                        #reply_stream_params_name,
+                                        #crate_path::service::Infallible,
                                     >
                                 > + ::core::marker::Unpin
                         > = ::std::boxed::Box::new(__mapped);
@@ -1104,12 +1120,16 @@ fn generate_handle_body(
                             let __mapped_reply = __reply.map(|__params| {
                                 #reply_stream_params_name::#stream_variant_name(__params)
                             });
-                            (__mapped_reply, ::std::vec::Vec::new())
+                            (
+                                ::core::result::Result::Ok(__mapped_reply),
+                                ::std::vec::Vec::new(),
+                            )
                         });
                         let __boxed: ::std::boxed::Box<
                             dyn #crate_path::futures_util::Stream<
                                     Item = #crate_path::service::ReplyStreamItem<
-                                        #reply_stream_params_name
+                                        #reply_stream_params_name,
+                                        #crate_path::service::Infallible,
                                     >
                                 > + ::core::marker::Unpin
                         > = ::std::boxed::Box::new(__mapped);
@@ -1120,14 +1140,15 @@ fn generate_handle_body(
                 let boxed_stream = quote! {
                     let __stream = #method_call;
                     let __mapped = #crate_path::futures_util::StreamExt::map(__stream, |__reply| {
-                        __reply.map(|__params| {
+                        ::core::result::Result::Ok(__reply.map(|__params| {
                             #reply_stream_params_name::#stream_variant_name(__params)
-                        })
+                        }))
                     });
                     let __boxed: ::std::boxed::Box<
                         dyn #crate_path::futures_util::Stream<
                                 Item = #crate_path::service::ReplyStreamItem<
-                                    #reply_stream_params_name
+                                    #reply_stream_params_name,
+                                    #crate_path::service::Infallible,
                                 >
                             > + ::core::marker::Unpin
                     > = ::std::boxed::Box::new(__mapped);

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -28,8 +28,11 @@ pub(super) struct MethodInfo {
     pub body: TokenStream,
     /// Whether this method returns a stream of replies (has `#[zlink(more)]`).
     pub is_streaming: bool,
-    /// The item type of the stream (the `T` in `Stream<Item = Reply<T>>`).
+    /// The item type of the stream (the `T` in `Stream<Item = Reply<T>>` or
+    /// `Stream<Item = Result<Reply<T>, E>>`).
     pub stream_item_type: Option<Type>,
+    /// The error type for streams that yield `Result<Reply<T>, E>` (the `E`).
+    pub stream_error_type: Option<Type>,
     /// The full return type for streaming methods (for generating enum variants).
     pub stream_return_type: Option<Type>,
     /// Whether the streaming method returns `impl Trait` (requires boxing).
@@ -127,46 +130,50 @@ impl MethodInfo {
             returns_result,
             error_type,
             stream_item_type,
+            stream_error_type,
             stream_return_type,
             stream_uses_impl_trait,
         ) = if is_streaming && return_fds {
-            // For streaming methods with FD passing, the stream yields (Reply<T>, Vec<OwnedFd>).
+            // For streaming methods with FD passing, the stream yields:
+            //   `(Reply<T>, Vec<OwnedFd>)`              — no error path
+            //   `(Result<Reply<T>, E>, Vec<OwnedFd>)`   — with error path
             match &method.sig.output {
                 ReturnType::Default => {
                     return Err(Error::new_spanned(
                         &method.sig,
-                        "streaming methods with return_fds must return \
-                         a Stream<Item = (Reply<T>, Vec<OwnedFd>)>",
+                        "streaming methods with return_fds must return a Stream<Item = \
+                         (Reply<T>, Vec<OwnedFd>)> or Stream<Item = (Result<Reply<T>, E>, \
+                         Vec<OwnedFd>)>",
                     ));
                 }
                 ReturnType::Type(_, ty) => {
                     let stream_item = extract_stream_item_type(ty).ok_or_else(|| {
                         Error::new_spanned(
                             ty,
-                            "streaming methods with return_fds must return \
-                             a Stream<Item = (Reply<T>, Vec<OwnedFd>)> \
-                             (could not extract Stream's Item type)",
+                            "streaming methods with return_fds must return a Stream<Item = \
+                             (Reply<T>, Vec<OwnedFd>)> or Stream<Item = (Result<Reply<T>, E>, \
+                             Vec<OwnedFd>)> (could not extract Stream's Item type)",
                         )
                     })?;
-                    // Extract Reply<T> from (Reply<T>, Vec<OwnedFd>).
-                    let reply_type =
-                        extract_first_tuple_element(&stream_item).ok_or_else(|| {
-                            Error::new_spanned(
-                                ty,
-                                "streaming methods with return_fds must return \
-                             a Stream<Item = (Reply<T>, Vec<OwnedFd>)> \
-                             (stream item must be a tuple)",
-                            )
-                        })?;
-                    // Extract T from Reply<T>.
-                    let inner_type = extract_reply_inner_type(&reply_type).ok_or_else(|| {
+                    // Extract first element from (X, Vec<OwnedFd>).
+                    let first = extract_first_tuple_element(&stream_item).ok_or_else(|| {
                         Error::new_spanned(
                             ty,
-                            "streaming methods with return_fds must return \
-                             a Stream<Item = (Reply<T>, Vec<OwnedFd>)> \
-                             (first tuple element must be Reply<T>)",
+                            "streaming methods with return_fds must return a Stream<Item = \
+                             (Reply<T>, Vec<OwnedFd>)> or Stream<Item = (Result<Reply<T>, E>, \
+                             Vec<OwnedFd>)> (stream item must be a tuple)",
                         )
                     })?;
+                    let (inner_type, err_type) =
+                        extract_reply_or_result_reply(&first).ok_or_else(|| {
+                            Error::new_spanned(
+                                ty,
+                                "streaming methods with return_fds must return a Stream<Item = \
+                                 (Reply<T>, Vec<OwnedFd>)> or Stream<Item = (Result<Reply<T>, \
+                                 E>, Vec<OwnedFd>)> (first tuple element must be Reply<T> or \
+                                 Result<Reply<T>, E>)",
+                            )
+                        })?;
                     // Check if return type uses `impl Trait`.
                     let uses_impl_trait = matches!(**ty, Type::ImplTrait(_));
                     (
@@ -174,39 +181,43 @@ impl MethodInfo {
                         false,
                         None,
                         Some(inner_type),
+                        err_type,
                         Some((**ty).clone()),
                         uses_impl_trait,
                     )
                 }
             }
         } else if is_streaming {
-            // For streaming methods, extract the Stream's Item type.
-            // Streaming methods can return either:
-            // - `impl Stream<Item = Reply<T>>` (will use boxing)
-            // - A concrete type implementing Stream (can avoid boxing)
+            // For streaming methods, extract the Stream's Item type. Streaming methods can yield:
+            // - `Reply<T>`                — no error path
+            // - `Result<Reply<T>, E>`     — with error path
+            // The macro accepts both `impl Stream<Item = ...>` and concrete stream types.
             match &method.sig.output {
                 ReturnType::Default => {
                     return Err(Error::new_spanned(
                         &method.sig,
-                        "streaming methods must return a Stream<Item = Reply<T>>",
+                        "streaming methods must return a Stream<Item = Reply<T>> or \
+                         Stream<Item = Result<Reply<T>, E>>",
                     ));
                 }
                 ReturnType::Type(_, ty) => {
                     let stream_item = extract_stream_item_type(ty).ok_or_else(|| {
                         Error::new_spanned(
                             ty,
-                            "streaming methods must return a Stream<Item = Reply<T>> \
-                             (could not extract Stream's Item type)",
+                            "streaming methods must return a Stream<Item = Reply<T>> or \
+                             Stream<Item = Result<Reply<T>, E>> (could not extract Stream's Item \
+                             type)",
                         )
                     })?;
-                    // Extract T from Reply<T>.
-                    let inner_type = extract_reply_inner_type(&stream_item).ok_or_else(|| {
-                        Error::new_spanned(
-                            ty,
-                            "streaming methods must return a Stream<Item = Reply<T>> \
-                             (stream item must be Reply<T>)",
-                        )
-                    })?;
+                    let (inner_type, err_type) = extract_reply_or_result_reply(&stream_item)
+                        .ok_or_else(|| {
+                            Error::new_spanned(
+                                ty,
+                                "streaming methods must return a Stream<Item = Reply<T>> or \
+                                 Stream<Item = Result<Reply<T>, E>> (stream item must be \
+                                 Reply<T> or Result<Reply<T>, E>)",
+                            )
+                        })?;
                     // Check if return type uses `impl Trait`.
                     let uses_impl_trait = matches!(**ty, Type::ImplTrait(_));
                     (
@@ -214,6 +225,7 @@ impl MethodInfo {
                         false,
                         None,
                         Some(inner_type),
+                        err_type,
                         Some((**ty).clone()),
                         uses_impl_trait,
                     )
@@ -243,7 +255,7 @@ impl MethodInfo {
 
                     if let Some((inner_ty, err_ty)) = extract_result_types(&first) {
                         // (Result<T, E>, Vec<OwnedFd>).
-                        (inner_ty, true, Some(err_ty), None, None, false)
+                        (inner_ty, true, Some(err_ty), None, None, None, false)
                     } else {
                         // (T, Vec<OwnedFd>).
                         let data_ty = if is_unit_type(&first) {
@@ -251,19 +263,19 @@ impl MethodInfo {
                         } else {
                             Some(first)
                         };
-                        (data_ty, false, None, None, None, false)
+                        (data_ty, false, None, None, None, None, false)
                     }
                 }
             }
         } else {
             // For non-streaming methods, extract Result types as before.
             match &method.sig.output {
-                ReturnType::Default => (None, false, None, None, None, false),
+                ReturnType::Default => (None, false, None, None, None, None, false),
                 ReturnType::Type(_, ty) => {
                     if let Some((inner_ty, err_ty)) = extract_result_types(ty) {
-                        (inner_ty, true, Some(err_ty), None, None, false)
+                        (inner_ty, true, Some(err_ty), None, None, None, false)
                     } else {
-                        (Some((**ty).clone()), false, None, None, None, false)
+                        (Some((**ty).clone()), false, None, None, None, None, false)
                     }
                 }
             }
@@ -284,6 +296,7 @@ impl MethodInfo {
             body,
             is_streaming,
             stream_item_type,
+            stream_error_type,
             stream_return_type,
             stream_uses_impl_trait,
             return_fds,
@@ -592,6 +605,20 @@ fn extract_stream_item_from_trait_bound(trait_bound: &syn::TraitBound) -> Option
     }
 
     None
+}
+
+/// Extract the success and (optional) error types from `Reply<T>` or `Result<Reply<T>, E>`.
+///
+/// Returns `Some((T, None))` for `Reply<T>`, `Some((T, Some(E)))` for `Result<Reply<T>, E>`,
+/// and `None` if the type matches neither shape.
+fn extract_reply_or_result_reply(ty: &Type) -> Option<(Type, Option<Type>)> {
+    if let Some(inner) = extract_reply_inner_type(ty) {
+        return Some((inner, None));
+    }
+    let (ok_ty, err_ty) = extract_result_types(ty)?;
+    let ok_ty = ok_ty?;
+    let inner = extract_reply_inner_type(&ok_ty)?;
+    Some((inner, Some(err_ty)))
 }
 
 /// Extract the inner type `T` from `Reply<T>`.

--- a/zlink-macros/tests/service.rs
+++ b/zlink-macros/tests/service.rs
@@ -21,5 +21,7 @@ mod metadata;
 mod multiple_interfaces;
 #[path = "service/streaming.rs"]
 mod streaming;
+#[path = "service/streaming_errors.rs"]
+mod streaming_errors;
 #[path = "service/streaming_fds.rs"]
 mod streaming_fds;

--- a/zlink-macros/tests/service/streaming_errors.rs
+++ b/zlink-macros/tests/service/streaming_errors.rs
@@ -1,0 +1,112 @@
+//! Tests for streaming service methods that emit method errors.
+//!
+//! Streaming methods can opt in to error replies by yielding `Result<Reply<T>, E>` instead of
+//! plain `Reply<T>`. The server dispatches each item as either a success reply or an error
+//! reply on the wire.
+
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use zlink::{
+    Reply, Server, introspect,
+    unix::{bind, connect},
+};
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn streaming_errors() -> Result<(), Box<dyn std::error::Error>> {
+    let socket_path = "/tmp/zlink-service-macro-streaming-errors-test.sock";
+    if let Err(e) = tokio::fs::remove_file(socket_path).await {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            return Err(e.into());
+        }
+    }
+
+    let listener = bind(socket_path).unwrap();
+    let server = Server::new(listener, CountingService);
+    tokio::select! {
+        res = server.run() => res?,
+        res = run_client(socket_path) => res?,
+    }
+
+    Ok(())
+}
+
+async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = connect(socket_path).await?;
+
+    // First call: `to = 3`, expect three success ticks then end-of-stream.
+    {
+        let mut stream = std::pin::pin!(conn.count(3).await?);
+
+        let mut values = Vec::new();
+        while let Some(result) = stream.next().await {
+            let tick = result?.expect("no error expected");
+            values.push(tick.value);
+        }
+        assert_eq!(values, vec![1, 2, 3]);
+    }
+
+    // Second call: `to = 0`, the server should yield a single error stream item.
+    {
+        let mut stream = std::pin::pin!(conn.count(0).await?);
+
+        let mut got_error = false;
+        let mut other_items = 0;
+        while let Some(result) = stream.next().await {
+            match result? {
+                Ok(_) => other_items += 1,
+                Err(CountError::AtZero) => got_error = true,
+                Err(other) => panic!("unexpected error: {other:?}"),
+            }
+        }
+        assert!(got_error, "expected AtZero error from stream");
+        assert_eq!(other_items, 0);
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, introspect::Type)]
+struct Tick {
+    value: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.counter")]
+enum CountError {
+    AtZero,
+    BadInput { reason: String },
+}
+
+struct CountingService;
+
+#[zlink::service(interface = "org.example.counter")]
+impl CountingService {
+    /// Stream values 1..=`to`, or fail with [`CountError::AtZero`] if `to == 0`.
+    #[zlink(more)]
+    async fn count(
+        &self,
+        more: bool,
+        to: u32,
+    ) -> impl futures_util::Stream<Item = Result<Reply<Tick>, CountError>> + Unpin {
+        if to == 0 {
+            return futures_util::stream::iter(vec![Err(CountError::AtZero)]);
+        }
+        let to = if more { to } else { 1 };
+        let last = to;
+        let items: Vec<Result<Reply<Tick>, CountError>> = (1..=to)
+            .map(
+                move |value| Ok(Reply::new(Some(Tick { value })).set_continues(Some(value < last))),
+            )
+            .collect();
+        futures_util::stream::iter(items)
+    }
+}
+
+#[zlink::proxy("org.example.counter")]
+trait CountingProxy {
+    #[zlink(more)]
+    async fn count(
+        &mut self,
+        to: u32,
+    ) -> zlink::Result<impl futures_util::Stream<Item = zlink::Result<Result<Tick, CountError>>>>;
+}

--- a/zlink-smol/Cargo.toml
+++ b/zlink-smol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-smol"
-version = "0.4.2"
+version = "0.5.0"
 description = "zlink library for the smol runtime"
 edition.workspace = true
 rust-version.workspace = true
@@ -20,7 +20,7 @@ tracing = ["zlink-core/tracing"]
 defmt = ["zlink-core/defmt"]
 
 [dependencies]
-zlink-core = { path = "../zlink-core", version = "=0.4.2", default-features = false, features = ["std"] }
+zlink-core = { path = "../zlink-core", version = "=0.5.0", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
     "async-await",
     "alloc",

--- a/zlink-tokio/Cargo.toml
+++ b/zlink-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-tokio"
-version = "0.4.2"
+version = "0.5.0"
 description = "zlink library for the Tokio runtime"
 edition.workspace = true
 rust-version.workspace = true
@@ -20,7 +20,7 @@ tracing = ["zlink-core/tracing", "tokio/tracing"]
 defmt = ["zlink-core/defmt"]
 
 [dependencies]
-zlink-core = { path = "../zlink-core", version = "=0.4.2", default-features = false, features = ["std"] }
+zlink-core = { path = "../zlink-core", version = "=0.5.0", default-features = false, features = ["std"] }
 tokio = { version = "1.44.0", features = ["net", "io-util"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
     "async-await",

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink"
-version = "0.4.2"
+version = "0.5.0"
 description = "Async Varlink API"
 edition.workspace = true
 rust-version.workspace = true
@@ -22,8 +22,8 @@ tracing = ["zlink-tokio?/tracing", "zlink-smol?/tracing"]
 defmt = ["zlink-tokio?/defmt", "zlink-smol?/defmt"]
 
 [dependencies]
-zlink-tokio = { path = "../zlink-tokio", version = "=0.4.2", default-features = false, optional = true }
-zlink-smol = { path = "../zlink-smol", version = "=0.4.2", default-features = false, optional = true }
+zlink-tokio = { path = "../zlink-tokio", version = "=0.5.0", default-features = false, optional = true }
+zlink-smol = { path = "../zlink-smol", version = "=0.5.0", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.44.0", features = [


### PR DESCRIPTION
## Summary

Streaming `#[zlink(more)]` methods previously had to yield `Reply<T>`, so an interface had no way to surface a Varlink error reply mid-stream. This PR recognises `Stream<Item = Result<Reply<T>, E>>` (and `(Result<Reply<T>, E>, Vec<OwnedFd>)` for `return_fds`) as an opt-in shape and dispatches each item as either `send_reply` or `send_error` on the wire.

### `Service` trait shape

- New `ReplyStreamError: Serialize + Debug` associated type (no default — Rust forbids defaults on stable).
- `ReplyStreamItem<P, E>` now wraps the success reply in a `Result`, so each stream item is either a success `Reply` or an error.
- New `service::Infallible`: a `Serialize`-carrying wrapper around `core::convert::Infallible` (workaround for [serde-rs/serde#2740](https://github.com/serde-rs/serde/issues/2740)). The wrapper is uninhabited, so its `Serialize` impl is `unreachable!`. Recommended for `ReplyError` and `ReplyStreamError` when the corresponding methods cannot fail.

### Macro

- New parser path for `Stream<Item = Result<Reply<T>, E>>` (and the `return_fds` variant).
- Generates a combined `__YourTypeReplyStreamError` enum with `From` impls per user error type when at least one streaming method declares an error; otherwise sets `type ReplyStreamError = service::Infallible`.
- Streaming method error types are folded into IDL generation so introspection picks them up.

### Server

- The streaming reply loop dispatches stream items by `Result` variant: `Ok` → `send_reply`, `Err` → `send_error`.

### Versioning

All workspace crates bumped from `0.4.2` → `0.5.0` to reflect the breaking changes in the `Service` trait shape.

### Tests / docs

- New round-trip test `zlink-macros/tests/service/streaming_errors.rs` covering both success and error stream items.
- `service` macro docs updated with a "Returning Method Errors From Streams" section + a "Streaming With Errors" doctest. The previous "temporary limitation" wording (#261) is replaced.

## Test plan

- [x] `cargo test --all-features` — all 38 test groups pass.
- [x] `cargo clippy --all-features -- -D warnings` — clean.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] `cargo check -p zlink-core --no-default-features --features idl-parse,proxy,defmt` — clean.

https://claude.ai/code/session_01TEm3Q5L14CrAsQEgHx5ARq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEm3Q5L14CrAsQEgHx5ARq)_