### PR TITLE
introspection: Add return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,12 @@ trait CalculatorProxy {
 }
 
 // Types shared between client and server.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, introspect::Type)]
 struct CalculationResult {
     result: f64,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, introspect::Type)]
 struct Statistics<'a> {
     count: u64,
     #[serde(borrow)]

--- a/zlink-core/src/idl/custom_object.rs
+++ b/zlink-core/src/idl/custom_object.rs
@@ -54,6 +54,11 @@ impl<'a> CustomObject<'a> {
         self.fields.iter()
     }
 
+    /// The fields as a slice.
+    pub const fn fields_as_slice(&self) -> Option<&[&Field<'a>]> {
+        self.fields.as_borrowed()
+    }
+
     /// Returns an iterator over the comments associated with this object type.
     pub fn comments(&self) -> impl Iterator<Item = &super::Comment<'a>> {
         self.comments.iter()

--- a/zlink-core/src/idl/custom_type.rs
+++ b/zlink-core/src/idl/custom_type.rs
@@ -36,7 +36,7 @@ impl<'a> CustomType<'a> {
     }
 
     /// Returns the object if this is an object custom type.
-    pub fn as_object(&self) -> Option<&CustomObject<'a>> {
+    pub const fn as_object(&self) -> Option<&CustomObject<'a>> {
         match self {
             CustomType::Object(obj) => Some(obj),
             CustomType::Enum(_) => None,

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -27,6 +27,7 @@ syn = { version = "2.0", default-features = false, features = [
     "parsing",
     "printing",
     "proc-macro",
+    "extra-traits"
 ] }
 
 [dev-dependencies]

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -109,7 +109,7 @@ pub(super) fn generate_service_impl(
         &interfaces,
         crate_path,
         &type_name,
-    );
+    )?;
 
     // Generate the ReplyStreamParams enum for streaming methods.
     let (reply_stream_params_enum, stream_item_type_map) =
@@ -907,7 +907,7 @@ fn generate_interface_descriptions(
     interfaces: &[String],
     crate_path: &TokenStream,
     type_name: &str,
-) -> TokenStream {
+) -> Result<TokenStream, Error> {
     let mut descriptions: Vec<TokenStream> = Vec::new();
 
     for interface in interfaces {
@@ -963,19 +963,52 @@ fn generate_interface_descriptions(
                     }
                 };
 
-                quote! {
+                let out_params_const = if method.is_streaming {
+                    method.stream_item_type.clone()
+                } else {
+                    method.return_type.clone()
+                }
+                .map(|ty| {
+                    if service_attrs.custom_types.contains(&ty) {
+                        quote! {
+                            const __OUT_PARAMS: &[&#crate_path::idl::Parameter<'static>] =
+                                <#ty as #crate_path::introspect::CustomType>::CUSTOM_TYPE
+                                    .as_object()
+                                    .expect("Return type has to be an object")
+                                    .fields_as_slice()
+                                    .unwrap();
+                        }
+                    } else {
+                        quote! {
+                            const __OUT_PARAMS: &[&#crate_path::idl::Parameter<'static>] =
+                                <#ty as #crate_path::introspect::Type>::TYPE
+                                    .as_object()
+                                    .expect("Return type has to be an object")
+                                    .as_borrowed()
+                                    .unwrap();
+                        }
+                    }
+                })
+                .unwrap_or_else(|| {
+                    quote! {
+                        const __OUT_PARAMS: &[&#crate_path::idl::Parameter<'static>] = &[];
+                    }
+                });
+
+                Ok(quote! {
                     const #method_const_name: &#crate_path::idl::Method<'static> = &{
                         #in_params_const
+                        #out_params_const
                         #crate_path::idl::Method::new(
                             #method_name,
                             __IN_PARAMS,
-                            &[],
+                            __OUT_PARAMS,
                             &[],
                         )
                     };
-                }
+                })
             })
-            .collect();
+            .collect::<Result<_, Error>>()?;
 
         // Generate the list of method references.
         let method_refs: Vec<TokenStream> = (0..interface_methods.len())
@@ -1045,7 +1078,7 @@ fn generate_interface_descriptions(
         });
     }
 
