### PR TITLE
🔧 Replace hardcoded /tmp socket paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,6 +557,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -607,7 +628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -736,6 +757,17 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -930,7 +962,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -975,6 +1007,15 @@ name = "libc"
 version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+
+[[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1038,7 +1079,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1073,6 +1114,12 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking"
@@ -1243,6 +1290,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,7 +1339,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1494,10 +1552,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1736,7 +1794,7 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.4",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -1847,7 +1905,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2140,6 +2198,7 @@ version = "0.6.0"
 dependencies = [
  "clap",
  "colored 3.0.0",
+ "dirs",
  "futures-util",
  "rustix",
  "serde",

--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ macros:
 
 ```rust
 use serde::{Deserialize, Serialize};
-use tokio::{select, sync::oneshot, fs::remove_file};
+use std::path::Path;
+use tokio::{select, sync::oneshot};
 use zlink::{introspect, proxy, service, unix, ReplyError, Server};
 
 #[tokio::main]
@@ -57,21 +58,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a channel to signal when server is ready.
     let (ready_tx, ready_rx) = oneshot::channel();
 
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("calculator.sock");
+
     // Run server and client concurrently.
     select! {
-        res = run_server(ready_tx) => res?,
-        res = run_client(ready_rx) => res?,
+        res = run_server(&socket_path, ready_tx) => res?,
+        res = run_client(&socket_path, ready_rx) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(ready_rx: oneshot::Receiver<()>) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(
+    socket_path: &Path,
+    ready_rx: oneshot::Receiver<()>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Wait for server to be ready.
     ready_rx.await.map_err(|_| "Server failed to start")?;
 
     // Connect to the calculator service.
-    let mut conn = unix::connect(SOCKET_PATH).await?;
+    let mut conn = unix::connect(socket_path).await?;
 
     // Use the proxy-generated methods.
     let result = conn.add(5.0, 3.0).await?.unwrap();
@@ -149,11 +156,12 @@ enum CalculatorError<'a> {
     },
 }
 
-async fn run_server(ready_tx: oneshot::Sender<()>) -> Result<(), Box<dyn std::error::Error>> {
-    let _ = remove_file(SOCKET_PATH).await;
-
+async fn run_server(
+    socket_path: &Path,
+    ready_tx: oneshot::Sender<()>,
+) -> Result<(), Box<dyn std::error::Error>> {
     // Setup and run the server.
-    let listener = unix::bind(SOCKET_PATH)?;
+    let listener = unix::bind(socket_path)?;
     let server = Server::new(listener, Calculator::new());
 
     // Signal that server is ready.
@@ -216,8 +224,6 @@ impl Calculator {
         }
     }
 }
-
-const SOCKET_PATH: &str = "/tmp/calculator_example.varlink";
 ```
 
 > **Note**: Typically you would want to spawn the server in a separate task but that's not what we
@@ -275,8 +281,12 @@ use zlink::{proxy, unix, ReplyError};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Connect to a batch processing service
-    let mut conn = unix::connect("/tmp/batch_processor.varlink").await?;
+    // Connect to a batch processing service in the XDG runtime dir
+    // (e.g. /run/user/1000/batch_processor.varlink).
+    let socket_path = dirs::runtime_dir()
+        .ok_or("XDG_RUNTIME_DIR is not set")?
+        .join("batch_processor.varlink");
+    let mut conn = unix::connect(&socket_path).await?;
 
     // Send multiple pipelined requests without waiting for responses.
     // Note: chain methods are only generated for proxy methods with owned return types.

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1351,9 +1351,9 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///
 /// # tokio::runtime::Runtime::new().unwrap().block_on(async {
 /// // Server setup.
-/// let socket_path = "/tmp/zlink-service-example.sock";
-/// let _ = std::fs::remove_file(socket_path);
-/// let listener = bind(socket_path)?;
+/// let dir = tempfile::tempdir()?;
+/// let socket_path = dir.path().join("service-example.sock");
+/// let listener = bind(&socket_path)?;
 /// let service = BankAccount::new(1000);
 /// let server = Server::new(listener, service);
 ///
@@ -1361,7 +1361,7 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// tokio::select! {
 ///     res = server.run() => res?,
 ///     res = async {
-///         let mut conn = connect(socket_path).await?;
+///         let mut conn = connect(&socket_path).await?;
 ///
 ///         // Check initial balance.
 ///         let balance = conn.get_balance().await?.unwrap();

--- a/zlink-macros/tests/service/streaming_errors.rs
+++ b/zlink-macros/tests/service/streaming_errors.rs
@@ -13,24 +13,20 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn streaming_errors() -> Result<(), Box<dyn std::error::Error>> {
-    let socket_path = "/tmp/zlink-service-macro-streaming-errors-test.sock";
-    if let Err(e) = tokio::fs::remove_file(socket_path).await {
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
 
-    let listener = bind(socket_path).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let server = Server::new(listener, CountingService);
     tokio::select! {
         res = server.run() => res?,
-        res = run_client(socket_path) => res?,
+        res = run_client(&socket_path) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(socket_path: &str) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
     let mut conn = connect(socket_path).await?;
 
     // First call: `to = 3`, expect three success ticks then end-of-stream.

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -47,6 +47,7 @@ futures-util = { version = "0.3.31", default-features = false, features = [
 clap = { version = "4.0", features = ["derive"] }
 colored = "3.0"
 tempfile = "3.8"
+dirs = "6.0"
 serde_json = "1.0"
 tracing-subscriber = "0.3.19"
 rustix = { version = "1.1.2", features = ["process"] }

--- a/zlink/tests/ftl.rs
+++ b/zlink/tests/ftl.rs
@@ -18,13 +18,8 @@ use zlink::{
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn ftl() -> Result<(), Box<dyn std::error::Error>> {
-    // Remove the socket file if it exists (from a previous run of this test).
-    if let Err(e) = tokio::fs::remove_file(SOCKET_PATH).await {
-        // It's OK if the file doesn't exist.
-        if e.kind() != std::io::ErrorKind::NotFound {
-            return Err(e.into());
-        }
-    }
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join(SOCKET_FILE);
 
     // The transitions between the drive conditions.
     let conditions = [
@@ -43,25 +38,28 @@ async fn ftl() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     // Setup the server and run it in a separate task.
-    let listener = bind(SOCKET_PATH).unwrap();
+    let listener = bind(&socket_path).unwrap();
     let service = Ftl::new(conditions[0]);
     let server = zlink::Server::new(listener, service);
     select! {
         res = server.run() => res?,
-        res = run_client(&conditions) => res?,
+        res = run_client(&socket_path, &conditions) => res?,
     }
 
     Ok(())
 }
 
-async fn run_client(conditions: &[DriveCondition]) -> Result<(), Box<dyn std::error::Error>> {
+async fn run_client(
+    socket_path: &std::path::Path,
+    conditions: &[DriveCondition],
+) -> Result<(), Box<dyn std::error::Error>> {
     // Now create a client connection that monitors changes in the drive condition.
-    let mut conn = connect(SOCKET_PATH).await?;
+    let mut conn = connect(socket_path).await?;
     let mut drive_monitor_stream = pin!(conn.get_drive_condition().await?);
 
     // And a client that only calls methods.
     {
-        let mut conn = connect(SOCKET_PATH).await?;
+        let mut conn = connect(socket_path).await?;
 
         // Let's start with some introspection.
         let info = conn.get_info().await?.map_err(|e| e.to_string())?;
@@ -513,8 +511,7 @@ async fn reply_error_derive_works() {
 // Constants
 // ============================================================================
 
-const SOCKET_PATH: &str = "/tmp/zlink-ftl.sock";
-
+const SOCKET_FILE: &str = "zlink-ftl.sock";
 const VENDOR: &str = "The FL project";
 const PRODUCT: &str = "FTL-capable Spaceship \u{1F680}";
 const VERSION: &str = "1";


### PR DESCRIPTION
Several tests and examples bound Unix sockets at hardcoded paths in /tmp, which is racy: parallel test runs or multiple checkouts collide on the same socket name. Give each its own path instead.

However for non-test examples, I think it's better to use $XDG_RUNTIME_DIR which is more realistic than `/tmp`. Add the `dirs` crate as a dev-dependency since this is just a compile-only test.

Assisted-by: OpenCode (Claude Opus 4.8)
