### PR TITLE
✨ core: Support the Varlink upgrade protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1221,6 +1230,35 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "rayon"
@@ -2141,6 +2179,7 @@ dependencies = [
  "clap",
  "colored 3.0.0",
  "futures-util",
+ "rand",
  "rustix",
  "serde",
  "serde-prefix-all",

--- a/zlink-codegen/src/codegen.rs
+++ b/zlink-codegen/src/codegen.rs
@@ -362,8 +362,16 @@ impl CodeGenerator {
             method_name
         };
 
+        if method.upgrade() {
+            self.writeln("#[zlink(upgrade)]")?;
+        }
+
         // Generate method signature.
-        let mut signature = format!("async fn {}(&mut self", safe_method_name);
+        let mut signature = if method.upgrade() {
+            format!("async fn {}(self", safe_method_name)
+        } else {
+            format!("async fn {}(&mut self", safe_method_name)
+        };
 
         // Add input parameters.
         for param in method.inputs() {
@@ -385,7 +393,11 @@ impl CodeGenerator {
             write!(&mut signature, " {}: {}", safe_param_name, rust_type)?;
         }
 
-        signature.push_str(") -> zlink::Result<Result<");
+        if method.upgrade() {
+            signature.push_str(") -> zlink::Result<zlink::connection::UpgradeReply<Self::Socket, ");
+        } else {
+            signature.push_str(") -> zlink::Result<Result<");
+        }
 
         // Handle output parameters.
         let output_count = method.outputs().count();

--- a/zlink-codegen/tests/codegen.rs
+++ b/zlink-codegen/tests/codegen.rs
@@ -309,3 +309,21 @@ method GetData() -> (items: []any, map: [string]any)
     assert!(code.contains("Vec<serde_json::Value>"));
     assert!(code.contains("std::collections::HashMap<"));
 }
+
+#[test]
+fn test_upgrade_method_codegen() {
+    let idl = r#"
+interface org.example.upgrade
+
+upgrade method DoUpgrade() -> (success: bool)
+"#;
+
+    let interface = Interface::try_from(idl).unwrap();
+    let code = generate_interface(&interface).unwrap();
+
+    // Verify #[zlink(upgrade)] attribute is present
+    assert!(code.contains("#[zlink(upgrade)]"));
+
+    // Verify signature with by-value `self` receiver and UpgradeReply return type
+    assert!(code.contains("async fn do_upgrade(self) -> zlink::Result<zlink::connection::UpgradeReply<Self::Socket, DoUpgradeOutput, UpgradeError>>;"));
+}

--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -54,6 +54,7 @@ pub mod chain;
 pub mod socket;
 #[cfg(test)]
 mod tests;
+mod upgrade;
 mod write_connection;
 use crate::{
     Call, Result,
@@ -65,6 +66,7 @@ pub use chain::Chain;
 use core::{fmt::Debug, sync::atomic::AtomicUsize};
 #[cfg(feature = "std")]
 use socket::FetchPeerCredentials;
+pub use upgrade::{ConnectionParts, UpgradeReply};
 pub use write_connection::WriteConnection;
 
 use serde::{Deserialize, Serialize};
@@ -147,6 +149,31 @@ where
             write,
             #[cfg(feature = "std")]
             credentials: None,
+        }
+    }
+
+    /// Consumes the connection and extracts the raw socket halves and leftover buffered bytes.
+    ///
+    /// This is used when upgrading the protocol from Varlink to a raw binary protocol.
+    /// After calling this method, the Varlink/JSON framing API is no longer available on this
+    /// connection. The caller must process any bytes in `read_buffer` before reading from
+    /// `read_half`.
+    ///
+    /// # Panics
+    ///
+    /// In debug builds, this will assert that any buffered writes have been flushed first.
+    pub fn into_parts(self) -> ConnectionParts<S> {
+        debug_assert_eq!(self.write.pos, 0, "flush before into_parts");
+
+        let read_parts = self.read.into_parts();
+        let write_half = self.write.into_inner();
+
+        ConnectionParts {
+            read_half: read_parts.socket,
+            write_half,
+            read_buffer: read_parts.read_buffer,
+            #[cfg(feature = "std")]
+            received_fds: read_parts.pending_fds,
         }
     }
 