-    quote! { #(#descriptions)* }
+    Ok(quote! { #(#descriptions)* })
 }
 
 /// Wrap a `MethodReply` expression into a `HandleResult` with no file descriptors.

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -538,7 +538,7 @@ fn extract_result_types(ty: &Type) -> Option<(Option<Type>, Type)> {
 ///
 /// For `impl Stream<Item = Reply<T>>`, returns `Reply<T>`.
 /// For concrete types like `SomeStream<T>`, returns `Reply<T>` (assuming the generic param is T).
-fn extract_stream_item_type(ty: &Type) -> Option<Type> {
+pub(super) fn extract_stream_item_type(ty: &Type) -> Option<Type> {
     match ty {
         // Handle `impl Stream<Item = T> + ...` (impl trait syntax).
         Type::ImplTrait(impl_trait) => {
@@ -611,7 +611,7 @@ fn extract_stream_item_from_trait_bound(trait_bound: &syn::TraitBound) -> Option
 ///
 /// Returns `Some((T, None))` for `Reply<T>`, `Some((T, Some(E)))` for `Result<Reply<T>, E>`,
 /// and `None` if the type matches neither shape.
-fn extract_reply_or_result_reply(ty: &Type) -> Option<(Type, Option<Type>)> {
+pub(super) fn extract_reply_or_result_reply(ty: &Type) -> Option<(Type, Option<Type>)> {
     if let Some(inner) = extract_reply_inner_type(ty) {
         return Some((inner, None));
     }
@@ -664,7 +664,7 @@ fn is_unit_type(ty: &Type) -> bool {
 
 /// Extract the first element type from a tuple type `(T, ...)`.
 /// Returns `None` if the type is not a tuple with at least one element.
-fn extract_first_tuple_element(ty: &Type) -> Option<Type> {
+pub(super) fn extract_first_tuple_element(ty: &Type) -> Option<Type> {
     let Type::Tuple(tuple) = ty else {
         return None;
     };

--- a/zlink-macros/tests/service/custom_bounds.rs
+++ b/zlink-macros/tests/service/custom_bounds.rs
@@ -53,7 +53,7 @@ struct CredentialCheckingService {
 // Service implementation with custom socket bounds using user-provided generics.
 // The first type parameter (Sock) is used as the socket type. The Socket bound is added
 // automatically, so we only specify additional bounds.
-#[zlink::service]
+#[zlink::service(types = [Balance])]
 impl<Sock> CredentialCheckingService
 where
     Sock::ReadHalf: FetchPeerCredentials,

--- a/zlink-macros/tests/service/fd_passing.rs
+++ b/zlink-macros/tests/service/fd_passing.rs
@@ -46,7 +46,7 @@ async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>>
     let fds = vec![r0.into(), r1.into(), r2.into()];
     // Read from index 1.
     let data = conn.read_fd(1, fds).await?.unwrap();
-    assert_eq!(data, "data-one");
+    assert_eq!(data.contents, "data-one");
 
     // Invalid index returns an error.
     let (r, mut w) = UnixStream::pair()?;
@@ -58,7 +58,7 @@ async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>>
     // Receive FDs from the service. Each handle has a name and fd_index referencing the FD vector.
     let names = vec!["config.txt".into(), "data.bin".into(), "log.txt".into()];
     let (result, fds) = conn.open_fds(names).await?;
-    let handles = result.unwrap();
+    let handles = result.unwrap().handles;
     assert_eq!(handles.len(), 3);
     assert_eq!(fds.len(), 3);
     // Verify each handle's name and that the FD at fd_index contains the name as content.
@@ -73,7 +73,7 @@ async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>>
 
     // Receive zero FDs from the service.
     let (result, fds) = conn.open_fds(Vec::new()).await?;
-    let handles = result.unwrap();
+    let handles = result.unwrap().handles;
     assert!(handles.is_empty());
     assert!(fds.is_empty());
 
@@ -102,10 +102,22 @@ async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>>
 }
 
 // Response type for FD operations. The `fd_index` field references a position in the FD vector.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, introspect::Type)]
 pub(crate) struct FdHandle {
     pub name: String,
     pub fd_index: u32,
+}
+
+// Response type for FD operations returning multiple handles.
+#[derive(Debug, Clone, Serialize, Deserialize, introspect::Type)]
+pub(crate) struct Handles {
+    pub handles: Vec<FdHandle>,
+}
+
+// Response type for read operations
+#[derive(Debug, Clone, Serialize, Deserialize, introspect::Type)]
+pub(crate) struct Contents {
+    pub contents: String,
 }
 
 // Error type for FD operations.
@@ -126,7 +138,7 @@ impl FdService {
         &self,
         fd_index: u32,
         #[zlink(fds)] fds: Vec<std::os::fd::OwnedFd>,
-    ) -> Result<String, FdError> {
+    ) -> Result<Contents, FdError> {
         use std::{io::Read, os::unix::net::UnixStream};
 
         let Some(fd) = fds.into_iter().nth(fd_index as usize) else {
@@ -135,12 +147,12 @@ impl FdService {
         let mut stream = UnixStream::from(fd);
         let mut buf = String::new();
         stream.read_to_string(&mut buf).unwrap();
-        Ok(buf)
+        Ok(Contents { contents: buf })
     }
 
     /// Open a list of named FDs and return handles with their indexes.
     #[zlink(return_fds)]
-    async fn open_fds(&self, names: Vec<String>) -> (Vec<FdHandle>, Vec<std::os::fd::OwnedFd>) {
+    async fn open_fds(&self, names: Vec<String>) -> (Handles, Vec<std::os::fd::OwnedFd>) {
         use std::{io::Write, os::unix::net::UnixStream};
 
         let mut handles = Vec::new();
@@ -156,7 +168,7 @@ impl FdService {
             });
             fds.push(r.into());
         }
-        (handles, fds)
+        (Handles { handles }, fds)
     }
 
     /// Try to open an FD. On success, return the handle with its index. On error, return the
@@ -195,13 +207,13 @@ trait FdProxy {
         &mut self,
         fd_index: u32,
         #[zlink(fds)] fds: Vec<std::os::fd::OwnedFd>,
-    ) -> zlink::Result<Result<String, FdError>>;
+    ) -> zlink::Result<Result<Contents, FdError>>;
 
     #[zlink(return_fds)]
     async fn open_fds(
         &mut self,
         names: Vec<String>,
-    ) -> zlink::Result<(Result<Vec<FdHandle>, FdError>, Vec<std::os::fd::OwnedFd>)>;
+    ) -> zlink::Result<(Result<Handles, FdError>, Vec<std::os::fd::OwnedFd>)>;
 
     #[zlink(return_fds)]
     async fn try_open_fd(

--- a/zlink-macros/tests/service/introspection.rs
+++ b/zlink-macros/tests/service/introspection.rs
@@ -3,6 +3,7 @@
 use super::basic::{BankAccount, BankError};
 use zlink::{
     Server,
+    idl::Type,
     unix::{bind, connect},
 };
 
@@ -57,12 +58,40 @@ async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>>
     );
 
     // Verify the interface contains exactly the expected methods.
-    let method_names: Vec<_> = interface.methods().map(|m| m.name()).collect();
+    let methods: Vec<_> = interface.methods().collect();
+    let method_names: Vec<_> = methods.iter().map(|m| m.name()).collect();
     assert_eq!(
         method_names.as_slice(),
         ["GetBalance", "Deposit", "Withdraw", "LockAccount"],
         "Unexpected methods"
     );
+    for method in methods {
+        match method.name() {
+            "GetBalance" => {
+                assert!(method.has_no_inputs());
+                let output_names = method.outputs().map(|f| f.name()).collect::<Vec<_>>();
+                let output_types = method.outputs().map(|f| f.ty()).collect::<Vec<_>>();
+                assert_eq!(output_names.as_slice(), &["amount"]);
+                assert_eq!(output_types.as_slice(), &[&Type::Int]);
+            }
+            "Deposit" | "Withdraw" => {
+                let input_names = method.inputs().map(|f| f.name()).collect::<Vec<_>>();
+                let input_types = method.inputs().map(|f| f.ty()).collect::<Vec<_>>();
+                assert_eq!(input_names.as_slice(), &["amount"]);
+                assert_eq!(input_types.as_slice(), &[&Type::Int]);
+
+                let output_names = method.outputs().map(|f| f.name()).collect::<Vec<_>>();
+                let output_types = method.outputs().map(|f| f.ty()).collect::<Vec<_>>();
+                assert_eq!(output_names.as_slice(), &["amount"]);
+                assert_eq!(output_types.as_slice(), &[&Type::Int]);
+            }
+            "LockAccount" => {
+                assert!(method.has_no_inputs());
+                assert!(method.has_no_outputs());
+            }
+            x => panic!("Unknown method: {}", x),
+        }
+    }
 
     // Verify the interface contains exactly the expected errors.
     let error_names: Vec<_> = interface.errors().map(|e| e.name()).collect();

--- a/zlink-macros/tests/service/streaming_fds.rs
+++ b/zlink-macros/tests/service/streaming_fds.rs
@@ -4,6 +4,7 @@ use super::fd_passing::{FdError, FdHandle};
 use serde::{Deserialize, Serialize};
 use zlink::{
     Server,
+    introspect::Type,
     unix::{bind, connect},
 };
 
@@ -111,7 +112,7 @@ async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>>
 }
 
 /// Response for streaming FD read operations.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Type)]
 struct FdReadResult {
     fd_index: u32,
     content: String,


### PR DESCRIPTION
(Draft as I am unsure about some details and the commits definitely need some cleanup.)

This is an attempt add adding introspection support for the return types of methods,
which is especially useful for e.g. the official varlink python bindings, which use the introspection information for parsing. Thus currently a service written with zlink will always return an empty dictionary... (I do think this is a separate bug of the python bindings, which should be addressed, but I figured adding proper return types to zlink would be nice nevertheless.)

As I understand the varlink [interface definition](https://varlink.org/Interface-Definition) return types need to be an object.

I also added support for CustomTypes to not break e.g. the `org.example.Bank`-example, which uses a custom `Balance`-return type. However I am not sure if using the name directly would be valid, as the varlink grammar only allows `struct` for the return type, not `name`.

As such this currently serializes the fields of `CustomType`s. If we keep this approach I need a way to expose the list directly for the const-generation. Any preferences on how that should be done?