### PR TITLE
🐛 core,zlink: exit cleanly when driven by a handed-down socket

### DIFF
--- a/zlink-core/CHANGELOG.md
+++ b/zlink-core/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- 🐛 A `Server` driven by a `ReadyListener` (handed-down socket: systemd `Accept=yes`,
+  `varlinkctl exec:`) now exits cleanly from `Server::run` once the lone connection closes,
+  instead of hanging forever waiting for a second `accept()` that never comes. This is driven
+  by a new defaulted `Listener::exit_when_done()` method which `ReadyListener` overrides to
+  `true`.
+
 ## 0.5.0 - 2026-05-03
 
 ### Added

--- a/zlink-core/src/server/listener.rs
+++ b/zlink-core/src/server/listener.rs
@@ -9,11 +9,36 @@ pub trait Listener: core::fmt::Debug {
 
     /// Accept a new connection.
     fn accept(&mut self) -> impl Future<Output = Result<Connection<Self::Socket>>>;
+
+    /// Whether this is a one-shot listener whose [`accept`] resolves at most once.
+    ///
+    /// When this returns `true`, [`accept`] is contracted to resolve exactly once (handing over a
+    /// single, already-connected socket) and to never resolve again afterwards.
+    /// [`crate::Server::run`] relies on that contract: it stops polling [`accept`] after the
+    /// first connection and returns cleanly once that connection closes and all in-flight work
+    /// has drained, rather than blocking forever on an [`accept`] that can never resolve again.
+    ///
+    /// Infinite listeners (the default, `false`) keep [`accept`] live and the server running,
+    /// waiting for more connections. This is the right behavior for the usual
+    /// [`bind`](crate)-style listeners. One-shot listeners that hand over a socket received from a
+    /// supervisor (systemd `Accept=yes`, `varlinkctl exec:`, such as [`ReadyListener`]) override
+    /// this to `true`.
+    ///
+    /// [`accept`]: Listener::accept
+    fn exit_when_done(&self) -> bool {
+        false
+    }
 }
 
 /// A listener that already has a socket.
 ///
-/// This is useful for services that get spawned by systemd and handed over a socket.
+/// This is useful for services that get spawned by their supervisor with a connected socket
+/// already in hand: systemd `Accept=yes` activation, `varlinkctl exec:`, and similar one-shot
+/// patterns.
+///
+/// A [`crate::Server`] built on a `ReadyListener` serves that single connection and then returns
+/// from [`crate::Server::run`] once it closes, because [`Listener::exit_when_done`] is `true` for
+/// this listener.
 #[derive(Debug)]
 pub struct ReadyListener<Sock: Socket> {
     socket: Option<Sock>,
@@ -39,12 +64,18 @@ where
 
     /// This implementation simply returns the contained socket.
     ///
-    /// After the first call, in simply never returns on subsequent calls.
+    /// After the first call, it never returns on subsequent calls. [`crate::Server::run`] does
+    /// not re-poll it: because [`Listener::exit_when_done`] is `true`, the server returns once
+    /// the single connection has closed and any in-flight work has drained.
     async fn accept(&mut self) -> Result<Connection<Self::Socket>> {
         match self.socket.take() {
             Some(socket) => Ok(Connection::new(socket)),
             None => core::future::pending().await,
         }
+    }
+
+    fn exit_when_done(&self) -> bool {
+        true
     }
 }
 

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -5,7 +5,7 @@ pub mod service;
 mod infallible;
 
 use alloc::vec::Vec;
-use futures_util::{FutureExt, StreamExt};
+use futures_util::{FutureExt, StreamExt, future::Either};
 use select_all::SelectAll;
 use service::MethodReply;
 