--- a/zlink-core/src/connection/read_connection.rs
+++ b/zlink-core/src/connection/read_connection.rs
@@ -35,6 +35,16 @@ pub struct ReadConnection<Read: ReadHalf> {
     socket: Read,
     read_pos: usize,
     msg_pos: usize,
+    /// Byte index one past the terminating `\0` of the most recently returned message.
+    ///
+    /// Together with `last_read_end`, this is the boundary an `upgrade` handoff uses to recover
+    /// leftover raw bytes via [`Self::into_parts`], *after* the normal end-of-burst reset has
+    /// already zeroed `msg_pos`/`read_pos`. It is derived purely from positions, so raw leftovers
+    /// that begin with `\0` are preserved verbatim.
+    last_msg_end: usize,
+    /// Value of `read_pos` (end of real received data, excluding the synthesized sentinel) at the
+    /// time the most recent message was returned, i.e. before any end-of-burst reset.
+    last_read_end: usize,
     buffer: Vec<u8>,
     id: usize,
     #[cfg(feature = "std")]
@@ -52,6 +62,8 @@ impl<Read: ReadHalf> ReadConnection<Read> {
             socket,
             read_pos: 0,
             msg_pos: 0,
+            last_msg_end: 0,
+            last_read_end: 0,
             id,
             buffer: alloc::vec![0; BUFFER_SIZE],
             #[cfg(feature = "std")]
@@ -159,6 +171,19 @@ impl<Read: ReadHalf> ReadConnection<Read> {
         let msg = stream.next();
         let null_index = self.msg_pos + stream.byte_offset();
         let buffer = &self.buffer[self.msg_pos..null_index];
+
+        // Record where this message ends and how much real data the burst held, *before* the
+        // end-of-burst reset below may zero `msg_pos`/`read_pos`. An `upgrade` handoff
+        // (`into_parts`) uses these to recover any leftover raw bytes verbatim — including
+        // leftovers that begin with `\0` — since the slice is taken by position, not content.
+        self.last_msg_end = null_index + 1;
+        self.last_read_end = self.read_pos;
+
+        // Varlink framing boundary logic: a `\0` immediately after this message's terminator marks
+        // the end of the burst (either consecutive framing nulls from the peer, or the sentinel
+        // `read_from_socket` writes at `buffer[read_pos]`). On normal traffic this resets so the
+        // next read starts fresh; the recorded fields above let the upgrade path still recover any
+        // leftovers afterward.
         if self.buffer[null_index + 1] == b'\0' {
             // This means we're reading the last message and can now reset the indices.
             self.read_pos = 0;
@@ -241,4 +266,30 @@ impl<Read: ReadHalf> ReadConnection<Read> {
     pub fn read_half(&self) -> &Read {
         &self.socket
     }
+
+    /// Consumes the read connection and extracts the raw read socket half, leftover buffered bytes,
+    /// and received FDs.
+    pub(super) fn into_parts(self) -> ReadParts<Read> {
+        // Use the boundary recorded by the last `read_message` rather than the live
+        // `msg_pos`/`read_pos`, which the normal end-of-burst reset may have already zeroed. This
+        // yields exactly the bytes the peer sent after the final Varlink `\0`, verbatim (leading
+        // `\0`s of a raw frame intact). If no message was ever read, both are `0` and the buffer
+        // is empty.
+        debug_assert!(self.last_msg_end <= self.last_read_end);
+        debug_assert!(self.last_read_end <= self.buffer.len());
+        let read_buffer = self.buffer[self.last_msg_end..self.last_read_end].to_vec();
+        ReadParts {
+            socket: self.socket,
+            read_buffer,
+            #[cfg(feature = "std")]
+            pending_fds: self.pending_fds,
+        }
+    }
+}
+
+pub(super) struct ReadParts<Read> {
+    pub(super) socket: Read,
+    pub(super) read_buffer: Vec<u8>,
+    #[cfg(feature = "std")]
+    pub(super) pending_fds: VecDeque<Vec<OwnedFd>>,
 }

--- a/zlink-core/src/connection/tests/mod.rs
+++ b/zlink-core/src/connection/tests/mod.rs
@@ -8,4 +8,6 @@ mod connection_tests;
 #[cfg(feature = "std")]
 mod read_connection_fds_tests;
 #[cfg(feature = "std")]
+mod upgrade_tests;
+#[cfg(feature = "std")]
 mod write_connection_fds_tests;

--- a/zlink-core/src/connection/tests/upgrade_tests.rs
+++ b/zlink-core/src/connection/tests/upgrade_tests.rs
@@ -1,0 +1,55 @@
+use crate::{Call, Connection, test_utils::mock_socket::MockSocket};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DummyUpgradeCall {
+    #[serde(rename = "upgrade")]
+    upgrade: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct DummyUpgradeReply {
+    success: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+enum DummyError {}
+
+#[tokio::test]
+async fn test_upgrade_and_pipelining() {
+    // Construct a response containing the upgrade reply terminated by a *single* Varlink `\0`,
+    // immediately followed by raw, pipelined custom-protocol bytes that START with `\0` bytes —
+    // e.g. a big-endian `u32` frame count `0x00000001` (`[0, 0, 0, 1]`) plus a payload byte.
+    //
+    // This is the realistic case that the old sentinel-scanning logic corrupted: it mistook the
+    // leading `\0` of the raw frame for its own end-of-burst sentinel and dropped/discarded it.
+    // The leftover bytes must now be preserved verbatim.
+    let mut response_bytes = b"{\"parameters\":{\"success\":true}}".to_vec();
+    response_bytes.push(0); // single Varlink message terminator
+    response_bytes.extend_from_slice(&[0, 0, 0, 1, 42]); // raw frame: big-endian u32 = 1, payload
+
+    // Convert the bytes to a string representation for MockSocket::with_responses.
+    // MockSocket null-terminates the message and, as it is the last one, appends another trailing
+    // `\0` (so the whole burst ends in `\0\0`, which the reader needs to detect end-of-burst).
+    let response_str = unsafe { std::str::from_utf8_unchecked(&response_bytes) };
+
+    let socket = MockSocket::with_responses(&[response_str]);
+    let connection = Connection::new(socket);
+
+    let call = Call::new(DummyUpgradeCall { upgrade: true }).set_upgrade(true);
+
+    // Call upgrade which consumes the connection
+    let upgrade_reply = connection
+        .call_upgrade::<_, DummyUpgradeReply, DummyError>(&call, vec![])
+        .await
+        .unwrap();
+
+    // Verify the reply was parsed correctly
+    let reply = upgrade_reply.reply.unwrap();
+    assert!(reply.parameters().unwrap().success);
+
+    // The leftover raw bytes must be preserved verbatim, including the leading `\0`s of the frame
+    // count. The two trailing `\0`s are MockSocket's null-termination of the (single) response.
+    let parts = upgrade_reply.parts;
+    assert_eq!(parts.read_buffer, vec![0, 0, 0, 1, 42, 0, 0]);
+}

--- a/zlink-core/src/connection/upgrade.rs
+++ b/zlink-core/src/connection/upgrade.rs
@@ -1,0 +1,78 @@
+use super::{Connection, Socket};
+use crate::{Call, Result, reply};
+use core::fmt::Debug;
+use serde::Serialize;
+
+/// Raw connection halves and any leftover buffered bytes after upgrading.
+#[derive(Debug)]
+pub struct ConnectionParts<S: Socket> {
+    /// The raw read half of the connection socket.
+    pub read_half: S::ReadHalf,
+    /// The raw write half of the connection socket.
+    pub write_half: S::WriteHalf,
+    /// The leftover bytes already read from the socket but not yet consumed by the Varlink parser.
+    ///
+    /// The caller MUST process these bytes before calling `read` on `read_half`, as they are
+    /// already taken from the socket's kernel buffer.
+    pub read_buffer: alloc::vec::Vec<u8>,
+    /// Any received file descriptors that have not yet been consumed (std only).
+    #[cfg(feature = "std")]
+    pub received_fds: alloc::collections::VecDeque<alloc::vec::Vec<std::os::fd::OwnedFd>>,
+}
+
+/// A reply to an upgrade call, containing the deserialized reply and the extracted connection
+/// parts.
+#[derive(Debug)]
+pub struct UpgradeReply<S: Socket, ReplyParams, ReplyError> {
+    /// The deserialized Varlink reply.
+    pub reply: reply::Result<ReplyParams, ReplyError>,
+    /// The raw connection halves and any leftover buffered bytes.
+    pub parts: ConnectionParts<S>,
+}
+
+impl<S> Connection<S>
+where
+    S: Socket,
+{
+    /// Call an upgrade method and return the single Varlink reply along with the raw connection
+    /// parts.
+    ///
+    /// This consumes the connection, and after this call, the Varlink/JSON framing API is gone.
+    /// The caller can continue communication using the raw socket halves inside `parts`.
+    ///
+    /// This method is NOT cancel-safe because it consumes the connection.
+    pub async fn call_upgrade<Method, ReplyParams, ReplyError>(
+        mut self,
+        call: &Call<Method>,
+        #[cfg(feature = "std")] fds: alloc::vec::Vec<std::os::fd::OwnedFd>,
+    ) -> Result<UpgradeReply<S, ReplyParams, ReplyError>>
+    where
+        Method: Serialize + Debug,
+        ReplyParams: serde::de::DeserializeOwned + Debug,
+        ReplyError: serde::de::DeserializeOwned + Debug,
+    {
+        debug_assert!(call.upgrade());
+
+        #[cfg(feature = "std")]
+        self.send_call(call, fds).await?;
+        #[cfg(not(feature = "std"))]
+        self.send_call(call).await?;
+
+        let recv_result = self.receive_reply::<ReplyParams, ReplyError>().await?;
+
+        #[cfg(feature = "std")]
+        let (reply, reply_fds) = recv_result;
+        #[cfg(not(feature = "std"))]
+        let reply = recv_result;
+
+        #[allow(unused_mut)]
+        let mut parts = self.into_parts();
+
+        #[cfg(feature = "std")]
+        if !reply_fds.is_empty() {
+            parts.received_fds.push_front(reply_fds);
+        }
+
+        Ok(UpgradeReply { reply, parts })
+    }
+}

--- a/zlink-core/src/connection/write_connection.rs
+++ b/zlink-core/src/connection/write_connection.rs
@@ -327,6 +327,11 @@ impl<Write: WriteHalf> WriteConnection<Write> {
         Ok(())
     }
 
+    /// Consumes the write connection and returns the raw write half of the socket.
+    pub(super) fn into_inner(self) -> Write {
+        self.socket
+    }
+
     fn grow_buffer(&mut self) -> crate::Result<()> {
         if self.buffer.len() >= super::MAX_BUFFER_SIZE {
             return Err(crate::Error::BufferOverflow);

--- a/zlink-core/src/idl/method.rs
+++ b/zlink-core/src/idl/method.rs
@@ -17,6 +17,8 @@ pub struct Method<'a> {
     outputs: List<'a, Parameter<'a>>,
     /// Comments associated with this method.
     comments: List<'a, Comment<'a>>,
+    /// Whether the method is an upgrade protocol call.
+    upgrade: bool,
 }
 
 impl<'a> Method<'a> {
@@ -32,6 +34,7 @@ impl<'a> Method<'a> {
             inputs: List::Borrowed(inputs),
             outputs: List::Borrowed(outputs),
             comments: List::Borrowed(comments),
+            upgrade: false,
         }
     }
 
@@ -47,7 +50,14 @@ impl<'a> Method<'a> {
             inputs: List::from(inputs),
             outputs: List::from(outputs),
             comments: List::from(comments),
+            upgrade: false,
         }
+    }
+
+    /// Sets whether this method is an upgrade protocol call, returning the updated method.
+    pub const fn set_upgrade(mut self, upgrade: bool) -> Self {
+        self.upgrade = upgrade;
+        self
     }
 
     /// Returns the name of the method.
@@ -79,6 +89,11 @@ impl<'a> Method<'a> {
     pub fn comments(&self) -> impl Iterator<Item = &Comment<'a>> {
         self.comments.iter()
     }
+
+    /// Returns true if the method is an upgrade protocol call.
+    pub fn upgrade(&self) -> bool {
+        self.upgrade
+    }
 }
 
 impl<'a> fmt::Display for Method<'a> {
@@ -87,7 +102,12 @@ impl<'a> fmt::Display for Method<'a> {
         for comment in self.comments.iter() {
             writeln!(f, "{comment}")?;
         }
-        write!(f, "method {}(", self.name)?;
+        let prefix = if self.upgrade {
+            "upgrade method"
+        } else {
+            "method"
+        };
+        write!(f, "{} {}(", prefix, self.name)?;
         let mut first = true;
         for param in self.inputs.iter() {
             if !first {
@@ -115,7 +135,10 @@ impl<'a> fmt::Display for Method<'a> {
 
 impl PartialEq for Method<'_> {
     fn eq(&self, other: &Self) -> bool {
-        self.name == other.name && self.inputs == other.inputs && self.outputs == other.outputs
+        self.name == other.name
+            && self.inputs == other.inputs
+            && self.outputs == other.outputs
+            && self.upgrade == other.upgrade
     }
 }
 
@@ -137,6 +160,7 @@ mod tests {
         assert_eq!(method.outputs().count(), 1);
         assert!(!method.has_no_inputs());
         assert!(!method.has_no_outputs());
+        assert!(!method.upgrade());
 
         // Check the parameters individually - order and values.
         let inputs_vec: Vec<_> = method.inputs().collect();
@@ -172,6 +196,27 @@ mod tests {
         let mut displayed = String::new();
         write!(&mut displayed, "{}", method).unwrap();
         assert_eq!(displayed, "method Register(name: string, id: string) -> ()");
+    }
+
+    #[test]
+    fn method_set_upgrade() {
+        use core::fmt::Write;
+
+        let method = Method::new("DoUpgrade", &[], &[], &[]).set_upgrade(true);
+        assert!(method.upgrade());
+
+        let mut displayed = String::new();
+        write!(&mut displayed, "{}", method).unwrap();
+        assert_eq!(displayed, "upgrade method DoUpgrade() -> ()");
+
+        // A method built without `set_upgrade` defaults to non-upgrade, and `set_upgrade(false)`
+        // is a no-op equivalent.
+        assert!(!Method::new("Plain", &[], &[], &[]).upgrade());
+        assert!(
+            !Method::new("Plain", &[], &[], &[])
+                .set_upgrade(false)
+                .upgrade()
+        );
     }
 
     #[test]

--- a/zlink-core/src/idl/parse/mod.rs
+++ b/zlink-core/src/idl/parse/mod.rs
@@ -229,6 +229,11 @@ fn parameter_list<'a>(
 fn method_def<'a>(input: &mut &'a [u8]) -> ModalResult<Method<'a>, InputError<&'a [u8]>> {
     let comments = parse_preceding_comments(input)?;
 
+    let upgrade = opt(literal("upgrade")).parse_next(input)?.is_some();
+    if upgrade {
+        take_while(1.., |c: u8| c.is_ascii_whitespace()).parse_next(input)?;
+    }
+
     literal("method").parse_next(input)?;
     take_while(1.., |c: u8| c.is_ascii_whitespace()).parse_next(input)?;
     let name = type_name(input)?;
@@ -239,12 +244,7 @@ fn method_def<'a>(input: &mut &'a [u8]) -> ModalResult<Method<'a>, InputError<&'
     ws(input)?;
     let output_params = parameter_list(input)?;
 
-    Ok(Method::new_owned(
-        name,
-        input_params,
-        output_params,
-        comments,
-    ))
+    Ok(Method::new_owned(name, input_params, output_params, comments).set_upgrade(upgrade))
 }
 
 /// Parse an error definition: error Name (fields).

--- a/zlink-core/src/idl/parse/tests.rs
+++ b/zlink-core/src/idl/parse/tests.rs
@@ -171,12 +171,29 @@ fn test_parse_method() {
     let method = parse_method(input).unwrap();
     assert_eq!(method.name(), "GetInfo");
     assert_eq!(method.inputs().count(), 0);
+    assert!(!method.upgrade());
     let mut outputs = method.outputs();
     assert_eq!(
         outputs.next().unwrap(),
         &Parameter::new("info", &Type::String, &[])
     );
     assert!(outputs.next().is_none());
+
+    // Test upgrade method
+    let input_upgrade = "upgrade method DoUpgrade() -> (success: bool)";
+    let method_upgrade = parse_method(input_upgrade).unwrap();
+    assert_eq!(method_upgrade.name(), "DoUpgrade");
+    assert!(method_upgrade.upgrade());
+    let mut outputs_upgrade = method_upgrade.outputs();
+    assert_eq!(
+        outputs_upgrade.next().unwrap(),
+        &Parameter::new("success", &Type::Bool, &[])
+    );
+    assert!(outputs_upgrade.next().is_none());
+
+    // Test round-trip Display
+    let displayed = method_upgrade.to_string();
+    assert_eq!(displayed, "upgrade method DoUpgrade() -> (success: bool)");
 
     let input = "method Add(a: int, b: int) -> (sum: int)";
     let method = parse_method(input).unwrap();

--- a/zlink-core/src/server/mod.rs
+++ b/zlink-core/src/server/mod.rs
@@ -123,16 +123,55 @@ where
                         let mut remove = true;
                         match call {
                             Ok(call) => {
+                                let is_upgrade = call.upgrade();
                                 #[cfg(feature = "std")]
-                                let result =
-                                    self.handle_call(call, &mut connections[idx], fds).await;
+                                let handles_upgrade = <Service as service::Service<Listener::Socket>>::HANDLES_UPGRADE;
                                 #[cfg(not(feature = "std"))]
-                                let result =
-                                    self.handle_call(call, &mut connections[idx]).await;
-                                match result {
-                                    Ok(None) => remove = false,
-                                    Ok(Some(s)) => stream = Some(s),
-                                    Err(e) => warn!("Error writing to connection: {:?}", e),
+                                let handles_upgrade = false;
+
+                                if is_upgrade && !handles_upgrade {
+                                    // The service doesn't support upgrades: reply with an error and
+                                    // keep the connection in JSON mode (don't hand off, don't drop
+                                    // on success). On a send failure, fall through to removal via
+                                    // the default `remove = true`.
+                                    let error = crate::varlink_service::Error::MethodNotImplemented {
+                                        method: alloc::borrow::Cow::Borrowed("upgrade"),
+                                    };
+                                    #[cfg(feature = "std")]
+                                    let send_err_res = connections[idx].send_error(&error, alloc::vec![]).await;
+                                    #[cfg(not(feature = "std"))]
+                                    let send_err_res = connections[idx].send_error(&error).await;
+                                    match send_err_res {
+                                        Ok(()) => remove = false,
+                                        Err(e) => warn!("Error sending upgrade error reply: {:?}", e),
+                                    }
+                                } else {
+                                    #[cfg(feature = "std")]
+                                    let result =
+                                        self.handle_call(call, &mut connections[idx], fds).await;
+                                    #[cfg(not(feature = "std"))]
+                                    let result =
+                                        self.handle_call(call, &mut connections[idx]).await;
+                                    match result {
+                                        Ok(None) => {
+                                            // The method's own reply has been sent. For an upgrade
+                                            // call (only reachable when the service handles it),
+                                            // hand the now-raw connection off to `on_upgrade`. In
+                                            // both cases the connection is no longer managed by the
+                                            // normal removal path below.
+                                            remove = false;
+                                            #[cfg(feature = "std")]
+                                            if is_upgrade {
+                                                let conn = connections.swap_remove(idx);
+                                                let parts = conn.into_parts();
+                                                if let Err(e) = self.service.on_upgrade(parts).await {
+                                                    warn!("Upgrade handler failed: {:?}", e);
+                                                }
+                                            }
+                                        }
+                                        Ok(Some(s)) => stream = Some(s),
+                                        Err(e) => warn!("Error writing to connection: {:?}", e),
+                                    }
                                 }
                             }
                             Err(e) => debug!("Error reading from socket: {:?}", e),

--- a/zlink-core/src/server/service.rs
+++ b/zlink-core/src/server/service.rs
@@ -95,6 +95,22 @@ where
     ) -> impl Future<
         Output = HandleResult<Self::ReplyParams<'ser>, Self::ReplyStream, Self::ReplyError<'ser>>,
     >;
+
+    /// Whether the service handles protocol upgrades.
+    #[cfg(feature = "std")]
+    const HANDLES_UPGRADE: bool = false;
+
+    /// Called when an upgrade has been successfully negotiated.
+    #[cfg(feature = "std")]
+    fn on_upgrade(
+        &mut self,
+        parts: crate::connection::ConnectionParts<Sock>,
+    ) -> impl Future<Output = crate::Result<()>> {
+        async move {
+            let _ = parts;
+            Ok(())
+        }
+    }
 }
 
 /// The result of a [`Service::handle`] call.

--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -24,8 +24,8 @@ pub(super) fn generate_chain_extension_method(
     // Check for explicit lifetimes early
     let has_explicit_lifetimes = method.sig.generics.lifetimes().next().is_some();
 
-    // Skip chain extension methods for streaming and return_fds methods.
-    if method_attrs.is_streaming || method_attrs.return_fds {
+    // Skip chain extension methods for streaming, return_fds and upgrade methods.
+    if method_attrs.is_streaming || method_attrs.return_fds || method_attrs.is_upgrade {
         return Ok((quote! {}, quote! {}));
     }
 
@@ -33,7 +33,7 @@ pub(super) fn generate_chain_extension_method(
     // Chain API requires DeserializeOwned for reply and error types.
     // Oneway methods don't have return types so this check doesn't apply to them.
     if !method_attrs.is_oneway {
-        let (reply_type, error_type) = parse_return_type(&method.sig.output, false, false)?;
+        let (reply_type, error_type) = parse_return_type(&method.sig.output, false, false, false)?;
         if type_contains_lifetime(&reply_type) || type_contains_lifetime(&error_type) {
             return Ok((quote! {}, quote! {}));
         }

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -31,7 +31,7 @@ pub(super) fn generate_chain_method(
     let has_explicit_lifetimes = method.sig.generics.lifetimes().next().is_some();
 
     // Skip chain methods for methods that return FDs since chains don't support returning FDs.
-    if method_attrs.return_fds {
+    if method_attrs.return_fds || method_attrs.is_upgrade {
         return Ok((quote! {}, quote! {}));
     }
 
@@ -40,7 +40,7 @@ pub(super) fn generate_chain_method(
     // Oneway methods don't have return types so this check doesn't apply to them.
     if !method_attrs.is_oneway {
         let (reply_type, error_type) =
-            parse_return_type(&method.sig.output, method_attrs.is_streaming, false)?;
+            parse_return_type(&method.sig.output, method_attrs.is_streaming, false, false)?;
         if type_contains_lifetime(&reply_type) || type_contains_lifetime(&error_type) {
             return Ok((quote! {}, quote! {}));
         }

--- a/zlink-macros/src/proxy/method_impl.rs
+++ b/zlink-macros/src/proxy/method_impl.rs
@@ -35,6 +35,10 @@ pub(super) fn generate_method_impl(
     // Extract data before mutable borrow
     let method_generics = method.sig.generics.clone();
     let method_output = method.sig.output.clone();
+    let is_self_by_value = match method.sig.inputs.first() {
+        Some(FnArg::Receiver(receiver)) => receiver.reference.is_none(),
+        _ => false,
+    };
 
     // Process all method arguments in a single pass
     let arg_infos = parse_method_arguments(method, has_explicit_lifetimes, param_attrs_map)?;
@@ -53,6 +57,32 @@ pub(super) fn generate_method_impl(
         return Err(Error::new_spanned(
             &method.sig,
             "method cannot be both oneway (`oneway`) and return file descriptors (`return_fds`)",
+        ));
+    }
+    if method_attrs.is_upgrade && method_attrs.is_streaming {
+        return Err(Error::new_spanned(
+            &method.sig,
+            "method cannot be both upgrade (`upgrade`) and streaming (`more`)",
+        ));
+    }
+    if method_attrs.is_upgrade && method_attrs.is_oneway {
+        return Err(Error::new_spanned(
+            &method.sig,
+            "method cannot be both upgrade (`upgrade`) and oneway (`oneway`)",
+        ));
+    }
+    if method_attrs.is_upgrade && method_attrs.return_fds {
+        return Err(Error::new_spanned(
+            &method.sig,
+            "method cannot be both upgrade (`upgrade`) and return file descriptors (`return_fds`)",
+        ));
+    }
+
+    // Validate that upgrade method takes `self` by value
+    if method_attrs.is_upgrade && !is_self_by_value {
+        return Err(Error::new_spanned(
+            &method.sig,
+            "upgrade method must take `self` by value",
         ));
     }
 
@@ -86,6 +116,7 @@ pub(super) fn generate_method_impl(
             &method_output,
             method_attrs.is_streaming,
             method_attrs.return_fds,
+            method_attrs.is_upgrade,
         )?
     };
 
@@ -165,6 +196,15 @@ pub(super) fn generate_method_impl(
             &error_type,
             out_params_extract,
             method_attrs.return_fds,
+            #[cfg(feature = "std")]
+            fds_init,
+            crate_path,
+        )
+    } else if method_attrs.is_upgrade {
+        generate_upgrade_method(
+            method_call_setup,
+            &reply_type,
+            &error_type,
             #[cfg(feature = "std")]
             fds_init,
             crate_path,
@@ -595,6 +635,32 @@ fn generate_regular_method(
             Ok(reply) => #ok_arm,
             Err(error) => #err_arm,
         }
+    };
+
+    (return_type, implementation)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn generate_upgrade_method(
+    method_call_setup: TokenStream,
+    reply_type: &Type,
+    error_type: &Type,
+    #[cfg(feature = "std")] fds_init: TokenStream,
+    crate_path: &TokenStream,
+) -> (TokenStream, TokenStream) {
+    let return_type = quote! {
+        #crate_path::Result<#crate_path::connection::UpgradeReply<Self::Socket, #reply_type, #error_type>>
+    };
+
+    #[cfg(feature = "std")]
+    let call_upgrade_args = quote! { &call, #fds_init };
+    #[cfg(not(feature = "std"))]
+    let call_upgrade_args = quote! { &call };
+
+    let implementation = quote! {
+        #method_call_setup
+        let call = #crate_path::Call::new(method_call).set_upgrade(true);
+        self.call_upgrade::<_, #reply_type, #error_type>(#call_upgrade_args).await
     };
 
     (return_type, implementation)

--- a/zlink-macros/src/proxy/types.rs
+++ b/zlink-macros/src/proxy/types.rs
@@ -13,6 +13,8 @@ pub(super) struct MethodAttrs {
     pub is_oneway: bool,
     /// Method returns file descriptors.
     pub return_fds: bool,
+    /// Method is an upgrade protocol call.
+    pub is_upgrade: bool,
 }
 
 impl MethodAttrs {
@@ -46,6 +48,12 @@ impl MethodAttrs {
                             ));
                         }
                         method_attrs.return_fds = true;
+                    }
+                    Meta::Path(path) if path.is_ident("upgrade") => {
+                        if method_attrs.is_upgrade {
+                            return Err(Error::new_spanned(&meta, "duplicate `upgrade` attribute"));
+                        }
+                        method_attrs.is_upgrade = true;
                     }
                     _ => {
                         return Err(Error::new_spanned(&meta, "unknown zlink attribute"));

--- a/zlink-macros/src/proxy/utils.rs
+++ b/zlink-macros/src/proxy/utils.rs
@@ -236,6 +236,7 @@ pub(super) fn parse_return_type(
     output: &ReturnType,
     is_streaming: bool,
     return_fds: bool,
+    is_upgrade: bool,
 ) -> Result<(Type, Type), Error> {
     match output {
         ReturnType::Default => Err(Error::new_spanned(
@@ -243,7 +244,9 @@ pub(super) fn parse_return_type(
             "proxy methods must have a return type",
         )),
         ReturnType::Type(_, ty) => {
-            if is_streaming && return_fds {
+            if is_upgrade {
+                extract_upgrade_result_types(ty)
+            } else if is_streaming && return_fds {
                 // For streaming methods with FDs, expect Result<impl Stream<Item =
                 // Result<(Result<T, E>, Vec<OwnedFd>)>>>
                 extract_streaming_with_fds_result_types(ty)
@@ -259,6 +262,68 @@ pub(super) fn parse_return_type(
             }
         }
     }
+}
+
+fn extract_upgrade_result_types(ty: &Type) -> Result<(Type, Type), Error> {
+    const ERROR_MSG: &str = "expected Result<UpgradeReply<impl Socket, ReplyParams, ReplyError>>";
+
+    let Type::Path(type_path) = ty else {
+        return Err(Error::new_spanned(ty, ERROR_MSG));
+    };
+
+    let segment = type_path
+        .path
+        .segments
+        .last()
+        .ok_or_else(|| Error::new_spanned(type_path, ERROR_MSG))?;
+
+    if segment.ident != "Result" {
+        return Err(Error::new_spanned(type_path, ERROR_MSG));
+    }
+
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return Err(Error::new_spanned(type_path, ERROR_MSG));
+    };
+
+    let GenericArgument::Type(inner_ty) = args
+        .args
+        .first()
+        .ok_or_else(|| Error::new_spanned(type_path, ERROR_MSG))?
+    else {
+        return Err(Error::new_spanned(type_path, ERROR_MSG));
+    };
+
+    let Type::Path(inner_path) = inner_ty else {
+        return Err(Error::new_spanned(inner_ty, ERROR_MSG));
+    };
+
+    let inner_segment = inner_path
+        .path
+        .segments
+        .last()
+        .ok_or_else(|| Error::new_spanned(inner_path, ERROR_MSG))?;
+
+    if inner_segment.ident != "UpgradeReply" {
+        return Err(Error::new_spanned(inner_path, ERROR_MSG));
+    }
+
+    let PathArguments::AngleBracketed(inner_args) = &inner_segment.arguments else {
+        return Err(Error::new_spanned(inner_path, ERROR_MSG));
+    };
+
+    if inner_args.args.len() < 3 {
+        return Err(Error::new_spanned(inner_path, ERROR_MSG));
+    }
+
+    let GenericArgument::Type(reply_params_ty) = &inner_args.args[1] else {
+        return Err(Error::new_spanned(inner_path, ERROR_MSG));
+    };
+
+    let GenericArgument::Type(reply_error_ty) = &inner_args.args[2] else {
+        return Err(Error::new_spanned(inner_path, ERROR_MSG));
+    };
+
+    Ok((reply_params_ty.clone(), reply_error_ty.clone()))
 }
 
 fn extract_nested_result_types(ty: &Type) -> Result<(Type, Type), Error> {

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -64,6 +64,15 @@ pub(super) fn generate_service_impl(
     let crate_path = &service_attrs.crate_path;
     let self_ty = &item_impl.self_ty;
 
+    let on_upgrade_fn = item_impl.items.iter().find_map(|item| {
+        if let syn::ImplItem::Fn(m) = item {
+            if m.sig.ident == "on_upgrade" {
+                return Some(m);
+            }
+        }
+        None
+    });
+
     // Extract the type name for generating auxiliary type names.
     // All generated types use `__` prefix to indicate they are internal implementation details.
     let type_name = extract_type_name(self_ty).unwrap_or_else(|| "Service".to_string());
@@ -240,6 +249,43 @@ pub(super) fn generate_service_impl(
     #[cfg(not(feature = "std"))]
     let handle_fds_param = quote! {};
 
+    let on_upgrade_impl = if let Some(on_upgrade_fn) = on_upgrade_fn {
+        let user_parts_arg = on_upgrade_fn.sig.inputs.iter().nth(1).ok_or_else(|| {
+            Error::new_spanned(
+                &on_upgrade_fn.sig,
+                "on_upgrade must take self and parts parameters",
+            )
+        })?;
+        let param_ident = if let syn::FnArg::Typed(pat_type) = user_parts_arg {
+            if let syn::Pat::Ident(pat_ident) = &*pat_type.pat {
+                Some(pat_ident.ident.clone())
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+        .unwrap_or_else(|| syn::Ident::new("parts", proc_macro2::Span::call_site()));
+
+        let on_upgrade_body = &on_upgrade_fn.block;
+        quote! {
+            #[cfg(feature = "std")]
+            const HANDLES_UPGRADE: bool = true;
+
+            #[cfg(feature = "std")]
+            async fn on_upgrade(
+                &mut self,
+                mut #param_ident: #crate_path::connection::ConnectionParts<#socket_ty>,
+            ) -> #crate_path::Result<()>
+            #on_upgrade_body
+        }
+    } else {
+        quote! {
+            #[cfg(feature = "std")]
+            const HANDLES_UPGRADE: bool = false;
+        }
+    };
+
     // Generate the impl block.
     let service_impl = quote! {
         impl #generics #crate_path::Service<#socket_ty> for #self_ty
@@ -251,6 +297,8 @@ pub(super) fn generate_service_impl(
             type ReplyStreamParams = #reply_stream_params_type;
             type ReplyStreamError = #reply_stream_error_ty;
             type ReplyError<'ser> = #error_type where Self: 'ser;
+
+            #on_upgrade_impl
 
             async fn handle<'__zlink_ser>(
                 &'__zlink_ser mut self,
@@ -1056,6 +1104,11 @@ fn generate_interface_descriptions(
                     }
                 });
 
+                let set_upgrade = if method.is_upgrade {
+                    quote! { .set_upgrade(true) }
+                } else {
+                    quote! {}
+                };
                 Ok(quote! {
                     const #method_const_name: &#crate_path::idl::Method<'static> = &{
                         #in_params_const
@@ -1073,7 +1126,7 @@ fn generate_interface_descriptions(
                             __IN_PARAMS,
                             __OUT_PARAMS,
                             &[],
-                        )
+                        )#set_upgrade
                     };
                 })
             })

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -41,6 +41,8 @@ pub(super) struct MethodInfo {
     pub stream_uses_impl_trait: bool,
     /// Whether this method returns file descriptors (`#[zlink(return_fds)]`).
     pub return_fds: bool,
+    /// Whether this method is an upgrade call (`#[zlink(upgrade)]`).
+    pub is_upgrade: bool,
 }
 
 impl MethodInfo {
@@ -303,6 +305,7 @@ impl MethodInfo {
             stream_return_type,
             stream_uses_impl_trait,
             return_fds,
+            is_upgrade: method_attrs.is_upgrade,
         })
     }
 
@@ -339,6 +342,8 @@ struct MethodAttrs {
     is_streaming: bool,
     /// Whether this method returns file descriptors.
     return_fds: bool,
+    /// Whether this method is an upgrade protocol call.
+    is_upgrade: bool,
 }
 
 impl MethodAttrs {
@@ -387,6 +392,11 @@ impl MethodAttrs {
                         return Err(meta.error("duplicate `return_fds` attribute"));
                     }
                     result.return_fds = true;
+                } else if meta.path.is_ident("upgrade") {
+                    if result.is_upgrade {
+                        return Err(meta.error("duplicate `upgrade` attribute"));
+                    }
+                    result.is_upgrade = true;
                 } else {
                     return Err(meta.error("unknown zlink attribute"));
                 }

--- a/zlink-macros/src/service/mod.rs
+++ b/zlink-macros/src/service/mod.rs
@@ -40,6 +40,10 @@ fn service_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Er
             continue;
         };
 
+        if method.sig.ident == "on_upgrade" {
+            continue;
+        }
+
         let method_info = MethodInfo::extract(method, &mut current_interface)?;
         methods_info.push(method_info);
     }
@@ -94,7 +98,8 @@ fn service_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Er
         let ImplItem::Fn(method) = item else {
             return true;
         };
-        !methods_with_conn.contains(&method.sig.ident.to_string())
+        let name = method.sig.ident.to_string();
+        name != "on_upgrade" && !methods_with_conn.contains(&name)
     });
 
     // Strip generics from the original impl block - they are only for the Service impl.

--- a/zlink-macros/tests/service.rs
+++ b/zlink-macros/tests/service.rs
@@ -27,3 +27,5 @@ mod streaming;
 mod streaming_errors;
 #[path = "service/streaming_fds.rs"]
 mod streaming_fds;
+#[path = "service/upgrade.rs"]
+mod upgrade;

--- a/zlink-macros/tests/service/upgrade.rs
+++ b/zlink-macros/tests/service/upgrade.rs
@@ -1,0 +1,814 @@
+//! Tests for the Varlink upgrade protocol.
+
+use std::{collections::VecDeque, os::fd::OwnedFd};
+use zlink::connection::socket::ReadHalf;
+
+// -------------------------------------------------------------
+// Helper function for reading exactly N bytes while collecting FDs
+// -------------------------------------------------------------
+pub(crate) async fn read_exact_with_fds<R: ReadHalf>(
+    read_half: &mut R,
+    read_buffer: &mut Vec<u8>,
+    received_fds: &mut VecDeque<Vec<OwnedFd>>,
+    collected_fds: &mut Vec<OwnedFd>,
+    out_buf: &mut [u8],
+) -> zlink::Result<()> {
+    let mut bytes_needed = out_buf.len();
+    let mut bytes_written = 0;
+
+    // 1. Try to consume from read_buffer first
+    if !read_buffer.is_empty() {
+        let to_take = std::cmp::min(read_buffer.len(), bytes_needed);
+        out_buf[bytes_written..bytes_written + to_take].copy_from_slice(&read_buffer[..to_take]);
+        read_buffer.drain(..to_take);
+        bytes_needed -= to_take;
+        bytes_written += to_take;
+    }
+
+    // 2. Also take any pre-received FDs from received_fds
+    while let Some(mut fds) = received_fds.pop_front() {
+        collected_fds.append(&mut fds);
+    }
+
+    // 3. Keep reading from read_half until we have enough bytes
+    while bytes_needed > 0 {
+        let mut temp_buf = vec![0u8; bytes_needed];
+        let (n, mut fds) = read_half.read(&mut temp_buf).await?;
+        if n == 0 {
+            return Err(zlink::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "unexpected EOF",
+            )));
+        }
+        out_buf[bytes_written..bytes_written + n].copy_from_slice(&temp_buf[..n]);
+        collected_fds.append(&mut fds);
+        bytes_needed -= n;
+        bytes_written += n;
+    }
+
+    Ok(())
+}
+
+mod basic_upgrade {
+    use serde::{Deserialize, Serialize};
+    use std::os::fd::OwnedFd;
+    use zlink::{
+        Server,
+        connection::socket::{ReadHalf, WriteHalf},
+        unix::{bind, connect},
+    };
+
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::CustomType)]
+    pub(crate) struct UpgradeReply {
+        pub success: bool,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::CustomType)]
+    pub(crate) struct PingReply {
+        pub pong: bool,
+    }
+
+    #[derive(Debug, Clone, PartialEq, zlink::ReplyError)]
+    #[zlink(interface = "org.example.upgrade")]
+    pub(crate) enum UpgradeError {}
+
+    // -------------------------------------------------------------
+    // 1. Service with on_upgrade implemented
+    // -------------------------------------------------------------
+    pub(crate) struct UpgradedService;
+
+    #[zlink::service(types = [UpgradeReply, PingReply])]
+    impl UpgradedService {
+        #[zlink(interface = "org.example.upgrade", upgrade)]
+        async fn do_upgrade(&self) -> UpgradeReply {
+            UpgradeReply { success: true }
+        }
+
+        #[zlink(interface = "org.example.upgrade")]
+        async fn ping(&self) -> PingReply {
+            PingReply { pong: true }
+        }
+
+        async fn on_upgrade<S: zlink::connection::Socket>(
+            &mut self,
+            mut parts: zlink::connection::ConnectionParts<S>,
+        ) -> zlink::Result<()> {
+            let mut read_half = parts.read_half;
+            let mut write_half = parts.write_half;
+
+            // Process leftovers or read from socket
+            let mut buf = [0; 4];
+            if parts.read_buffer.len() >= 4 {
+                buf.copy_from_slice(&parts.read_buffer[..4]);
+            } else {
+                let offset = parts.read_buffer.len();
+                buf[..offset].copy_from_slice(&parts.read_buffer);
+                let mut temp = vec![0; 4 - offset];
+                let (n, _fds) = read_half.read(&mut temp).await.unwrap();
+                assert_eq!(n, 4 - offset);
+                buf[offset..].copy_from_slice(&temp);
+            }
+
+            if &buf == b"ping" {
+                write_half.write(b"pong", &[] as &[OwnedFd]).await.unwrap();
+            }
+
+            Ok(())
+        }
+    }
+
+    // Client proxy
+    #[zlink::proxy("org.example.upgrade")]
+    trait UpgradeProxy {
+        #[zlink(upgrade)]
+        async fn do_upgrade(
+            self,
+        ) -> zlink::Result<zlink::connection::UpgradeReply<Self::Socket, UpgradeReply, UpgradeError>>;
+
+        async fn ping(&mut self) -> zlink::Result<Result<PingReply, UpgradeError>>;
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_successful_upgrade() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let socket_path = dir.path().join("upgrade.sock");
+
+        let listener = bind(&socket_path).unwrap();
+        let service = UpgradedService;
+        let server = Server::new(listener, service);
+
+        let client_fut = async {
+            // Connect to upgraded service
+            let conn = connect(&socket_path).await.unwrap();
+
+            // Perform the upgrade call
+            let upgrade_result = conn.do_upgrade().await.unwrap();
+            let reply = upgrade_result.reply.unwrap();
+            let params = reply.into_parameters().unwrap();
+            assert!(params.success);
+
+            // Retrieve raw socket halves from client upgrade result parts
+            let parts = upgrade_result.parts;
+            let mut read_half = parts.read_half;
+            let mut write_half = parts.write_half;
+
+            // Write raw custom protocol ping
+            write_half.write(b"ping", &[] as &[OwnedFd]).await.unwrap();
+
+            // Read raw custom protocol pong
+            let mut buf = [0; 4];
+            let (n, _fds) = read_half.read(&mut buf).await.unwrap();
+            assert_eq!(n, 4);
+            assert_eq!(&buf, b"pong");
+        };
+
+        tokio::select! {
+            res = server.run() => { if let Err(e) = res { panic!("Server failed: {:?}", e); } },
+            _ = client_fut => {},
+        }
+
+        Ok(())
+    }
+
+    // -------------------------------------------------------------
+    // 2. Service WITHOUT on_upgrade implemented (should return MethodNotImplemented)
+    // -------------------------------------------------------------
+    pub(crate) struct UnimplementedService;
+
+    #[zlink::service(types = [UpgradeReply, PingReply])]
+    impl UnimplementedService {
+        #[zlink(interface = "org.example.upgrade", upgrade)]
+        async fn do_upgrade(&self) -> UpgradeReply {
+            UpgradeReply { success: true }
+        }
+
+        #[zlink(interface = "org.example.upgrade")]
+        async fn ping(&self) -> PingReply {
+            PingReply { pong: true }
+        }
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_upgrade_not_implemented() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let socket_path = dir.path().join("unimplemented.sock");
+
+        let listener = bind(&socket_path).unwrap();
+        let service = UnimplementedService;
+        let server = Server::new(listener, service);
+
+        let client_fut = async {
+            // Connect to service
+            let mut conn = connect(&socket_path).await.unwrap();
+
+            // Manual upgrade call to avoid consuming `conn` (T2)
+            #[derive(Serialize, Debug)]
+            struct UpgradeMethodCall {
+                method: &'static str,
+            }
+
+            let call = zlink::Call::new(UpgradeMethodCall {
+                method: "org.example.upgrade.DoUpgrade",
+            })
+            .set_upgrade(true);
+
+            #[derive(Serialize, Deserialize, Debug)]
+            struct DummyUpgradeReply {}
+            #[derive(Serialize, Deserialize, Debug)]
+            struct DummyError {}
+
+            // Try to perform upgrade call - since server lacks on_upgrade, it should fail
+            // with MethodNotImplemented VarlinkService error.
+            let upgrade_result = conn
+                .call_method::<_, DummyUpgradeReply, DummyError>(&call, vec![])
+                .await;
+            assert!(upgrade_result.is_err());
+
+            let err_str = format!("{:?}", upgrade_result.unwrap_err());
+            assert!(err_str.contains("MethodNotImplemented") || err_str.contains("VarlinkService"));
+
+            // Now, verify that the SAME connection is still usable for a normal method call (T2)
+            let ping_reply = conn.ping().await.unwrap().unwrap();
+            assert!(ping_reply.pong);
+        };
+
+        tokio::select! {
+            res = server.run() => { if let Err(e) = res { panic!("Server failed: {:?}", e); } },
+            _ = client_fut => {},
+        }
+
+        Ok(())
+    }
+}
+
+mod fd_upgrade {
+    use super::read_exact_with_fds;
+    use serde::{Deserialize, Serialize};
+    use std::{
+        io::Read,
+        os::fd::OwnedFd,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+    };
+    use zlink::{
+        Server,
+        connection::socket::WriteHalf,
+        unix::{bind, connect},
+    };
+
+    // -------------------------------------------------------------
+    // 3. Service with on_upgrade that passes and validates FDs (T1)
+    // -------------------------------------------------------------
+    pub(crate) struct FdUpgradeService {
+        pub verified: Arc<AtomicBool>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::CustomType)]
+    pub(crate) struct FdUpgradeReply {
+        pub success: bool,
+    }
+
+    #[derive(Debug, Clone, PartialEq, zlink::ReplyError)]
+    #[zlink(interface = "org.example.fdupgrade")]
+    pub(crate) enum FdUpgradeError {}
+
+    #[zlink::service(types = [FdUpgradeReply])]
+    impl FdUpgradeService {
+        #[zlink(interface = "org.example.fdupgrade", upgrade)]
+        async fn do_upgrade(&self) -> FdUpgradeReply {
+            FdUpgradeReply { success: true }
+        }
+
+        async fn on_upgrade<S: zlink::connection::Socket>(
+            &mut self,
+            mut parts: zlink::connection::ConnectionParts<S>,
+        ) -> zlink::Result<()> {
+            let mut read_half = parts.read_half;
+            let mut write_half = parts.write_half;
+
+            // In this test, client does NOT pipeline, so read_buffer must be empty at start
+            assert!(
+                parts.read_buffer.is_empty(),
+                "read_buffer must be empty since client did not pipeline"
+            );
+
+            let mut collected_fds = Vec::new();
+
+            // 1. Read the 4-byte big-endian FD count. This deliberately starts the raw frame with
+            // `\0` bytes (`0x00000002` = `[0, 0, 0, 2]`) to exercise the leftover/handoff path with
+            // a `\0`-leading frame — the case the buffer-boundary logic must preserve verbatim.
+            let mut count_buf = [0u8; 4];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut collected_fds,
+                &mut count_buf,
+            )
+            .await?;
+
+            // T1: Verify big-endian framing specifically
+            let fd_count = u32::from_be_bytes(count_buf) as usize;
+            assert_eq!(fd_count, 2, "Expected exactly 2 FDs");
+
+            // 2. Read 1-byte payload length
+            let mut len_buf = [0u8; 1];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut collected_fds,
+                &mut len_buf,
+            )
+            .await?;
+
+            let payload_len = len_buf[0] as usize;
+            assert_eq!(payload_len, 12);
+
+            // 3. Read payload
+            let mut payload_buf = vec![0u8; payload_len];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut collected_fds,
+                &mut payload_buf,
+            )
+            .await?;
+
+            assert_eq!(payload_buf, b"demo-payload");
+            assert_eq!(collected_fds.len(), fd_count);
+
+            // 4. Read trailing null terminator
+            let mut term_buf = [0u8; 1];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut collected_fds,
+                &mut term_buf,
+            )
+            .await?;
+            assert_eq!(term_buf[0], 0, "Trailing terminator must be null byte");
+
+            // 5. Read from the FDs and assert their content
+            let mut stream0 = std::os::unix::net::UnixStream::from(collected_fds.remove(0));
+            let mut content0 = String::new();
+            stream0.read_to_string(&mut content0).unwrap();
+            assert_eq!(content0, "fd-payload-A");
+
+            let mut stream1 = std::os::unix::net::UnixStream::from(collected_fds.remove(0));
+            let mut content1 = String::new();
+            stream1.read_to_string(&mut content1).unwrap();
+            assert_eq!(content1, "fd-payload-B");
+
+            // 6. Write back confirmation
+            let reply_payload = b"ok";
+            let mut response = Vec::new();
+            response.extend_from_slice(&0u32.to_be_bytes());
+            response.push(reply_payload.len() as u8);
+            response.extend_from_slice(reply_payload);
+            response.push(0); // trailing null-terminator for the custom reply
+
+            write_half.write(&response, &[] as &[OwnedFd]).await?;
+
+            self.verified.store(true, Ordering::SeqCst);
+
+            Ok(())
+        }
+    }
+
+    // Client proxy for FD upgrade
+    #[zlink::proxy("org.example.fdupgrade")]
+    #[allow(unused)]
+    trait FdUpgradeProxy {
+        #[zlink(upgrade)]
+        async fn do_upgrade(
+            self,
+        ) -> zlink::Result<
+            zlink::connection::UpgradeReply<Self::Socket, FdUpgradeReply, FdUpgradeError>,
+        >;
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_upgrade_fd_passing() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let socket_path = dir.path().join("upgrade_fd.sock");
+
+        let listener = bind(&socket_path).unwrap();
+        let verified = Arc::new(AtomicBool::new(false));
+        let service = FdUpgradeService {
+            verified: verified.clone(),
+        };
+        let server = Server::new(listener, service);
+
+        let client_fut = async {
+            // Connect to upgraded service
+            let conn = connect(&socket_path).await.unwrap();
+
+            // Perform the upgrade call
+            let upgrade_result = conn.do_upgrade().await.unwrap();
+            let reply = upgrade_result.reply.unwrap();
+            let params = reply.into_parameters().unwrap();
+            assert!(params.success);
+
+            // Retrieve raw socket halves from client upgrade result parts
+            let mut parts = upgrade_result.parts;
+            let mut read_half = parts.read_half;
+            let mut write_half = parts.write_half;
+
+            // Prepare FDs to send
+            use std::io::Write;
+            let (r0, mut w0) = std::os::unix::net::UnixStream::pair().unwrap();
+            w0.write_all(b"fd-payload-A").unwrap();
+            drop(w0);
+            let fd0: OwnedFd = r0.into();
+
+            let (r1, mut w1) = std::os::unix::net::UnixStream::pair().unwrap();
+            w1.write_all(b"fd-payload-B").unwrap();
+            drop(w1);
+            let fd1: OwnedFd = r1.into();
+
+            let fds_to_send = vec![fd0, fd1];
+
+            // Build frame bytes. The frame begins with the big-endian FD count (`0x00000002` =
+            // `[0, 0, 0, 2]`), i.e. it starts with `\0` bytes — proving the upgrade handoff
+            // preserves `\0`-leading raw frames.
+            let payload = b"demo-payload";
+            let mut frame_bytes = Vec::new();
+            frame_bytes.extend_from_slice(&2u32.to_be_bytes()); // 2 FDs
+            frame_bytes.push(payload.len() as u8);
+            frame_bytes.extend_from_slice(payload);
+            frame_bytes.push(0); // trailing null-terminator
+
+            // Write raw custom protocol with FDs
+            write_half.write(&frame_bytes, &fds_to_send).await.unwrap();
+
+            // Read response
+            let mut res_collected_fds = Vec::new();
+            let mut res_count_buf = [0u8; 4];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut res_collected_fds,
+                &mut res_count_buf,
+            )
+            .await
+            .unwrap();
+
+            let res_fd_count = u32::from_be_bytes(res_count_buf);
+            assert_eq!(res_fd_count, 0);
+
+            let mut res_len_buf = [0u8; 1];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut res_collected_fds,
+                &mut res_len_buf,
+            )
+            .await
+            .unwrap();
+
+            let res_payload_len = res_len_buf[0] as usize;
+            assert_eq!(res_payload_len, 2);
+
+            let mut res_payload_buf = vec![0u8; res_payload_len];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut res_collected_fds,
+                &mut res_payload_buf,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(res_payload_buf, b"ok");
+
+            let mut res_term_buf = [0u8; 1];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut res_collected_fds,
+                &mut res_term_buf,
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                res_term_buf[0], 0,
+                "Custom reply trailing terminator must be null byte"
+            );
+        };
+
+        tokio::select! {
+            res = server.run() => { if let Err(e) = res { panic!("Server failed: {:?}", e); } },
+            _ = client_fut => {},
+        }
+
+        assert!(
+            verified.load(Ordering::SeqCst),
+            "Server should have verified the FDs and their contents"
+        );
+
+        Ok(())
+    }
+}
+
+mod pipelined_upgrade {
+    use super::read_exact_with_fds;
+    use serde::{Deserialize, Serialize};
+    use std::{
+        collections::VecDeque,
+        os::fd::OwnedFd,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+    };
+    use zlink::{
+        Server,
+        connection::{
+            Socket,
+            socket::{ReadHalf, WriteHalf},
+        },
+        unix::bind,
+    };
+
+    // -------------------------------------------------------------
+    // 4. Service for verifying pipelined leftover-buffer handoff (T3)
+    // -------------------------------------------------------------
+    pub(crate) struct PipelinedUpgradeService {
+        pub verified: Arc<AtomicBool>,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::CustomType)]
+    pub(crate) struct PipelinedReply {
+        pub success: bool,
+    }
+
+    #[derive(Debug, Clone, PartialEq, zlink::ReplyError)]
+    #[zlink(interface = "org.example.pipelined")]
+    #[allow(dead_code)]
+    pub(crate) enum PipelinedError {}
+
+    #[zlink::service(types = [PipelinedReply])]
+    impl PipelinedUpgradeService {
+        #[zlink(interface = "org.example.pipelined", upgrade)]
+        async fn do_upgrade(&self) -> PipelinedReply {
+            PipelinedReply { success: true }
+        }
+
+        async fn on_upgrade<S: zlink::connection::Socket>(
+            &mut self,
+            mut parts: zlink::connection::ConnectionParts<S>,
+        ) -> zlink::Result<()> {
+            let mut read_half = parts.read_half;
+            let mut write_half = parts.write_half;
+
+            // T3: Assert that read_buffer is NOT empty (because client pipelined the custom frame
+            // right after upgrade request)
+            assert!(
+                !parts.read_buffer.is_empty(),
+                "Pipelined bytes must be present in read_buffer"
+            );
+            // Frame = BE u32 count (4) + payload len (1) + "demo-payload" (12) + `\0` (1) = 18.
+            assert_eq!(
+                parts.read_buffer.len(),
+                18,
+                "Should have exactly 18 leftover bytes"
+            );
+            // The leftover frame starts with the big-endian count `0x00000000` = `[0, 0, 0, 0]`,
+            // i.e. with `\0` bytes — exactly the case the boundary logic must preserve verbatim.
+            assert_eq!(
+                &parts.read_buffer[..4],
+                &[0, 0, 0, 0],
+                "Leftover frame must start with the `\\0`-leading BE count, intact"
+            );
+
+            let mut collected_fds = Vec::new();
+
+            // Read 4-byte BE count
+            let mut count_buf = [0u8; 4];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut collected_fds,
+                &mut count_buf,
+            )
+            .await?;
+            let fd_count = u32::from_be_bytes(count_buf) as usize;
+            assert_eq!(fd_count, 0, "No FDs in pipelined test");
+
+            // Read 1-byte payload length
+            let mut len_buf = [0u8; 1];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut collected_fds,
+                &mut len_buf,
+            )
+            .await?;
+            let payload_len = len_buf[0] as usize;
+            assert_eq!(payload_len, 12);
+
+            // Read payload
+            let mut payload_buf = vec![0u8; payload_len];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut collected_fds,
+                &mut payload_buf,
+            )
+            .await?;
+            assert_eq!(payload_buf, b"demo-payload");
+
+            // Read trailing null terminator
+            let mut term_buf = [0u8; 1];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut parts.read_buffer,
+                &mut parts.received_fds,
+                &mut collected_fds,
+                &mut term_buf,
+            )
+            .await?;
+            assert_eq!(term_buf[0], 0, "Trailing terminator must be null byte");
+
+            // Write back confirmation
+            let reply_payload = b"ok";
+            let mut response = Vec::new();
+            response.extend_from_slice(&0u32.to_be_bytes());
+            response.push(reply_payload.len() as u8);
+            response.extend_from_slice(reply_payload);
+            response.push(0);
+
+            write_half.write(&response, &[] as &[OwnedFd]).await?;
+
+            self.verified.store(true, Ordering::SeqCst);
+
+            Ok(())
+        }
+    }
+
+    #[zlink::proxy("org.example.pipelined")]
+    #[allow(unused)]
+    trait PipelinedProxy {
+        #[zlink(upgrade)]
+        async fn do_upgrade(
+            self,
+        ) -> zlink::Result<
+            zlink::connection::UpgradeReply<Self::Socket, PipelinedReply, PipelinedError>,
+        >;
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread"))]
+    async fn test_upgrade_pipelining() -> Result<(), Box<dyn std::error::Error>> {
+        let dir = tempfile::tempdir()?;
+        let socket_path = dir.path().join("upgrade_pipelined.sock");
+
+        let listener = bind(&socket_path).unwrap();
+        let verified = Arc::new(AtomicBool::new(false));
+        let service = PipelinedUpgradeService {
+            verified: verified.clone(),
+        };
+        let server = Server::new(listener, service);
+
+        let client_fut = async {
+            // This test deliberately bypasses the `Connection`/`call_upgrade` client API and writes
+            // raw bytes to a `UnixStream`. The point is *pipelining*: sending the upgrade call and
+            // the first raw post-upgrade frame in a single write, before the server has replied.
+            // `call_upgrade` can't express that — it sends the call, awaits exactly one reply, and
+            // only then hands back the raw socket halves. Pipelining ahead of the reply is what
+            // leaves `\0`-leading raw bytes buffered in the server's reader, which is the handoff
+            // path under test.
+            let stream = tokio::net::UnixStream::connect(&socket_path).await.unwrap();
+            let socket = zlink::unix::Stream::from(stream);
+            let (mut read_half, mut write_half) = socket.split();
+
+            // 1. Serialize the upgrade call exactly as the wire format expects, then append the
+            //    `\0` Varlink message terminator by hand (we're framing the bytes ourselves here).
+            #[derive(Serialize, Debug)]
+            struct UpgradeMethodCall {
+                method: &'static str,
+            }
+            let call = zlink::Call::new(UpgradeMethodCall {
+                method: "org.example.pipelined.DoUpgrade",
+            })
+            .set_upgrade(true);
+            let mut data = serde_json::to_vec(&call).unwrap();
+            data.push(0); // Varlink message terminator.
+
+            // Pipelined custom protocol frame. It starts with the big-endian count `0x00000000` =
+            // `[0, 0, 0, 0]`, i.e. with `\0` bytes, immediately after the upgrade call's `\0`
+            // terminator — exercising the `\0`-leading leftover handoff path.
+            let payload = b"demo-payload";
+            data.extend_from_slice(&0u32.to_be_bytes()); // 0 FDs
+            data.push(payload.len() as u8);
+            data.extend_from_slice(payload);
+            data.push(0); // trailing terminator to satisfy Varlink null-termination
+
+            // Send all bytes at once (pipelining)!
+            write_half.write(&data, &[] as &[OwnedFd]).await.unwrap();
+
+            // Read upgrade reply from server
+            let mut reply_buf = vec![0u8; 1024];
+            let (n, _fds) = read_half.read(&mut reply_buf).await.unwrap();
+
+            // Find the boundary of the Varlink reply (first null terminator)
+            let first_null_idx = reply_buf[..n]
+                .iter()
+                .position(|&b| b == 0)
+                .expect("Should find null terminator");
+            let end_idx = first_null_idx + 1;
+
+            let varlink_reply_bytes = &reply_buf[..end_idx];
+            let custom_bytes = &reply_buf[end_idx..n];
+
+            // Verify the Varlink reply
+            let reply_str = std::str::from_utf8(varlink_reply_bytes).unwrap();
+            assert!(reply_str.contains("\"success\":true"));
+
+            // Verify the custom protocol response in custom_bytes
+            let mut client_read_buffer = custom_bytes.to_vec();
+            let mut client_received_fds = VecDeque::new();
+            let mut client_collected_fds = Vec::new();
+
+            // Read custom confirmation BE count
+            let mut res_count_buf = [0u8; 4];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut client_read_buffer,
+                &mut client_received_fds,
+                &mut client_collected_fds,
+                &mut res_count_buf,
+            )
+            .await
+            .unwrap();
+
+            let res_fd_count = u32::from_be_bytes(res_count_buf);
+            assert_eq!(res_fd_count, 0);
+
+            let mut res_len_buf = [0u8; 1];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut client_read_buffer,
+                &mut client_received_fds,
+                &mut client_collected_fds,
+                &mut res_len_buf,
+            )
+            .await
+            .unwrap();
+
+            let res_payload_len = res_len_buf[0] as usize;
+            assert_eq!(res_payload_len, 2);
+
+            let mut res_payload_buf = vec![0u8; res_payload_len];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut client_read_buffer,
+                &mut client_received_fds,
+                &mut client_collected_fds,
+                &mut res_payload_buf,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(res_payload_buf, b"ok");
+
+            let mut res_term_buf = [0u8; 1];
+            read_exact_with_fds(
+                &mut read_half,
+                &mut client_read_buffer,
+                &mut client_received_fds,
+                &mut client_collected_fds,
+                &mut res_term_buf,
+            )
+            .await
+            .unwrap();
+            assert_eq!(
+                res_term_buf[0], 0,
+                "Custom reply trailing terminator must be null byte"
+            );
+        };
+
+        tokio::select! {
+            res = server.run() => { if let Err(e) = res { panic!("Server failed: {:?}", e); } },
+            _ = client_fut => {},
+        }
+
+        assert!(
+            verified.load(Ordering::SeqCst),
+            "Server should have verified the pipelined leftover bytes"
+        );
+
+        Ok(())
+    }
+}

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -10,8 +10,9 @@ authors.workspace = true
 
 [features]
 default = ["tokio", "service", "proxy", "tracing"]
