### PR TITLE
✨ codegen: Add `generate_files()` library API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,7 +1411,6 @@ dependencies = [
 name = "test-integration"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "serde",
  "serde_json",
  "tokio",
@@ -1997,7 +1996,6 @@ dependencies = [
 name = "zlink-codegen"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "clap",
  "heck",
  "pretty_assertions",

--- a/zlink-codegen/Cargo.toml
+++ b/zlink-codegen/Cargo.toml
@@ -20,7 +20,6 @@ zlink = { path = "../zlink", version = "0.1.0", features = [
 ] }
 clap = { version = "4.5", features = ["derive"] }
 heck = "0.5"
-anyhow = "1.0"
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/zlink-codegen/src/cli.rs
+++ b/zlink-codegen/src/cli.rs
@@ -19,6 +19,10 @@ pub struct Args {
     /// Generate separate files for each interface (ignored if --output is specified).
     #[arg(short = 'm', long)]
     pub multiple_files: bool,
+
+    /// Format the generated Rust code using rustfmt.
+    #[arg(short = 'f', long)]
+    pub rustfmt: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -36,5 +40,9 @@ pub enum Command {
         /// Generate separate files for each interface.
         #[arg(short = 'm', long)]
         multiple_files: bool,
+
+        /// Format the generated Rust code using rustfmt.
+        #[arg(short = 'f', long)]
+        rustfmt: bool,
     },
 }

--- a/zlink-codegen/src/codegen.rs
+++ b/zlink-codegen/src/codegen.rs
@@ -1,8 +1,9 @@
 //! Code generation implementation.
 
-use anyhow::Result;
 use heck::{ToPascalCase, ToSnakeCase};
 use std::fmt::Write;
+
+type Result<T = ()> = std::result::Result<T, std::fmt::Error>;
 use zlink::idl::{CustomEnum, CustomObject, CustomType, Field, Interface, Method, Type};
 
 /// Code generator for Varlink interfaces.

--- a/zlink-codegen/src/error.rs
+++ b/zlink-codegen/src/error.rs
@@ -1,0 +1,66 @@
+/// Error types that can occur during Varlink interface code generation.
+#[derive(Debug)]
+pub enum Error {
+    /// An invalid argument was provided.
+    InvalidArgument,
+
+    /// An I/O error occurred during file operations.
+    Io(std::io::Error),
+
+    /// An error from the zlink-core library.
+    Zlink(zlink::Error),
+
+    /// Writing to the internal output buffer failed during code generation.
+    Fmt(std::fmt::Error),
+
+    /// `rustfmt` produced output that was not valid UTF-8.
+    InvalidUtf8(std::string::FromUtf8Error),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidArgument => write!(f, "Invalid argument provided"),
+            Self::Io(e) => write!(f, "I/O error: {e}"),
+            Self::Zlink(e) => write!(f, "Zlink error: {e}"),
+            Self::Fmt(e) => write!(f, "Formatting error: {e}"),
+            Self::InvalidUtf8(e) => write!(f, "Invalid UTF-8 from rustfmt: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Zlink(e) => Some(e),
+            Self::Fmt(e) => Some(e),
+            Self::InvalidUtf8(e) => Some(e),
+            Self::InvalidArgument => None,
+        }
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(e: std::io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl From<zlink::Error> for Error {
+    fn from(e: zlink::Error) -> Self {
+        Self::Zlink(e)
+    }
+}
+
+impl From<std::fmt::Error> for Error {
+    fn from(e: std::fmt::Error) -> Self {
+        Self::Fmt(e)
+    }
+}
+
+impl From<std::string::FromUtf8Error> for Error {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        Self::InvalidUtf8(e)
+    }
+}

--- a/zlink-codegen/src/lib.rs
+++ b/zlink-codegen/src/lib.rs
@@ -3,21 +3,31 @@
 )]
 //! Code generation for Varlink interfaces.
 
-use anyhow::{Context, Result};
+use std::{fs, path::PathBuf};
 use zlink::idl::Interface;
 
 mod codegen;
 pub use codegen::CodeGenerator;
+mod error;
+pub use self::error::Error;
 
 /// Generate Rust code from a Varlink interface.
-pub fn generate_interface(interface: &Interface<'_>) -> Result<String> {
+///
+/// # Errors
+///
+/// - [`Error::Fmt`] - Writing to the internal output buffer failed.
+pub fn generate_interface(interface: &Interface<'_>) -> Result<String, Error> {
     let mut generator = CodeGenerator::new();
     generator.generate_interface(interface, false)?;
     Ok(generator.output())
 }
 
 /// Generate Rust code from multiple Varlink interfaces.
-pub fn generate_interfaces(interfaces: &[Interface<'_>]) -> Result<String> {
+///
+/// # Errors
+///
+/// - [`Error::Fmt`] - Writing to the internal output buffer failed.
+pub fn generate_interfaces(interfaces: &[Interface<'_>]) -> Result<String, Error> {
     let mut generator = CodeGenerator::new();
 
     // Add module-level header for multiple interfaces.
@@ -25,7 +35,7 @@ pub fn generate_interfaces(interfaces: &[Interface<'_>]) -> Result<String> {
         generator.write_module_header()?;
     }
 
-    for interface in interfaces.iter() {
+    for interface in interfaces {
         // Skip module header for all interfaces when generating multiple.
         let skip_header = interfaces.len() > 1;
         generator.generate_interface(interface, skip_header)?;
@@ -34,7 +44,12 @@ pub fn generate_interfaces(interfaces: &[Interface<'_>]) -> Result<String> {
 }
 
 /// Format generated Rust code using rustfmt.
-pub fn format_code(code: &str) -> Result<String> {
+///
+/// # Errors
+///
+/// - [`Error::Io`] - Spawning or communicating with the `rustfmt` process failed.
+/// - [`Error::InvalidUtf8`] - `rustfmt` produced output that was not valid UTF-8.
+pub fn format_code(code: &str) -> Result<String, Error> {
     use std::{
         io::Write,
         process::{Command, Stdio},
@@ -45,27 +60,191 @@ pub fn format_code(code: &str) -> Result<String> {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()
-        .context("Failed to spawn rustfmt")?;
+        .spawn()?;
 
     if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(code.as_bytes())
-            .context("Failed to write to rustfmt stdin")?;
+        stdin.write_all(code.as_bytes())?;
     }
 
-    let output = child
-        .wait_with_output()
-        .context("Failed to wait for rustfmt")?;
+    let output = child.wait_with_output()?;
 
     if !output.status.success() {
         // If rustfmt fails, return the original code.
         eprintln!(
             "Warning: rustfmt failed: {}",
-            String::from_utf8_lossy(&output.stderr)
+            String::from_utf8_lossy(&output.stderr),
         );
         return Ok(code.to_string());
     }
 
-    String::from_utf8(output.stdout).context("Failed to parse rustfmt output")
+    String::from_utf8(output.stdout).map_err(Error::from)
+}
+
+/// Configuration options for Varlink code generation.
+///
+/// See [`generate_files`] for an end-to-end usage example.
+#[derive(Default)]
+pub struct CodegenOptions {
+    /// Input Varlink IDL file(s).
+    pub files: Vec<PathBuf>,
+    /// Output file path (defaults to stdout if not specified).
+    pub output: Option<PathBuf>,
+    /// Generate separate files for each interface (ignored if output is specified).
+    pub multiple_files: bool,
+    /// Whether to format the generated Rust code using `rustfmt`.
+    ///
+    /// Default value: false
+    pub rustfmt: bool,
+}
+
+/// Generate Rust source files from Varlink interface files.
+///
+/// This function reads Varlink interface definition files from `config.files`, parses them,
+/// generates corresponding Rust code, and handles output based on the configuration.
+///
+/// # Behavior
+///
+/// - If `config.output` is specified: Generates a single file with all interfaces combined.
+/// - If `config.multiple_files` is true: Generates separate `.rs` files for each interface in the
+///   current working directory. The output filename is derived from the interface name (dots
+///   replaced with underscores and converted to lowercase).
+/// - Otherwise: Writes the generated code to stdout.
+///
+/// # Arguments
+///
+/// * `config` - Code generation options containing input files, output configuration, and
+///   formatting options.
+///
+/// # Returns
+///
+/// Returns `Ok(())` on successful code generation and output.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - [`Error::InvalidArgument`] - No input files were specified.
+/// - [`Error::Io`] - File I/O failed (reading input, writing output or invoking `rustfmt`).
+/// - [`Error::Zlink`] - A Varlink interface definition is malformed or invalid.
+/// - [`Error::Fmt`] - Writing to the internal output buffer failed.
+/// - [`Error::InvalidUtf8`] - `rustfmt` produced output that was not valid UTF-8.
+///
+/// # Examples
+///
+/// ```no_run
+/// use std::path::PathBuf;
+/// use zlink_codegen::CodegenOptions;
+///
+/// let config = CodegenOptions {
+///     files: vec![PathBuf::from("interface.varlink")],
+///     output: Some(PathBuf::from("generated.rs")),
+///     rustfmt: true,
+///     ..Default::default()
+/// };
+/// zlink_codegen::generate_files(&config).expect("Failed to generate code");
+/// ```
+pub fn generate_files(config: &CodegenOptions) -> Result<(), Error> {
+    use std::io::Write;
+
+    if config.files.is_empty() {
+        return Err(Error::InvalidArgument);
+    }
+
+    // Read and parse all interface files
+    let mut file_contents = Vec::new();
+    for interface_file in &config.files {
+        let content = fs::read_to_string(interface_file)?;
+        file_contents.push(content);
+    }
+
+    let mut interfaces = Vec::new();
+    for content in &file_contents {
+        let interface = Interface::try_from(content.as_str())?;
+        interfaces.push(interface);
+    }
+
+    // Determine output mode
+    if let Some(output_path) = &config.output {
+        // Single output file mode
+        let code = if interfaces.len() == 1 {
+            generate_interface(&interfaces[0])?
+        } else {
+            generate_interfaces(&interfaces)?
+        };
+
+        let output = if config.rustfmt {
+            format_code(&code)?
+        } else {
+            code
+        };
+
+        fs::write(output_path, output)?;
+    } else if config.multiple_files {
+        // Multiple output files mode - generate separate file for each interface
+        for interface in &interfaces {
+            let code = generate_interface(interface)?;
+
+            let output = if config.rustfmt {
+                format_code(&code)?
+            } else {
+                code
+            };
+
+            // Generate output filename from interface name
+            let filename = interface_to_filename(interface.name());
+            let output_path = PathBuf::from(filename);
+
+            fs::write(&output_path, output)?;
+        }
+    } else {
+        // Stdout mode
+        let code = if interfaces.len() == 1 {
+            generate_interface(&interfaces[0])?
+        } else {
+            generate_interfaces(&interfaces)?
+        };
+
+        let output = if config.rustfmt {
+            format_code(&code)?
+        } else {
+            code
+        };
+
+        std::io::stdout().write_all(output.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+/// Convert an interface name to a filename.
+///
+/// The filename is converted to lowercase to comply with Rust's naming conventions.
+///
+/// For example: `"org.example.Interface"` → `"org_example_interface.rs"`
+fn interface_to_filename(interface_name: &str) -> String {
+    format!("{}.rs", interface_name.replace('.', "_").to_lowercase())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_interface_to_filename() {
+        assert_eq!(
+            interface_to_filename("org.example.Interface"),
+            "org_example_interface.rs"
+        );
+        assert_eq!(
+            interface_to_filename("com.example.MyService"),
+            "com_example_myservice.rs"
+        );
+        assert_eq!(
+            interface_to_filename("SimpleInterface"),
+            "simpleinterface.rs"
+        );
+        assert_eq!(
+            interface_to_filename("org.varlink.service"),
+            "org_varlink_service.rs"
+        );
+    }
 }

--- a/zlink-codegen/src/main.rs
+++ b/zlink-codegen/src/main.rs
@@ -1,27 +1,21 @@
-use anyhow::{Context, Result};
 use clap::Parser;
-use heck::ToSnakeCase;
-use std::{
-    fs,
-    io::{self, Write},
-};
-use zlink::idl::Interface;
-use zlink_codegen::{format_code, generate_interface, generate_interfaces};
+use zlink_codegen::{CodegenOptions, Error};
 
 mod cli;
 use cli::Args;
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Error> {
     let args = Args::parse();
 
     // Handle the case where no command is provided (use files directly).
-    let (files, output, multiple_files) = match args.command {
+    let (files, output, multiple_files, rustfmt) = match args.command {
         Some(cli::Command::Generate {
             files,
             output,
             multiple_files,
-        }) => (files, output, multiple_files),
-        None => (args.files, args.output, args.multiple_files),
+            rustfmt,
+        }) => (files, output, multiple_files, rustfmt),
+        None => (args.files, args.output, args.multiple_files, args.rustfmt),
     };
 
     if files.is_empty() {
@@ -30,103 +24,16 @@ fn main() -> Result<()> {
         std::process::exit(1);
     }
 
-    // Parse all interfaces from input files.
-    // We need to keep the file contents alive because Interface borrows from them.
-    let mut file_contents = Vec::new();
-    let mut interfaces = Vec::new();
-    for file_path in &files {
-        let content = fs::read_to_string(file_path)
-            .with_context(|| format!("Failed to read file: {}", file_path.display()))?;
+    // Create configuration from command-line arguments
+    let config = CodegenOptions {
+        files,
+        output,
+        multiple_files,
+        rustfmt,
+    };
 
-        file_contents.push(content);
-    }
-
-    for (i, file_path) in files.iter().enumerate() {
-        let interface = Interface::try_from(file_contents[i].as_str())
-            .with_context(|| format!("Failed to parse interface from: {}", file_path.display()))?;
-
-        interfaces.push(interface);
-    }
-
-    // Generate code based on output options.
-    if let Some(output_path) = output {
-        // Single output file.
-        let output = if interfaces.len() == 1 {
-            generate_interface(&interfaces[0]).with_context(|| {
-                format!(
-                    "Failed to generate code for interface: {}",
-                    interfaces[0].name()
-                )
-            })?
-        } else {
-            generate_interfaces(&interfaces)
-                .with_context(|| "Failed to generate code for interfaces".to_string())?
-        };
-
-        // Format the code.
-        let formatted = format_code(&output)?;
-
-        // Write to file.
-        fs::write(&output_path, formatted)
-            .with_context(|| format!("Failed to write output file: {}", output_path.display()))?;
-
-        println!("Generated code written to {}", output_path.display());
-    } else if multiple_files {
-        // Multiple output files.
-        for interface in &interfaces {
-            let code = generate_interface(interface).with_context(|| {
-                format!(
-                    "Failed to generate code for interface: {}",
-                    interface.name()
-                )
-            })?;
-
-            // Format the code.
-            let formatted = format_code(&code)?;
-
-            // Generate output filename from interface name.
-            let filename = interface_to_filename(interface.name());
-            let output_path = format!("{}.rs", filename);
-
-            // Write to file.
-            fs::write(&output_path, formatted)
-                .with_context(|| format!("Failed to write output file: {}", output_path))?;
-
-            println!(
-                "Generated code for `{}` written to {}",
-                interface.name(),
-                output_path
-            );
-        }
-    } else {
-        // Output to stdout.
-        let output = if interfaces.len() == 1 {
-            generate_interface(&interfaces[0]).with_context(|| {
-                format!(
-                    "Failed to generate code for interface: {}",
-                    interfaces[0].name()
-                )
-            })?
-        } else {
-            generate_interfaces(&interfaces)
-                .with_context(|| "Failed to generate code for interfaces".to_string())?
-        };
-
-        // Format the code.
-        let formatted = format_code(&output)?;
-
-        // Write to stdout.
-        io::stdout().write_all(formatted.as_bytes())?;
-    }
+    // Generate the files
+    zlink_codegen::generate_files(&config)?;
 
     Ok(())
-}
-
-fn interface_to_filename(interface_name: &str) -> String {
-    // Convert interface name like "org.example.Interface" to "interface".
-    interface_name
-        .split('.')
-        .next_back()
-        .unwrap_or(interface_name)
-        .to_snake_case()
 }

--- a/zlink-codegen/test-integration/Cargo.toml
+++ b/zlink-codegen/test-integration/Cargo.toml
@@ -16,7 +16,6 @@ zlink = { path = "../../zlink", features = ["proxy"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["rt", "macros"] }
-anyhow = "1.0"
 
 [build-dependencies]
 zlink = { path = "../../zlink", features = ["idl-parse"] }

--- a/zlink-codegen/test-integration/build.rs
+++ b/zlink-codegen/test-integration/build.rs
@@ -1,4 +1,4 @@
-use std::{env, fs, path::PathBuf};
+use std::{env, path::PathBuf};
 
 fn main() {
     // Get the manifest directory.
@@ -7,40 +7,27 @@ fn main() {
     // Process all IDL files.
     let idl_files = ["test.idl", "calc.idl", "storage.idl", "camelcase.idl"];
 
-    // Read all IDL file contents first (they need to stay alive for Interface lifetimes).
-    let mut contents = Vec::new();
-    for idl_file in &idl_files {
-        let idl_path = PathBuf::from(&manifest_dir).join(idl_file);
+    // Build paths to IDL files.
+    let idl_paths: Vec<PathBuf> = idl_files
+        .iter()
+        .map(|idl_file| PathBuf::from(&manifest_dir).join(idl_file))
+        .collect();
 
-        // Tell cargo to rerun if the IDL file changes.
+    // Tell cargo to rerun if any IDL file changes.
+    for idl_path in &idl_paths {
         println!("cargo:rerun-if-changed={}", idl_path.display());
-
-        let content = fs::read_to_string(&idl_path)
-            .unwrap_or_else(|_| panic!("Failed to read IDL file: {}", idl_path.display()));
-
-        contents.push(content);
     }
-
-    // Parse all interfaces.
-    let mut interfaces = Vec::new();
-    for content in &contents {
-        let interface: zlink::idl::Interface = content
-            .as_str()
-            .try_into()
-            .expect("Failed to parse IDL file");
-
-        interfaces.push(interface);
-    }
-
-    // Generate code for all interfaces.
-    let generated_code =
-        zlink_codegen::generate_interfaces(&interfaces).expect("Failed to generate code");
-
-    // Format the generated code if rustfmt is available.
-    let formatted_code = zlink_codegen::format_code(&generated_code).unwrap_or(generated_code);
 
     // Write generated code to OUT_DIR.
     let out_dir = env::var("OUT_DIR").unwrap();
-    let out_path = PathBuf::from(&out_dir).join("generated.rs");
-    fs::write(&out_path, formatted_code).expect("Failed to write generated code");
+    let output_file = PathBuf::from(out_dir).join("generated.rs");
+
+    // Generate code from all interface files.
+    zlink_codegen::generate_files(&zlink_codegen::CodegenOptions {
+        files: idl_paths,
+        output: Some(output_file),
+        rustfmt: true,
+        ..Default::default()
+    })
+    .expect("Failed to generate code");
 }


### PR DESCRIPTION
Expose `zlink-codegen` as a library so build scripts can drive code generation without shelling out to the `zlink-codegen` binary, and migrate the binary itself onto the same entry point.

- Introduce `Error` enum (`InvalidArgument`, `Io`, `Zlink`, `Fmt`, `InvalidUtf8`) with proper `Display` / `source` / `From` impls. No `anyhow` in the public API.
- Add `CodegenOptions` and `generate_files(&CodegenOptions)`, covering the three output modes: single file, one-file-per-interface, stdout. Add a `--rustfmt` flag (and matching `CodegenOptions::rustfmt`) to optionally pipe generated code through `rustfmt`.
- Refactor `main.rs` to be a thin wrapper around `generate_files()`.
- Add a `test-integration` crate that exercises the library from a real `build.rs`.

Supersedes #124. Rebased and adjusted to drop the `anyhow` dependency entirely per the review feedback.
