### PR TITLE
🐛 core,zlink: exit cleanly when driven by a handed-down socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2136,7 +2136,7 @@ dependencies = [
 
 [[package]]
 name = "zlink"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "colored 3.0.0",
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-codegen"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "clap",
  "heck",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures-util",
  "proc-macro2",
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-smol"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-broadcast",
  "async-channel",
@@ -2231,7 +2231,7 @@ dependencies = [
 
 [[package]]
 name = "zlink-tokio"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures-util",
  "pin-project-lite",

--- a/zlink-codegen/Cargo.toml
+++ b/zlink-codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-codegen"
-version = "0.5.0"
+version = "0.6.0"
 description = "Utility to generate zlink code from varlink IDL files"
 edition.workspace = true
 rust-version.workspace = true
@@ -15,7 +15,7 @@ name = "zlink-codegen"
 path = "src/main.rs"
 
 [dependencies]
-zlink = { path = "../zlink", version = "0.5.0", features = [
+zlink = { path = "../zlink", version = "0.6.0", features = [
     "idl",
     "idl-parse",
 ] }

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-core"
-version = "0.5.0"
+version = "0.6.0"
 description = "The core crate of the zlink project"
 edition.workspace = true
 rust-version.workspace = true
@@ -21,7 +21,7 @@ introspection = ["idl", "zlink-macros/introspection"]
 
 [dependencies]
 serde = { version = "1.0.218", default-features = false, features = ["derive", "alloc"] }
-zlink-macros = { path = "../zlink-macros", version = "=0.5.0" }
+zlink-macros = { path = "../zlink-macros", version = "=0.6.0" }
 serde_json = { version = "1.0.139", default-features = false, features = ["alloc"] }
 itoa = { version = "1.0", default-features = false }
 ryu = { version = "1.0", default-features = false }

--- a/zlink-core/src/connection/credentials.rs
+++ b/zlink-core/src/connection/credentials.rs
@@ -16,11 +16,6 @@ pub struct Credentials {
 
 impl Credentials {
     /// Create new credentials for a peer connection.
-    ///
-    /// # Arguments
-    /// * `unix_user_id` - The numeric Unix user ID.
-    /// * `process_id` - The numeric process ID.
-    /// * `process_fd` (Linux only) - A file descriptor pinning the process.
     pub(crate) fn new(
         unix_user_id: Uid,
         unix_primary_group_id: Gid,

--- a/zlink-core/src/server/listener.rs
+++ b/zlink-core/src/server/listener.rs
@@ -8,7 +8,10 @@ pub trait Listener: core::fmt::Debug {
     type Socket: Socket;
 
     /// Accept a new connection.
-    fn accept(&mut self) -> impl Future<Output = Result<Connection<Self::Socket>>>;
+    ///
+    /// Returns `Ok(None)` to signal that no more connections will be produced. Once `Ok(None)`
+    /// has been returned, subsequent calls must pend forever — the listener is considered closed.
+    fn accept(&mut self) -> impl Future<Output = Result<Option<Connection<Self::Socket>>>>;
 }
 
 /// A listener that already has a socket.
@@ -40,9 +43,9 @@ where
     /// This implementation simply returns the contained socket.
     ///
     /// After the first call, in simply never returns on subsequent calls.
-    async fn accept(&mut self) -> Result<Connection<Self::Socket>> {
+    async fn accept(&mut self) -> Result<Option<Connection<Self::Socket>>> {
         match self.socket.take() {
-            Some(socket) => Ok(Connection::new(socket)),
+            Some(socket) => Ok(Some(Connection::new(socket))),
             None => core::future::pending().await,
         }
     }
@@ -61,7 +64,7 @@ mod tests {
         let mut listener = ReadyListener::new(socket);
 
         // First call returns a connection with properly split read/write halves.
-        let conn = listener.accept().await.unwrap();
+        let conn = listener.accept().await.unwrap().unwrap();
         let (read, write) = conn.split();
         assert_eq!(read.id(), write.id());
 

--- a/zlink-core/src/server/listener.rs
+++ b/zlink-core/src/server/listener.rs
@@ -16,10 +16,21 @@ pub trait Listener: core::fmt::Debug {
 
 /// A listener that already has a socket.
 ///
-/// This is useful for services that get spawned by systemd and handed over a socket.
+/// This is useful for services spawned by their supervisor with a connected socket already in
+/// hand (systemd `Accept=yes`, `varlinkctl exec:`, etc.). [`Server::run`] exits cleanly once the
+/// handed-out connection closes.
+///
+/// [`Server::run`]: crate::Server::run
 #[derive(Debug)]
 pub struct ReadyListener<Sock: Socket> {
-    socket: Option<Sock>,
+    state: ReadyListenerState<Sock>,
+}
+
+#[derive(Debug)]
+enum ReadyListenerState<Sock: Socket> {
+    Ready(Sock),
+    Handed,
+    Closed,
 }
 
 impl<Sock> ReadyListener<Sock>
@@ -29,7 +40,7 @@ where
     /// Create a new listener from a socket.
     pub fn new(socket: Sock) -> Self {
         Self {
-            socket: Some(socket),
+            state: ReadyListenerState::Ready(socket),
         }
     }
 }
@@ -40,13 +51,20 @@ where
 {
     type Socket = Sock;
 
-    /// This implementation simply returns the contained socket.
-    ///
-    /// After the first call, in simply never returns on subsequent calls.
+    /// Returns the contained socket on the first call, then reports closure.
     async fn accept(&mut self) -> Result<Option<Connection<Self::Socket>>> {
-        match self.socket.take() {
-            Some(socket) => Ok(Some(Connection::new(socket))),
-            None => core::future::pending().await,
+        match core::mem::replace(&mut self.state, ReadyListenerState::Handed) {
+            ReadyListenerState::Ready(socket) => Ok(Some(Connection::new(socket))),
+            ReadyListenerState::Handed => {
+                self.state = ReadyListenerState::Closed;
+
+                Ok(None)
+            }
+            ReadyListenerState::Closed => {
+                self.state = ReadyListenerState::Closed;
+
+                core::future::pending().await
+            }
         }
     }
 }
@@ -68,7 +86,10 @@ mod tests {
         let (read, write) = conn.split();
         assert_eq!(read.id(), write.id());
 
-        // Second call should be pending forever.
+        // Second call reports closure.
+        assert!(matches!(listener.accept().await, Ok(None)));
+
+        // Subsequent calls pend forever.
         let accept_fut = listener.accept();
         futures_util::pin_mut!(accept_fut);
         let is_pending = poll_fn(|cx| Poll::Ready(accept_fut.as_mut().poll(cx).is_pending())).await;

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -67,8 +67,13 @@ where
         let mut read_futures = Vec::new();
         let mut last_reply_stream_winner = None;
         let mut last_method_call_winner = None;
+        let mut listener_closed = false;
 
         loop {
+            if listener_closed && connections.is_empty() && reply_streams.is_empty() {
+                return Ok(());
+            }
+
             // We re-populate the `reply_stream_futures` in each iteration so we must clear it
             // first.
             reply_stream_futures.clear();
@@ -107,7 +112,7 @@ where
                 // 1. Accept a new connection.
                 conn = listener.accept().fuse() => match conn? {
                     Some(conn) => connections.push(conn),
-                    None => (),
+                    None => listener_closed = true,
                 },
                 // 2. Read method calls from the existing connections and handle them.
                 (idx, result) = read_select_all.fuse() => {

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -105,9 +105,10 @@ where
 
             futures_util::select_biased! {
                 // 1. Accept a new connection.
-                conn = listener.accept().fuse() => {
-                    connections.push(conn?);
-                }
+                conn = listener.accept().fuse() => match conn? {
+                    Some(conn) => connections.push(conn),
+                    None => (),
+                },
                 // 2. Read method calls from the existing connections and handle them.
                 (idx, result) = read_select_all.fuse() => {
                         #[cfg(feature = "std")]

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-macros"
-version = "0.5.0"
+version = "0.6.0"
 description = "Macros providing the high-level zlink API"
 edition.workspace = true
 rust-version.workspace = true

--- a/zlink-smol/Cargo.toml
+++ b/zlink-smol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-smol"
-version = "0.5.0"
+version = "0.6.0"
 description = "zlink library for the smol runtime"
 edition.workspace = true
 rust-version.workspace = true
@@ -20,7 +20,7 @@ tracing = ["zlink-core/tracing"]
 defmt = ["zlink-core/defmt"]
 
 [dependencies]
-zlink-core = { path = "../zlink-core", version = "=0.5.0", default-features = false, features = ["std"] }
+zlink-core = { path = "../zlink-core", version = "=0.6.0", default-features = false, features = ["std"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
     "async-await",
     "alloc",

--- a/zlink-smol/src/unix/listener.rs
+++ b/zlink-smol/src/unix/listener.rs
@@ -24,9 +24,9 @@ pub struct Listener {
 impl crate::Listener for Listener {
     type Socket = super::Stream;
 
-    async fn accept(&mut self) -> Result<Connection<Self::Socket>> {
+    async fn accept(&mut self) -> Result<Option<Connection<Self::Socket>>> {
         let (stream, _) = self.listener.accept().await?;
-        Ok(super::Stream::from(stream).into())
+        Ok(Some(super::Stream::from(stream).into()))
     }
 }
 
@@ -74,7 +74,7 @@ mod tests {
                         .unwrap()
                 });
 
-                let connection = listener.accept().await.unwrap();
+                let connection = listener.accept().await.unwrap().unwrap();
                 let id = connection.id();
 
                 // Each connection should have a unique ID
@@ -113,7 +113,7 @@ mod tests {
                     .unwrap()
             });
 
-            let connection = listener.accept().await.unwrap();
+            let connection = listener.accept().await.unwrap().unwrap();
             // Just verify we got a valid connection with an ID
             let id = connection.id();
             assert!(id < usize::MAX);

--- a/zlink-smol/src/unix/stream.rs
+++ b/zlink-smol/src/unix/stream.rs
@@ -49,6 +49,15 @@ impl From<Async<StdUnixStream>> for Stream {
     }
 }
 
+impl TryFrom<StdUnixStream> for Stream {
+    type Error = crate::Error;
+
+    fn try_from(stream: StdUnixStream) -> Result<Self> {
+        stream.set_nonblocking(true)?;
+        Ok(Self(Async::new(stream)?))
+    }
+}
+
 impl AsFd for Stream {
     fn as_fd(&self) -> BorrowedFd<'_> {
         self.0.as_fd()

--- a/zlink-tokio/Cargo.toml
+++ b/zlink-tokio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink-tokio"
-version = "0.5.0"
+version = "0.6.0"
 description = "zlink library for the Tokio runtime"
 edition.workspace = true
 rust-version.workspace = true
@@ -20,7 +20,7 @@ tracing = ["zlink-core/tracing", "tokio/tracing"]
 defmt = ["zlink-core/defmt"]
 
 [dependencies]
-zlink-core = { path = "../zlink-core", version = "=0.5.0", default-features = false, features = ["std"] }
+zlink-core = { path = "../zlink-core", version = "=0.6.0", default-features = false, features = ["std"] }
 tokio = { version = "1.44.0", features = ["net", "io-util"] }
 futures-util = { version = "0.3.31", default-features = false, features = [
     "async-await",

--- a/zlink-tokio/src/unix/listener.rs
+++ b/zlink-tokio/src/unix/listener.rs
@@ -21,11 +21,11 @@ pub struct Listener {
 impl crate::Listener for Listener {
     type Socket = super::Stream;
 
-    async fn accept(&mut self) -> Result<Connection<Self::Socket>> {
+    async fn accept(&mut self) -> Result<Option<Connection<Self::Socket>>> {
         self.listener
             .accept()
             .await
-            .map(|(stream, _)| super::Stream::from(stream).into())
+            .map(|(stream, _)| Some(super::Stream::from(stream).into()))
             .map_err(Into::into)
     }
 }
@@ -79,7 +79,7 @@ mod tests {
                     .unwrap()
             });
 
-            let connection = listener.accept().await.unwrap();
+            let connection = listener.accept().await.unwrap().unwrap();
             let id = connection.id();
 
             // Each connection should have a unique ID
@@ -116,7 +116,7 @@ mod tests {
                 .unwrap()
         });
 
-        let connection = listener.accept().await.unwrap();
+        let connection = listener.accept().await.unwrap().unwrap();
         // Just verify we got a valid connection with an ID
         let id = connection.id();
         assert!(id < usize::MAX);

--- a/zlink-tokio/src/unix/stream.rs
+++ b/zlink-tokio/src/unix/stream.rs
@@ -2,7 +2,10 @@ use crate::{
     Result,
     connection::socket::{self, Socket},
 };
-use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
+use std::os::{
+    fd::{AsFd, BorrowedFd, OwnedFd},
+    unix::net::UnixStream as StdUnixStream,
+};
 use tokio::net::{UnixStream, unix};
 
 /// The connection type that uses Unix Domain Sockets for transport.
@@ -40,6 +43,15 @@ impl Socket for Stream {
 impl From<UnixStream> for Stream {
     fn from(stream: UnixStream) -> Self {
         Self(stream)
+    }
+}
+
+impl TryFrom<StdUnixStream> for Stream {
+    type Error = crate::Error;
+
+    fn try_from(stream: StdUnixStream) -> Result<Self> {
+        stream.set_nonblocking(true)?;
+        UnixStream::from_std(stream).map(Self).map_err(Into::into)
     }
 }
 

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zlink"
-version = "0.5.0"
+version = "0.6.0"
 description = "Async Varlink API"
 edition.workspace = true
 rust-version.workspace = true
@@ -22,8 +22,8 @@ tracing = ["zlink-tokio?/tracing", "zlink-smol?/tracing"]
 defmt = ["zlink-tokio?/defmt", "zlink-smol?/defmt"]
 
 [dependencies]
-zlink-tokio = { path = "../zlink-tokio", version = "=0.5.0", default-features = false, optional = true }
-zlink-smol = { path = "../zlink-smol", version = "=0.5.0", default-features = false, optional = true }
+zlink-tokio = { path = "../zlink-tokio", version = "=0.6.0", default-features = false, optional = true }
+zlink-smol = { path = "../zlink-smol", version = "=0.6.0", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.44.0", features = [

--- a/zlink/tests/peer_credentials.rs
+++ b/zlink/tests/peer_credentials.rs
@@ -27,7 +27,7 @@ async fn peer_credentials_unix_socket() {
             .unwrap()
     });
 
-    let mut connection = listener.accept().await.unwrap();
+    let mut connection = listener.accept().await.unwrap().unwrap();
 
     // Get peer credentials.
     let creds = connection.peer_credentials().await.unwrap();

--- a/zlink/tests/ready_listener_exit.rs
+++ b/zlink/tests/ready_listener_exit.rs
@@ -1,0 +1,83 @@
+//! Regression test: a `ReadyListener`-driven server must exit cleanly once its handed-down
+//! connection closes, instead of hanging on the next `accept()`.
+
+#![cfg(all(feature = "server", feature = "proxy"))]
+
+use std::{os::unix::net::UnixStream as StdUnixStream, time::Duration};
+
+use serde::{Deserialize, Serialize};
+use tokio::time::timeout;
+use zlink::{
+    Connection, ReadyListener, Server,
+    introspect::{self, CustomType},
+    unix::Stream,
+};
+
+const TIMEOUT: Duration = Duration::from_secs(5);
+
+#[test_log::test(tokio::test(flavor = "current_thread"))]
+async fn ready_listener_exits_after_client_disconnects() {
+    let (server_sock, client_sock) = StdUnixStream::pair().unwrap();
+    let server_stream = Stream::try_from(server_sock).unwrap();
+    let client_stream = Stream::try_from(client_sock).unwrap();
+
+    let server = Server::new(ReadyListener::new(server_stream), PingService);
+    let client = Connection::new(client_stream);
+
+    // `Server::run` is `!Send` (rustc-100013), so drive both halves on the same task.
+    let result = timeout(TIMEOUT, async {
+        let (server_result, client_result) = tokio::join!(server.run(), run_client(client));
+        client_result.expect("client side failed");
+        server_result
+    })
+    .await;
+
+    let server_result = result.unwrap_or_else(|_| {
+        panic!(
+            "ReadyListener-driven server did not exit within {TIMEOUT:?} after the client \
+             disconnected"
+        )
+    });
+
+    server_result.expect("server returned an error instead of Ok(())");
+}
+
+async fn run_client(mut conn: Connection<Stream>) -> Result<(), Box<dyn std::error::Error>> {
+    use zlink::proxy;
+
+    #[proxy(interface = "org.example.ping")]
+    trait PingProxy {
+        async fn ping(&mut self) -> zlink::Result<Result<Pong, PingError>>;
+    }
+
+    let reply = conn.ping().await?.expect("server returned an error");
+    assert!(reply.ok);
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct Pong {
+    ok: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.ping")]
+enum PingError {
+    Boom,
+}
+
+struct PingService;
+
+#[zlink::service(
+    interface = "org.example.ping",
+    vendor = "zlink tests",
+    product = "ping",
+    version = "1",
+    url = "https://example.invalid/",
+    types = [Pong]
+)]
+impl PingService {
+    async fn ping(&self) -> Pong {
+        Pong { ok: true }
+    }
+}


### PR DESCRIPTION
- **📝 core: Drop redundant internal docs**
- **💥 core,tokio,smol: Let Listener::accept signal exhaustion**
- **🐛 core: Exit Server::run when a listener signals exhaustion**
- **✨ core: ReadyListener signals exhaustion after handing out its socket**
- **✅ zlink: Regression test for ReadyListener-driven server exit**
- **🔖 all: Bump workspace crates to 0.6.0**