@@ -59,6 +59,11 @@ where
     /// [`tokio::select!`]: https://docs.rs/tokio/latest/tokio/macro.select.html
     pub async fn run(mut self) -> crate::Result<()> {
         let mut listener = self.listener.take().unwrap();
+        // Whether this is a one-shot listener whose `accept()` resolves at most once. True for
+        // listeners like `ReadyListener` (handed-down socket); false for listening sockets that
+        // should keep accepting forever. When true, we return once that single connection has
+        // been served and all work has drained (see `accepted_once` below).
+        let exit_when_done = listener.exit_when_done();
         let mut connections = Vec::new();
         let mut reply_streams = Vec::<ReplyStream<Service::ReplyStream, Listener::Socket>>::new();
         let mut reply_stream_futures = Vec::new();
@@ -67,8 +72,22 @@ where
         let mut read_futures = Vec::new();
         let mut last_reply_stream_winner = None;
         let mut last_method_call_winner = None;
+        // Tracks whether the listener has produced its connection. For a one-shot listener
+        // (`exit_when_done == true`), `accept()` resolves at most once, so this flag marks the
+        // listener as exhausted: it lets us return cleanly once that connection and all in-flight
+        // work has drained.
+        let mut accepted_once = false;
 
         loop {
+            // Exit cleanly when we're done: a one-shot listener has handed out its single
+            // connection, every connection has been closed, and every reply stream has finished.
+            // Without this, `Server::run` would block forever on `listener.accept()` (which pends
+            // forever for `ReadyListener` after the first call).
+            if exit_when_done && accepted_once && connections.is_empty() && reply_streams.is_empty()
+            {
+                return Ok(());
+            }
+
             // We re-populate the `reply_stream_futures` in each iteration so we must clear it
             // first.
             reply_stream_futures.clear();
@@ -103,10 +122,23 @@ where
                 }
             }
 