-tokio = ["dep:zlink-tokio"]
-smol = ["dep:zlink-smol"]
+std = []
+tokio = ["dep:zlink-tokio", "std"]
+smol = ["dep:zlink-smol", "std"]
 server = ["zlink-tokio?/server", "zlink-smol?/server"]
 proxy = ["zlink-tokio?/proxy", "zlink-smol?/proxy"]
 service = ["server", "introspection", "zlink-tokio?/service", "zlink-smol?/service"]

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -51,6 +51,7 @@ tempfile = "3.8"
 serde_json = "1.0"
 tracing-subscriber = "0.3.19"
 rustix = { version = "1.1.2", features = ["process"] }
+rand = "0.9"
 
 [[example]]
 name = "varlink-inspect"

--- a/zlink/tests/upgrade_fd_e2e.rs
+++ b/zlink/tests/upgrade_fd_e2e.rs
@@ -1,0 +1,330 @@
+//! Realistic end-to-end test: "log tail attach" combining zlink's upgrade
+//! feature with out-of-band file-descriptor passing.
+//!
+//! The scenario mirrors how systemd services hand off file descriptors after a
+//! Varlink method call (e.g. machined's `Open` returning a `ptyFileDescriptor`):
+//!
+//!   1. The client connects over a real Unix domain socket to a real tokio server task and first
+//!      performs a *normal* Varlink call, `Stats()`, to prove ordinary request/response framing
+//!      works on the connection.
+//!   2. The client then calls the `upgrade` method `Attach(name)`. After the reply, the connection
+//!      switches to a raw binary protocol.
+//!   3. In its `on_upgrade` handler the server materializes a *random* number (1-5) of temp files
+//!      with random small sizes (0-100 bytes each) into real `std::fs::File`s, converts each into
+//!      an `OwnedFd`, and sends a single raw frame of two big-endian `u32`s — the fd count and the
+//!      combined byte total — followed by NO inline payload. The file contents travel *out of band*
+//!      as ancillary data (SCM_RIGHTS); the receiver gets the open file descriptors themselves.
+//!   4. The client reads the two `u32`s, collects exactly `fd_count` descriptors, reads every one
+//!      to EOF, and asserts the combined byte count read back through the fds equals the announced
+//!      total. Random counts/sizes (including possibly-empty files) exercise multi-fd passing
+//!      rather than a single hard-coded payload.
+
+#![cfg(all(feature = "service", feature = "introspection", feature = "proxy"))]
+
+use std::{
+    collections::VecDeque,
+    io::{Read, Seek, Write},
+    os::fd::OwnedFd,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+};
+
+use rand::{Rng, RngCore};
+use serde::{Deserialize, Serialize};
+use zlink::{
+    Server,
+    connection::socket::{ReadHalf, WriteHalf},
+    unix::{bind, connect},
+};
+
+/// Single-byte request the client sends over the upgraded connection to ask the
+/// server to hand off the logs. Making the raw protocol client-initiated avoids
+/// pipelining raw bytes into the same burst as the Varlink upgrade reply (which
+/// the framing layer expects to end the burst with a `\0`).
+const REQ_BYTE: u8 = 0x05;
+
+// -------------------------------------------------------------------------
+// Wire types for the `org.example.LogService` interface.
+// -------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::CustomType)]
+struct StatsReply {
+    #[serde(rename = "lineCount")]
+    line_count: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, zlink::introspect::CustomType)]
+struct AttachReply {
+    ready: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError, zlink::introspect::ReplyError)]
+#[zlink(interface = "org.example.LogService")]
+enum LogError {
+    /// The requested log stream does not exist.
+    NotFound,
+}
+
+// -------------------------------------------------------------------------
+// Helper: read exactly `out_buf.len()` bytes from the upgraded read half while
+// collecting any ancillary file descriptors. Leftover bytes/fds buffered during
+// the Varlink phase (`read_buffer` / `received_fds`) are drained first.
+// -------------------------------------------------------------------------
+async fn read_exact_with_fds<R: ReadHalf>(
+    read_half: &mut R,
+    read_buffer: &mut Vec<u8>,
+    received_fds: &mut VecDeque<Vec<OwnedFd>>,
+    collected_fds: &mut Vec<OwnedFd>,
+    out_buf: &mut [u8],
+) -> zlink::Result<()> {
+    // `rest` always points at the still-unfilled tail of `out_buf`. Each step fills a prefix and
+    // re-slices `rest` to the remainder via `split_at_mut`, so there's no manual index arithmetic
+    // (and thus no room for an off-by-one slice panic).
+    let mut rest = out_buf;
+
+    // Consume any leftover bytes buffered during the Varlink phase first.
+    if !read_buffer.is_empty() {
+        let to_take = read_buffer.len().min(rest.len());
+        let (head, tail) = rest.split_at_mut(to_take);
+        head.copy_from_slice(&read_buffer[..to_take]);
+        read_buffer.drain(..to_take);
+        rest = tail;
+    }
+
+    // Take any fds that arrived alongside those leftover bytes.
+    while let Some(mut fds) = received_fds.pop_front() {
+        collected_fds.append(&mut fds);
+    }
+
+    // Read the rest straight off the socket, gathering fds as they arrive. Reading directly into
+    // `rest` means the socket can never write past the buffer.
+    while !rest.is_empty() {
+        let (n, mut fds) = read_half.read(rest).await?;
+        collected_fds.append(&mut fds);
+        if n == 0 {
+            return Err(zlink::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::UnexpectedEof,
+                "unexpected EOF during upgraded read",
+            )));
+        }
+        // `read` reports bytes written into `rest`, so `n <= rest.len()`; clamp defensively so a
+        // misbehaving impl can never make the re-slice below panic.
+        let (_filled, tail) = rest.split_at_mut(n.min(rest.len()));
+        rest = tail;
+    }
+
+    Ok(())
+}
+
+// -------------------------------------------------------------------------
+// The logging service.
+// -------------------------------------------------------------------------
+
+/// Number of log lines the service reports via the normal `Stats` method.
+const STATS_LINE_COUNT: i64 = 4;
+
+struct LogService {
+    /// Set once `on_upgrade` has handed off the fds, so the test can assert the
+    /// server actually reached the upgrade path.
+    served: Arc<AtomicBool>,
+    /// The combined byte total the server actually generated and announced, so
+    /// the test can sanity-check it against the size read back through the fds.
+    total_served: Arc<AtomicU64>,
+}
+
+#[zlink::service(types = [StatsReply, AttachReply])]
+impl LogService {
+    /// Normal Varlink method, exercised before the upgrade to prove ordinary
+    /// request/response framing works on the connection.
+    #[zlink(interface = "org.example.LogService")]
+    async fn stats(&self) -> Result<StatsReply, LogError> {
+        Ok(StatsReply {
+            line_count: STATS_LINE_COUNT,
+        })
+    }
+
+    /// Upgrade method: the client asks to attach to a named log stream. After
+    /// the reply the connection switches to the raw fd-passing protocol handled
+    /// in `on_upgrade`.
+    #[zlink(interface = "org.example.LogService", upgrade)]
+    async fn attach(&self, name: String) -> Result<AttachReply, LogError> {
+        if name == "main" {
+            Ok(AttachReply { ready: true })
+        } else {
+            Err(LogError::NotFound)
+        }
+    }
+
+    async fn on_upgrade<S: zlink::connection::Socket>(
+        &mut self,
+        mut parts: zlink::connection::ConnectionParts<S>,
+    ) -> zlink::Result<()> {
+        let mut read_half = parts.read_half;
+        let mut write_half = parts.write_half;
+
+        // The raw protocol is client-initiated: wait for the client's request
+        // byte before sending anything. This guarantees the client has already
+        // consumed the Varlink upgrade reply, so our raw frame is never mixed
+        // into the same read burst as that reply.
+        let mut req = [0u8; 1];
+        let (n, _fds) = read_half.read(&mut req).await?;
+        if n != 1 || req[0] != REQ_BYTE {
+            return Err(zlink::Error::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "client did not send the expected request byte",
+            )));
+        }
+
+        // Materialize a random number of small temp files with random sizes, then hand off their
+        // open descriptors. Reading the bytes back through the received fds is what proves the
+        // out-of-band transfer worked, and the random multiplicity exercises multi-fd passing.
+        let mut rng = rand::rng();
+        let fd_count = rng.random_range(1..=5u32);
+
+        let mut fds: Vec<OwnedFd> = Vec::with_capacity(fd_count as usize);
+        let mut total: u64 = 0;
+        for _ in 0..fd_count {
+            let size = rng.random_range(0..=100usize); // deliberately allows empty files.
+            // Random bytes so a mis-routed or truncated fd would be noticeable.
+            let mut contents = vec![0u8; size];
+            rng.fill_bytes(&mut contents);
+
+            let mut file = tempfile::tempfile().expect("create temp file");
+            file.write_all(&contents).expect("write temp file");
+            file.flush().expect("flush temp file");
+            file.rewind().expect("rewind temp file");
+
+            total += size as u64;
+            fds.push(OwnedFd::from(file));
+        }
+
+        // The wire frame is two big-endian u32s — the fd count and the combined byte total — with
+        // no inline payload; the bytes themselves ride along as the passed descriptors
+        // (SCM_RIGHTS).
+        let mut frame = Vec::with_capacity(8);
+        frame.extend_from_slice(&fd_count.to_be_bytes());
+        frame.extend_from_slice(&(total as u32).to_be_bytes());
+        write_half.write(&frame, &fds).await?;
+
+        self.total_served.store(total, Ordering::SeqCst);
+        self.served.store(true, Ordering::SeqCst);
+
+        Ok(())
+    }
+}
+
+// -------------------------------------------------------------------------
+// Client proxy.
+// -------------------------------------------------------------------------
+
+#[zlink::proxy("org.example.LogService")]
+trait LogProxy {
+    async fn stats(&mut self) -> zlink::Result<Result<StatsReply, LogError>>;
+
+    #[zlink(upgrade)]
+    async fn attach(
+        self,
+        name: &str,
+    ) -> zlink::Result<zlink::connection::UpgradeReply<Self::Socket, AttachReply, LogError>>;
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn log_tail_attach() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("logservice.sock");
+
+    let listener = bind(&socket_path)?;
+    let served = Arc::new(AtomicBool::new(false));
+    let total_served = Arc::new(AtomicU64::new(0));
+    let service = LogService {
+        served: served.clone(),
+        total_served: total_served.clone(),
+    };
+    let server = Server::new(listener, service);
+
+    let client_fut = async {
+        let mut conn = connect(&socket_path).await.unwrap();
+
+        // 1. Prove normal Varlink works before upgrading. `attach` consumes the connection, so
+        //    `stats` must run on `&mut conn` first.
+        let stats = conn.stats().await.unwrap().unwrap();
+        assert_eq!(stats.line_count, STATS_LINE_COUNT);
+
+        // 2. Upgrade: attach to the "main" log stream.
+        let res = conn.attach("main").await.unwrap();
+        let reply = res.reply.unwrap();
+        let params = reply.into_parameters().unwrap();
+        assert!(params.ready);
+
+        // 3. Switch to the raw protocol: read the two-u32 header frame plus the fds.
+        let mut parts = res.parts;
+        let mut read_half = parts.read_half;
+        let mut write_half = parts.write_half;
+        let mut collected_fds = Vec::new();
+
+        // Ask the server (over the raw protocol) to hand off the logs.
+        write_half
+            .write(&[REQ_BYTE], &[] as &[OwnedFd])
+            .await
+            .unwrap();
+
+        // Header: big-endian [fd_count, total_size].
+        let mut header = [0u8; 8];
+        read_exact_with_fds(
+            &mut read_half,
+            &mut parts.read_buffer,
+            &mut parts.received_fds,
+            &mut collected_fds,
+            &mut header,
+        )
+        .await
+        .unwrap();
+        let announced_fd_count = u32::from_be_bytes(header[..4].try_into().unwrap()) as usize;
+        let announced_total = u32::from_be_bytes(header[4..].try_into().unwrap()) as u64;
+
+        assert_eq!(
+            collected_fds.len(),
+            announced_fd_count,
+            "received fd count must match the announced count"
+        );
+        assert!(
+            (1..=5).contains(&announced_fd_count),
+            "server should hand off 1-5 fds, got {announced_fd_count}"
+        );
+
+        // 4. Read every received fd to EOF and sum the bytes; the combined total read back out of
+        //    band must equal what the server announced.
+        let mut combined = 0u64;
+        for fd in collected_fds.drain(..) {
+            let mut file = std::fs::File::from(fd);
+            let mut contents = Vec::new();
+            let n = file.read_to_end(&mut contents).unwrap();
+            assert_eq!(n, contents.len());
+            combined += n as u64;
+        }
+
+        assert_eq!(
+            combined, announced_total,
+            "combined bytes read through the fds must equal the announced total"
+        );
+    };
+
+    tokio::select! {
+        res = server.run() => { if let Err(e) = res { panic!("Server failed: {e:?}"); } },
+        _ = client_fut => {},
+    }
+
+    assert!(
+        served.load(Ordering::SeqCst),
+        "server should have served the log fds via on_upgrade"
+    );
+    // The total must fit the u32 wire field given the size bounds (max 5 * 100 = 500 bytes).
+    assert!(
+        total_served.load(Ordering::SeqCst) <= 5 * 100,
+        "server total exceeds the documented size bounds"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The Varlink spec lets a method set `upgrade: true`, after which the
server sends a single reply and both ends hand the connection off to a
custom, non-Varlink protocol (typically to speak a binary protocol
for large data or pass file decriptors).

Add support for this. If a server doesn't opt-in to upgrade
handling, we default to returning an error.

Assisted-by: OpenCode (Various models)
Signed-off-by: Colin Walters <walters@verbum.org>