+            // Once a one-shot listener has produced its connection, stop polling `accept()` (which
+            // would pend forever for `ReadyListener`) by swapping in a never-ready future at
+            // the same output type. `Either` implements `Future` with the same `Output` as both
+            // arms, so the `select_biased!` arm below sees `Result<Connection<_>>` either way.
+            let accept_fut = if exit_when_done && accepted_once {
+                Either::Left(core::future::pending::<
+                    crate::Result<Connection<Listener::Socket>>,
+                >())
+            } else {
+                Either::Right(listener.accept())
+            };
+
             futures_util::select_biased! {
                 // 1. Accept a new connection.
-                conn = listener.accept().fuse() => {
+                conn = accept_fut.fuse() => {
                     connections.push(conn?);
+                    accepted_once = true;
                 }
                 // 2. Read method calls from the existing connections and handle them.
                 (idx, result) = read_select_all.fuse() => {

--- a/zlink/tests/ready_listener_exit.rs
+++ b/zlink/tests/ready_listener_exit.rs
@@ -1,0 +1,98 @@
+//! Tests that a `ReadyListener`-driven server exits cleanly when the handed-down connection
+//! closes.
+//!
+//! This is the regression test for the systemd `Accept=yes` / `varlinkctl exec:` hang: before
+//! the fix, `Server::run()` with a `ReadyListener` would block forever after the lone client
+//! disconnected, because `accept()` pends after the first call. Now `ReadyListener` reports
+//! `Listener::exit_when_done() == true`, so the server returns `Ok(())` once the connection is
+//! gone and any in-flight work has drained.
+
+#![cfg(all(feature = "service", feature = "proxy"))]
+
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tokio::{net::UnixStream, time::timeout};
+use zlink::{
+    Connection, ReadyListener, Server,
+    introspect::{self, CustomType},
+    unix::Stream,
+};
+
+/// The whole test must complete in well under this; the hang behavior we're guarding against
+/// would manifest as the server task never returning.
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Server side returns `Ok(())` once the client side closes, even though `ReadyListener::accept`
+/// continues to pend forever after the first call. The fix is `ReadyListener::exit_when_done()`
+/// returning `true`, which `Server::run` honors.
+#[test_log::test(tokio::test(flavor = "current_thread"))]
+async fn ready_listener_exits_after_client_disconnects() {
+    let (server_sock, client_sock) = UnixStream::pair().unwrap();
+
+    let server = Server::new(ReadyListener::new(Stream::from(server_sock)), PingService);
+    let client = Connection::new(Stream::from(client_sock));
+
+    // We cannot `tokio::spawn(server.run())` because the future is `!Send` (see the
+    // rustc-100013 caveat on `Server::run`). Drive both halves on the same task with
+    // `tokio::join!` instead — the client closes its side at the end, which is what lets
+    // the server's `run()` return.
+    let result = timeout(TIMEOUT, async {
+        let (server_result, client_result) = tokio::join!(server.run(), run_client(client));
+        client_result.expect("client side failed");
+        server_result
+    })
+    .await;
+
+    let server_result = result.unwrap_or_else(|_| {
+        panic!(
+            "ReadyListener-driven server did not exit within {TIMEOUT:?} after the client \
+             disconnected, which is the hang bug exit_when_done is supposed to fix"
+        )
+    });
+
+    server_result.expect("server returned an error instead of Ok(())");
+}
+
+/// Send one `Ping` call, await the reply, drop the connection. Dropping closes the client
+/// side, which is what the server needs to observe to wind down.
+async fn run_client(mut conn: Connection<Stream>) -> Result<(), Box<dyn std::error::Error>> {
+    use zlink::proxy;
+
+    #[proxy(interface = "org.example.ping")]
+    trait PingProxy {
+        async fn ping(&mut self) -> zlink::Result<Result<Pong, PingError>>;
+    }
+
+    let reply = conn.ping().await?.expect("server returned an error");
+    assert!(reply.ok);
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct Pong {
+    ok: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.ping")]
+enum PingError {
+    Boom,
+}
+
+struct PingService;
+
+#[zlink::service(
+    interface = "org.example.ping",
+    vendor = "zlink tests",
+    product = "ping",
+    version = "1",
+    url = "https://example.invalid/",
+    types = [Pong]
+)]
+impl PingService {
+    /// Replies once with `{ ok: true }`.
+    async fn ping(&self) -> Pong {
+        Pong { ok: true }
+    }
+}


### PR DESCRIPTION
[Please let me know what you think, I find the comments a bit too verbose but maybe you prefer it this way, idk]

A zlink server started per-connection from an already-accepted socket never exits. For example, running a zlink service under:

    varlinkctl exec: ./my-service

(or systemd socket activation with `Accept=yes`) hands the service a single, already-connected socket, wrapped in a `ReadyListener`. The expectation is that the service handles that one connection and exits when the client disconnects. Instead it hangs forever after the client goes away.

The cause is that `ReadyListener::accept()` yields its one connection and then pends forever on subsequent calls. `Server::run()`'s select loop has no notion of "done", so once the lone connection closes there is nothing to return on: the loop just waits on a listener that will never produce again. Downstream this shows up as per-connection systemd services that never exit, eventually exhausting the socket's `MaxConnections=` limit.

Make the exit behavior a property of the listener rather than of how the server was constructed. Add a defaulted `Listener::exit_when_done()` method (false by default, so the tokio/smol listening sockets keep running forever as before) and override it to `true` for `ReadyListener`. `Server::run` reads it once up front and returns `Ok(())` as soon as the listener has produced its connection and both `connections` and `reply_streams` have drained.

This means the obvious `Server::new(ReadyListener::new(socket))` now just works for the handed-down-socket case, with no separate entry point to remember. The trait method is defaulted, so existing `Listener` impls are unaffected.

Also adds:

- An integration test that drives a real `ReadyListener`-backed server over a `UnixStream::pair`, sends one ping, drops the client, and asserts the server returns within a timeout (the failure mode being the historical hang).
- A `systemd-socket-activate` example handling both `Accept=yes` (handed-down connection, exits per connection) and `Accept=no` (listening socket, runs forever), observable end-to-end with `systemd-socket-activate(1)`.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
