### PR TITLE
Pass credentials over Unix sockets

### DIFF
--- a/zlink-core/benches/benchmarks.rs
+++ b/zlink-core/benches/benchmarks.rs
@@ -438,6 +438,9 @@ impl WriteHalf for BiPipeWriteHalf {
         &mut self,
         buf: &[u8],
         #[cfg(feature = "std")] _fds: &[impl std::os::fd::AsFd],
+        #[cfg(all(feature = "std", target_os = "linux"))] _credentials: Option<
+            &zlink_core::connection::PassedCredentials,
+        >,
     ) -> zlink_core::Result<()> {
         self.sender
             .send(buf.to_vec())

--- a/zlink-core/benches/benchmarks.rs
+++ b/zlink-core/benches/benchmarks.rs
@@ -407,10 +407,7 @@ impl ReadHalf for BiPipeReadHalf {
             let to_read = (self.buffer.len() - self.pos).min(buf.len());
             buf[..to_read].copy_from_slice(&self.buffer[self.pos..self.pos + to_read]);
             self.pos += to_read;
-            #[cfg(feature = "std")]
-            return Ok((to_read, vec![]));
-            #[cfg(not(feature = "std"))]
-            return Ok(to_read);
+            return Ok(zlink_core::connection::socket::ReadResult::new(to_read));
         }
 
         // Otherwise, wait for new data.
@@ -421,16 +418,11 @@ impl ReadHalf for BiPipeReadHalf {
                 let to_read = self.buffer.len().min(buf.len());
                 buf[..to_read].copy_from_slice(&self.buffer[..to_read]);
                 self.pos = to_read;
-                #[cfg(feature = "std")]
-                return Ok((to_read, vec![]));
-                #[cfg(not(feature = "std"))]
-                return Ok(to_read);
+                return Ok(zlink_core::connection::socket::ReadResult::new(to_read));
             }
             None => {
-                #[cfg(feature = "std")]
-                return Ok((0, vec![])); // Connection closed.
-                #[cfg(not(feature = "std"))]
-                return Ok(0); // Connection closed.
+                // Connection closed.
+                return Ok(zlink_core::connection::socket::ReadResult::new(0));
             }
         }
     }

--- a/zlink-core/src/connection/chain/mod.rs
+++ b/zlink-core/src/connection/chain/mod.rs
@@ -633,8 +633,22 @@ mod tests {
         }
 
         impl WriteHalf for TrackingWriteHalf {
-            async fn write(&mut self, buf: &[u8], fds: &[impl AsFd]) -> crate::Result<()> {
-                self.mock.write(buf, fds).await
+            async fn write(
+                &mut self,
+                buf: &[u8],
+                fds: &[impl AsFd],
+                #[cfg(target_os = "linux")] credentials: Option<
+                    &crate::connection::PassedCredentials,
+                >,
+            ) -> crate::Result<()> {
+                self.mock
+                    .write(
+                        buf,
+                        fds,
+                        #[cfg(target_os = "linux")]
+                        credentials,
+                    )
+                    .await
             }
         }
 

--- a/zlink-core/src/connection/credentials.rs
+++ b/zlink-core/src/connection/credentials.rs
@@ -76,7 +76,8 @@ pub struct PassedCredentials {
 }
 
 impl PassedCredentials {
-    pub(crate) fn new(unix_user_id: Uid, unix_primary_group_id: Gid, process_id: Pid) -> Self {
+    /// Create a new `PassedCredentials` instance.
+    pub fn new(unix_user_id: Uid, unix_primary_group_id: Gid, process_id: Pid) -> Self {
         Self {
             unix_user_id,
             unix_primary_group_id,

--- a/zlink-core/src/connection/credentials.rs
+++ b/zlink-core/src/connection/credentials.rs
@@ -5,11 +5,9 @@ use super::{Gid, Pid, Uid};
 /// Credentials of a peer connection.
 #[derive(Debug)]
 pub struct Credentials {
-    unix_user_id: Uid,
-    unix_primary_group_id: Gid,
+    basic: PassedCredentials,
     #[cfg(target_os = "linux")]
     unix_supplementary_group_ids: Vec<Gid>,
-    process_id: Pid,
     #[cfg(target_os = "linux")]
     process_fd: std::os::fd::OwnedFd,
 }
@@ -17,18 +15,14 @@ pub struct Credentials {
 impl Credentials {
     /// Create new credentials for a peer connection.
     pub(crate) fn new(
-        unix_user_id: Uid,
-        unix_primary_group_id: Gid,
+        basic: PassedCredentials,
         #[cfg(target_os = "linux")] unix_supplementary_group_ids: Vec<Gid>,
-        process_id: Pid,
         #[cfg(target_os = "linux")] process_fd: std::os::fd::OwnedFd,
     ) -> Self {
         Self {
-            unix_user_id,
-            unix_primary_group_id,
+            basic,
             #[cfg(target_os = "linux")]
             unix_supplementary_group_ids,
-            process_id,
             #[cfg(target_os = "linux")]
             process_fd,
         }
@@ -36,19 +30,19 @@ impl Credentials {
 
     /// The numeric Unix user ID, as defined by POSIX.
     pub fn unix_user_id(&self) -> Uid {
-        self.unix_user_id
+        self.basic.unix_user_id
     }
 
     /// The numeric process ID, on platforms that have this concept.
     ///
     /// On Unix, this is the process ID defined by POSIX.
     pub fn process_id(&self) -> Pid {
-        self.process_id
+        self.basic.process_id
     }
 
     /// The numeric Unix group ID, as defined by POSIX.
     pub fn unix_primary_group_id(&self) -> Gid {
-        self.unix_primary_group_id
+        self.basic.unix_primary_group_id
     }
 
     /// The set of numeric supplementary Unix group IDs, as defined by POSIX.
@@ -70,5 +64,40 @@ impl Credentials {
         use std::os::fd::AsFd;
 
         self.process_fd.as_fd()
+    }
+}
+
+/// Credentials passed over of socket.
+#[derive(Debug)]
+pub struct PassedCredentials {
+    unix_user_id: Uid,
+    unix_primary_group_id: Gid,
+    process_id: Pid,
+}
+
+impl PassedCredentials {
+    pub(crate) fn new(unix_user_id: Uid, unix_primary_group_id: Gid, process_id: Pid) -> Self {
+        Self {
+            unix_user_id,
+            unix_primary_group_id,
+            process_id,
+        }
+    }
+
+    /// The numeric Unix user ID, as defined by POSIX.
+    pub fn unix_user_id(&self) -> Uid {
+        self.unix_user_id
+    }
+
+    /// The numeric process ID, on platforms that have this concept.
+    ///
+    /// On Unix, this is the process ID defined by POSIX.
+    pub fn process_id(&self) -> Pid {
+        self.process_id
+    }
+
+    /// The numeric Unix group ID, as defined by POSIX.
+    pub fn unix_primary_group_id(&self) -> Gid {
+        self.unix_primary_group_id
     }
 }

--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -666,6 +666,14 @@ where
     {
         self.read.received_credentials()
     }
+
+    /// Set the credentials to send with all subsequent writes.
+    ///
+    /// This is only available for `std` feature and `linux` target.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub fn set_credentials(&mut self, credentials: Option<PassedCredentials>) {
+        self.write.set_credentials(credentials);
+    }
 }
 
 impl<S> From<S> for Connection<S>

--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -47,6 +47,8 @@ mod credentials;
 mod read_connection;
 #[cfg(feature = "std")]
 pub use credentials::Credentials;
+#[cfg(feature = "std")]
+pub use credentials::PassedCredentials;
 pub use read_connection::ReadConnection;
 #[cfg(feature = "std")]
 pub use rustix::{process::Gid, process::Pid, process::Uid};

--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -657,6 +657,15 @@ where
         // method doesn't error out.
         Ok(self.credentials.as_ref().unwrap())
     }
+
+    /// The credentials passed through over the socket with the latest message (if any).
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub fn received_credentials(&self) -> Option<&std::sync::Arc<PassedCredentials>>
+    where
+        S::ReadHalf: socket::UnixSocket,
+    {
+        self.read.received_credentials()
+    }
 }
 
 impl<S> From<S> for Connection<S>

--- a/zlink-core/src/connection/read_connection.rs
+++ b/zlink-core/src/connection/read_connection.rs
@@ -203,11 +203,17 @@ impl<Read: ReadHalf> ReadConnection<Read> {
 
         loop {
             let result = self.socket.read(&mut self.buffer[self.read_pos..]).await?;
+            #[cfg(all(feature = "std", target_os = "linux"))]
+            let mut result = result;
 
             if result.bytes_read() == 0 {
                 return Err(crate::Error::UnexpectedEof);
             }
             self.read_pos += result.bytes_read();
+            #[cfg(all(feature = "std", target_os = "linux"))]
+            if let Some(creds) = result.take_credentials() {
+                self.received_credentials = Some(std::sync::Arc::new(creds));
+            }
             #[cfg(feature = "std")]
             if !result.fds().is_empty() {
                 self.pending_fds.push_back(result.into_fds());

--- a/zlink-core/src/connection/read_connection.rs
+++ b/zlink-core/src/connection/read_connection.rs
@@ -2,6 +2,8 @@
 
 use core::{fmt::Debug, str::from_utf8_unchecked};
 
+#[cfg(all(feature = "std", target_os = "linux"))]
+use crate::connection::PassedCredentials;
 use crate::{Result, varlink_service};
 
 use super::{
@@ -43,6 +45,8 @@ pub struct ReadConnection<Read: ReadHalf> {
     // `WriteConnection::held_fds` on macOS. See that field's comment for details.
     #[cfg(all(feature = "std", target_os = "macos"))]
     pub(super) fd_recvs: usize,
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    received_credentials: Option<std::sync::Arc<PassedCredentials>>,
 }
 
 impl<Read: ReadHalf> ReadConnection<Read> {
@@ -58,6 +62,8 @@ impl<Read: ReadHalf> ReadConnection<Read> {
             pending_fds: VecDeque::new(),
             #[cfg(all(feature = "std", target_os = "macos"))]
             fd_recvs: 0,
+            #[cfg(all(feature = "std", target_os = "linux"))]
+            received_credentials: None,
         }
     }
 
@@ -237,5 +243,14 @@ impl<Read: ReadHalf> ReadConnection<Read> {
     /// The underlying read half of the socket.
     pub fn read_half(&self) -> &Read {
         &self.socket
+    }
+
+    /// The credentials passed through over the socket with the latest message (if any).
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub fn received_credentials(&self) -> Option<&std::sync::Arc<PassedCredentials>>
+    where
+        Read: super::socket::UnixSocket,
+    {
+        self.received_credentials.as_ref()
     }
 }

--- a/zlink-core/src/connection/read_connection.rs
+++ b/zlink-core/src/connection/read_connection.rs
@@ -196,18 +196,15 @@ impl<Read: ReadHalf> ReadConnection<Read> {
         }
 
         loop {
-            #[cfg(feature = "std")]
-            let (bytes_read, fds) = self.socket.read(&mut self.buffer[self.read_pos..]).await?;
-            #[cfg(not(feature = "std"))]
-            let bytes_read = self.socket.read(&mut self.buffer[self.read_pos..]).await?;
+            let result = self.socket.read(&mut self.buffer[self.read_pos..]).await?;
 
-            if bytes_read == 0 {
+            if result.bytes_read() == 0 {
                 return Err(crate::Error::UnexpectedEof);
             }
-            self.read_pos += bytes_read;
+            self.read_pos += result.bytes_read();
             #[cfg(feature = "std")]
-            if !fds.is_empty() {
-                self.pending_fds.push_back(fds);
+            if !result.fds().is_empty() {
+                self.pending_fds.push_back(result.into_fds());
                 // Track receipt so `Connection` can drain `WriteConnection::held_fds`.
                 #[cfg(target_os = "macos")]
                 {

--- a/zlink-core/src/connection/socket.rs
+++ b/zlink-core/src/connection/socket.rs
@@ -5,20 +5,6 @@ use core::future::Future;
 #[cfg(feature = "std")]
 use std::os::fd::{AsFd, OwnedFd};
 
-/// Result type for [`ReadHalf::read`] operations.
-///
-/// With `std` feature: returns `(usize, Vec<OwnedFd>)` - bytes read and file descriptors.
-/// Without `std` feature: returns `usize` - just bytes read.
-#[cfg(feature = "std")]
-pub type ReadResult = (usize, alloc::vec::Vec<OwnedFd>);
-
-/// Result type for [`ReadHalf::read`] operations.
-///
-/// With `std` feature: returns `(usize, Vec<OwnedFd>)` - bytes read and file descriptors.
-/// Without `std` feature: returns `usize` - just bytes read.
-#[cfg(not(feature = "std"))]
-pub type ReadResult = usize;
-
 /// The socket trait.
 ///
 /// This is the trait that needs to be implemented for a type to be used as a socket/transport.
@@ -142,5 +128,64 @@ pub mod impl_for_doc {
         ) -> crate::Result<()> {
             unreachable!("This is only for doc tests")
         }
+    }
+}
+
+/// Result type for [`ReadHalf::read`] operations.
+#[derive(Debug)]
+pub struct ReadResult {
+    /// The number of bytes read.
+    bytes_read: usize,
+    /// The file descriptors received, if any. This is only available with the `std` feature.
+    #[cfg(feature = "std")]
+    fds: alloc::vec::Vec<OwnedFd>,
+}
+
+impl ReadResult {
+    /// Creates a new `ReadResult` with the given number of bytes read.
+    #[doc(hidden)]
+    pub fn new(bytes_read: usize) -> Self {
+        Self {
+            bytes_read,
+            #[cfg(feature = "std")]
+            fds: vec![],
+        }
+    }
+
+    /// The number of bytes read.
+    pub fn bytes_read(&self) -> usize {
+        self.bytes_read
+    }
+
+    /// The file descriptors received, if any. This is only available with the `std` feature.
+    #[cfg(feature = "std")]
+    pub fn fds(&self) -> &[OwnedFd] {
+        &self.fds
+    }
+
+    /// Sets the file descriptors received, if any. This is only available with the `std` feature.
+    #[cfg(feature = "std")]
+    #[doc(hidden)]
+    pub fn set_fds<F>(mut self, fds: F) -> Self
+    where
+        F: Into<alloc::vec::Vec<OwnedFd>>,
+    {
+        self.fds = fds.into();
+
+        self
+    }
+
+    /// Takes the file descriptors received, leaving an empty list in their place. This is only
+    /// available with the `std` feature.
+    #[cfg(feature = "std")]
+    pub fn take_fds(&mut self) -> alloc::vec::Vec<OwnedFd> {
+        core::mem::take(&mut self.fds)
+    }
+
+    /// Consumes this `ReadResult` and returns the file descriptors received, if any. This is only
+    /// available with the `std` feature.
+    #[cfg(feature = "std")]
+    pub fn into_fds(self) -> alloc::vec::Vec<OwnedFd> {
+        self.fds
     }
 }

--- a/zlink-core/src/connection/socket.rs
+++ b/zlink-core/src/connection/socket.rs
@@ -139,6 +139,10 @@ pub struct ReadResult {
     /// The file descriptors received, if any. This is only available with the `std` feature.
     #[cfg(feature = "std")]
     fds: alloc::vec::Vec<OwnedFd>,
+    /// The credentials received, if any. This is only available with the `std` feature and `linux`
+    /// target.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    credentials: Option<crate::connection::PassedCredentials>,
 }
 
 impl ReadResult {
@@ -149,6 +153,8 @@ impl ReadResult {
             bytes_read,
             #[cfg(feature = "std")]
             fds: vec![],
+            #[cfg(all(feature = "std", target_os = "linux"))]
+            credentials: None,
         }
     }
 
@@ -163,6 +169,13 @@ impl ReadResult {
         &self.fds
     }
 
+    /// The credentials received, if any. This is only available with the `std` feature and `linux`
+    /// target.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub fn credentials(&self) -> Option<&crate::connection::PassedCredentials> {
+        self.credentials.as_ref()
+    }
+
     /// Sets the file descriptors received, if any. This is only available with the `std` feature.
     #[cfg(feature = "std")]
     #[doc(hidden)]
@@ -171,6 +184,19 @@ impl ReadResult {
         F: Into<alloc::vec::Vec<OwnedFd>>,
     {
         self.fds = fds.into();
+
+        self
+    }
+
+    /// Sets the credentials received, if any. This is only available with the `std` feature and
+    /// `linux` target.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    #[doc(hidden)]
+    pub fn set_credentials(
+        mut self,
+        credentials: Option<crate::connection::PassedCredentials>,
+    ) -> Self {
+        self.credentials = credentials;
 
         self
     }
@@ -187,5 +213,19 @@ impl ReadResult {
     #[cfg(feature = "std")]
     pub fn into_fds(self) -> alloc::vec::Vec<OwnedFd> {
         self.fds
+    }
+
+    /// Takes the credentials received, leaving `None` in their place. This is only available with
+    /// the `std` feature and `linux` target.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub fn take_credentials(&mut self) -> Option<crate::connection::PassedCredentials> {
+        self.credentials.take()
+    }
+
+    /// Consumes this `ReadResult` and returns the credentials received, if any. This is only
+    /// available with the `std` feature and `linux` target.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub fn into_credentials(self) -> Option<crate::connection::PassedCredentials> {
+        self.credentials
     }
 }

--- a/zlink-core/src/connection/socket.rs
+++ b/zlink-core/src/connection/socket.rs
@@ -51,6 +51,9 @@ pub trait WriteHalf: core::fmt::Debug {
         &mut self,
         buf: &[u8],
         #[cfg(feature = "std")] fds: &[impl AsFd],
+        #[cfg(all(feature = "std", target_os = "linux"))] credentials: Option<
+            &crate::connection::PassedCredentials,
+        >,
     ) -> impl Future<Output = crate::Result<()>>;
 }
 
@@ -125,6 +128,9 @@ pub mod impl_for_doc {
             &mut self,
             _buf: &[u8],
             #[cfg(feature = "std")] _fds: &[impl super::AsFd],
+            #[cfg(all(feature = "std", target_os = "linux"))] _credentials: Option<
+                &crate::connection::PassedCredentials,
+            >,
         ) -> crate::Result<()> {
             unreachable!("This is only for doc tests")
         }

--- a/zlink-core/src/connection/tests/chain_fds_tests.rs
+++ b/zlink-core/src/connection/tests/chain_fds_tests.rs
@@ -415,8 +415,20 @@ struct TrackingWriteHalf {
 }
 
 impl WriteHalf for TrackingWriteHalf {
-    async fn write(&mut self, buf: &[u8], fds: &[impl AsFd]) -> Result<()> {
-        self.mock.write(buf, fds).await
+    async fn write(
+        &mut self,
+        buf: &[u8],
+        fds: &[impl AsFd],
+        #[cfg(target_os = "linux")] credentials: Option<&crate::connection::PassedCredentials>,
+    ) -> Result<()> {
+        self.mock
+            .write(
+                buf,
+                fds,
+                #[cfg(target_os = "linux")]
+                credentials,
+            )
+            .await
     }
 }
 
@@ -435,7 +447,12 @@ struct WriteOperationTracker {
 }
 
 impl WriteHalf for WriteOperationTracker {
-    async fn write(&mut self, buf: &[u8], fds: &[impl AsFd]) -> Result<()> {
+    async fn write(
+        &mut self,
+        buf: &[u8],
+        fds: &[impl AsFd],
+        #[cfg(target_os = "linux")] credentials: Option<&crate::connection::PassedCredentials>,
+    ) -> Result<()> {
         // Record this write operation.
         self.operations.push(WriteOperation {
             data: buf.to_vec(),
@@ -443,6 +460,13 @@ impl WriteHalf for WriteOperationTracker {
         });
 
         // Also write to the mock for actual functionality.
-        self.mock.write(buf, fds).await
+        self.mock
+            .write(
+                buf,
+                fds,
+                #[cfg(target_os = "linux")]
+                credentials,
+            )
+            .await
     }
 }

--- a/zlink-core/src/connection/tests/mod.rs
+++ b/zlink-core/src/connection/tests/mod.rs
@@ -7,5 +7,7 @@ mod chain_fds_tests;
 mod connection_tests;
 #[cfg(feature = "std")]
 mod read_connection_fds_tests;
+#[cfg(all(feature = "std", target_os = "linux"))]
+mod write_connection_credentials_tests;
 #[cfg(feature = "std")]
 mod write_connection_fds_tests;

--- a/zlink-core/src/connection/tests/write_connection_credentials_tests.rs
+++ b/zlink-core/src/connection/tests/write_connection_credentials_tests.rs
@@ -1,0 +1,63 @@
+//! Unit tests for WriteConnection credential passing.
+
+#![cfg(all(test, target_os = "linux"))]
+
+use crate::{
+    Call,
+    connection::{PassedCredentials, write_connection::WriteConnection},
+    test_utils::mock_socket::MockWriteHalf,
+};
+use rustix::process::{Gid, Pid, Uid};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "method", content = "parameters")]
+enum TestMethod {
+    #[serde(rename = "org.example.Test")]
+    Test { value: u32 },
+}
+
+fn sample_creds() -> PassedCredentials {
+    // SAFETY: 1 is a valid PID.
+    let pid = Pid::from_raw(1).unwrap();
+    PassedCredentials::new(Uid::ROOT, Gid::ROOT, pid)
+}
+
+#[tokio::test]
+async fn no_credentials_by_default() {
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+    let call = Call::new(TestMethod::Test { value: 1 });
+
+    write_conn.send_call(&call, vec![]).await.unwrap();
+
+    assert!(write_conn.write_half().credentials_written().is_empty());
+}
+
+#[tokio::test]
+async fn credentials_sent_after_set() {
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+    write_conn.set_credentials(Some(sample_creds()));
+
+    let call = Call::new(TestMethod::Test { value: 1 });
+    write_conn.send_call(&call, vec![]).await.unwrap();
+
+    let written = write_conn.write_half().credentials_written();
+    assert_eq!(written.len(), 1);
+    assert_eq!(written[0].unix_user_id(), Uid::ROOT);
+}
+
+#[tokio::test]
+async fn credentials_cleared_on_set_none() {
+    let mut write_conn = WriteConnection::new(MockWriteHalf::new(), 0);
+    write_conn.set_credentials(Some(sample_creds()));
+
+    let call = Call::new(TestMethod::Test { value: 1 });
+    write_conn.send_call(&call, vec![]).await.unwrap();
+
+    write_conn.set_credentials(None);
+    write_conn.send_call(&call, vec![]).await.unwrap();
+
+    let written = write_conn.write_half().credentials_written();
+    // Only the first call should have recorded credentials.
+    assert_eq!(written.len(), 1);
+}

--- a/zlink-core/src/connection/write_connection.rs
+++ b/zlink-core/src/connection/write_connection.rs
@@ -28,6 +28,8 @@ pub struct WriteConnection<Write: WriteHalf> {
     id: usize,
     #[cfg(feature = "std")]
     pending_fds: VecDeque<MessageFds>,
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    credentials: Option<crate::connection::PassedCredentials>,
     // On macOS, SCM_RIGHTS does not properly hold a reference to the underlying file description
     // when the sender closes the FD in the same process before the receiver calls `recvmsg`. The
     // receiver ends up with a stale FD. We work around this by keeping sent FDs alive until the
@@ -46,6 +48,8 @@ impl<Write: WriteHalf> WriteConnection<Write> {
             pos: 0,
             #[cfg(feature = "std")]
             pending_fds: VecDeque::new(),
+            #[cfg(all(feature = "std", target_os = "linux"))]
+            credentials: None,
             #[cfg(all(feature = "std", target_os = "macos"))]
             held_fds: VecDeque::new(),
         }
@@ -203,7 +207,12 @@ impl<Write: WriteHalf> WriteConnection<Write> {
                         fd_offset - sent_pos
                     );
                     self.socket
-                        .write(&self.buffer[sent_pos..fd_offset], &[] as &[OwnedFd])
+                        .write(
+                            &self.buffer[sent_pos..fd_offset],
+                            &[] as &[OwnedFd],
+                            #[cfg(target_os = "linux")]
+                            self.credentials.as_ref(),
+                        )
                         .await?;
                 }
 
@@ -221,7 +230,12 @@ impl<Write: WriteHalf> WriteConnection<Write> {
                     fds.len()
                 );
                 self.socket
-                    .write(&self.buffer[fd_offset..msg_end], &fds)
+                    .write(
+                        &self.buffer[fd_offset..msg_end],
+                        &fds,
+                        #[cfg(target_os = "linux")]
+                        self.credentials.as_ref(),
+                    )
                     .await?;
                 sent_pos = msg_end;
 
@@ -242,7 +256,12 @@ impl<Write: WriteHalf> WriteConnection<Write> {
             #[cfg(feature = "std")]
             {
                 self.socket
-                    .write(&self.buffer[sent_pos..self.pos], &[] as &[OwnedFd])
+                    .write(
+                        &self.buffer[sent_pos..self.pos],
+                        &[] as &[OwnedFd],
+                        #[cfg(target_os = "linux")]
+                        self.credentials.as_ref(),
+                    )
                     .await?;
             }
             #[cfg(not(feature = "std"))]
@@ -258,6 +277,14 @@ impl<Write: WriteHalf> WriteConnection<Write> {
     /// The underlying write half of the socket.
     pub fn write_half(&self) -> &Write {
         &self.socket
+    }
+
+    /// Set the credentials to send with all subsequent writes.
+    ///
+    /// This is only available for `std` feature and `linux` target.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub fn set_credentials(&mut self, credentials: Option<crate::connection::PassedCredentials>) {
+        self.credentials = credentials;
     }
 
     pub(super) async fn write<T>(

--- a/zlink-core/src/test_utils/mock_socket.rs
+++ b/zlink-core/src/test_utils/mock_socket.rs
@@ -89,6 +89,8 @@ impl Socket for MockSocket {
                 written: Vec::new(),
                 #[cfg(feature = "std")]
                 fds_written: RefCell::new(Vec::new()),
+                #[cfg(all(feature = "std", target_os = "linux"))]
+                credentials_written: Vec::new(),
             },
         )
     }
@@ -208,6 +210,8 @@ pub struct MockWriteHalf {
     written: Vec<u8>,
     #[cfg(feature = "std")]
     fds_written: RefCell<Vec<Vec<OwnedFd>>>,
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    credentials_written: Vec<crate::connection::PassedCredentials>,
 }
 
 impl MockWriteHalf {
@@ -217,6 +221,8 @@ impl MockWriteHalf {
         Self {
             written: Vec::new(),
             fds_written: RefCell::new(Vec::new()),
+            #[cfg(all(feature = "std", target_os = "linux"))]
+            credentials_written: Vec::new(),
         }
     }
 
@@ -236,6 +242,12 @@ impl MockWriteHalf {
     pub fn fd_write_count(&self) -> usize {
         self.fds_written.borrow().len()
     }
+
+    /// All credentials that have been written.
+    #[cfg(all(feature = "std", target_os = "linux"))]
+    pub fn credentials_written(&self) -> &[crate::connection::PassedCredentials] {
+        &self.credentials_written
+    }
 }
 
 #[cfg(feature = "std")]
@@ -250,6 +262,9 @@ impl WriteHalf for MockWriteHalf {
         &mut self,
         buf: &[u8],
         #[cfg(feature = "std")] fds: &[impl std::os::fd::AsFd],
+        #[cfg(all(feature = "std", target_os = "linux"))] credentials: Option<
+            &crate::connection::PassedCredentials,
+        >,
     ) -> crate::Result<()> {
         self.written.extend_from_slice(buf);
 
@@ -268,6 +283,18 @@ impl WriteHalf for MockWriteHalf {
                     })
                     .collect::<crate::Result<Vec<_>>>()?;
                 self.fds_written.borrow_mut().push(owned_fds);
+            }
+
+            #[cfg(target_os = "linux")]
+            if let Some(credentials) = credentials {
+                // `PassedCredentials` doesn't implement `Clone`, so reconstruct from its fields.
+                // This is fine for test-only code.
+                self.credentials_written
+                    .push(crate::connection::PassedCredentials::new(
+                        credentials.unix_user_id(),
+                        credentials.unix_primary_group_id(),
+                        credentials.process_id(),
+                    ));
             }
         }
 
@@ -328,6 +355,9 @@ impl WriteHalf for TestWriteHalf {
         &mut self,
         buf: &[u8],
         #[cfg(feature = "std")] fds: &[impl std::os::fd::AsFd],
+        #[cfg(all(feature = "std", target_os = "linux"))] _credentials: Option<
+            &crate::connection::PassedCredentials,
+        >,
     ) -> crate::Result<()> {
         assert_eq!(buf.len(), self.expected_len);
 
@@ -379,6 +409,9 @@ impl WriteHalf for CountingWriteHalf {
         &mut self,
         _buf: &[u8],
         #[cfg(feature = "std")] _fds: &[impl std::os::fd::AsFd],
+        #[cfg(all(feature = "std", target_os = "linux"))] _credentials: Option<
+            &crate::connection::PassedCredentials,
+        >,
     ) -> crate::Result<()> {
         self.count += 1;
         Ok(())
@@ -421,7 +454,15 @@ mod tests {
         let (r1, _w1) = UnixStream::pair().unwrap();
         let borrowed = r1.as_fd();
 
-        write.write(b"test", &[borrowed]).await.unwrap();
+        write
+            .write(
+                b"test",
+                &[borrowed],
+                #[cfg(target_os = "linux")]
+                None,
+            )
+            .await
+            .unwrap();
 
         assert_eq!(write.written_data(), b"test");
         assert_eq!(write.fd_write_count(), 1);
@@ -439,7 +480,15 @@ mod tests {
         let (r2, _w2) = UnixStream::pair().unwrap();
         let borrowed = [r1.as_fd(), r2.as_fd()];
 
-        write.write(b"test", &borrowed).await.unwrap();
+        write
+            .write(
+                b"test",
+                &borrowed,
+                #[cfg(target_os = "linux")]
+                None,
+            )
+            .await
+            .unwrap();
 
         assert_eq!(write.write_count(), 1);
     }
@@ -455,7 +504,15 @@ mod tests {
         let borrowed = [r1.as_fd()];
 
         // This should panic because we expect 2 FDs but provide 1.
-        write.write(b"test", &borrowed).await.unwrap();
+        write
+            .write(
+                b"test",
+                &borrowed,
+                #[cfg(target_os = "linux")]
+                None,
+            )
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/zlink-core/src/test_utils/mock_socket.rs
+++ b/zlink-core/src/test_utils/mock_socket.rs
@@ -6,7 +6,7 @@
 
 #[cfg(feature = "std")]
 use crate::connection;
-use crate::connection::socket::{ReadHalf, Socket, WriteHalf};
+use crate::connection::socket::{ReadHalf, ReadResult, Socket, WriteHalf};
 use alloc::vec::Vec;
 #[cfg(feature = "std")]
 use core::cell::RefCell;
@@ -120,13 +120,10 @@ impl MockReadHalf {
 
 impl ReadHalf for MockReadHalf {
     #[cfg(feature = "std")]
-    async fn read(
-        &mut self,
-        buf: &mut [u8],
-    ) -> crate::Result<(usize, alloc::vec::Vec<std::os::fd::OwnedFd>)> {
+    async fn read(&mut self, buf: &mut [u8]) -> crate::Result<ReadResult> {
         // No more messages - EOF.
         if self.msg_index >= self.messages.len() {
-            return Ok((0, Vec::new()));
+            return Ok(ReadResult::new(0));
         }
 
         let msg = &self.messages[self.msg_index];
@@ -149,14 +146,14 @@ impl ReadHalf for MockReadHalf {
             Vec::new()
         };
 
-        Ok((to_read, fds))
+        Ok(ReadResult::new(to_read).set_fds(fds))
     }
 
     #[cfg(not(feature = "std"))]
-    async fn read(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
+    async fn read(&mut self, buf: &mut [u8]) -> crate::Result<ReadResult> {
         // No more messages - EOF.
         if self.msg_index >= self.messages.len() {
-            return Ok(0);
+            return Ok(ReadResult::new(0));
         }
 
         let msg = &self.messages[self.msg_index];
@@ -171,7 +168,7 @@ impl ReadHalf for MockReadHalf {
             self.pos_in_msg = 0;
         }
 
-        Ok(to_read)
+        Ok(ReadResult::new(to_read))
     }
 }
 
@@ -406,13 +403,13 @@ mod tests {
         let (mut read, _write) = socket.split();
 
         let mut buf = [0u8; 10]; // Small buffer to force multiple reads
-        let (bytes, fds1) = read.read(&mut buf).await.unwrap();
-        assert!(bytes > 0);
-        assert_eq!(fds1.len(), 1);
+        let result = read.read(&mut buf).await.unwrap();
+        assert!(result.bytes_read() > 0);
+        assert_eq!(result.fds().len(), 1);
 
-        let (bytes, fds2) = read.read(&mut buf).await.unwrap();
-        assert!(bytes > 0);
-        assert_eq!(fds2.len(), 1);
+        let result = read.read(&mut buf).await.unwrap();
+        assert!(result.bytes_read() > 0);
+        assert_eq!(result.fds().len(), 1);
     }
 
     #[tokio::test]
@@ -475,9 +472,9 @@ mod tests {
         let (mut read, _write) = socket.split();
 
         let mut buf = [0u8; 1024];
-        let (bytes, fds) = read.read(&mut buf).await.unwrap();
-        assert!(bytes > 0);
-        assert_eq!(fds.len(), 3);
+        let result = read.read(&mut buf).await.unwrap();
+        assert!(result.bytes_read() > 0);
+        assert_eq!(result.fds().len(), 3);
     }
 
     #[tokio::test]
@@ -493,12 +490,12 @@ mod tests {
 
         let mut buf = [0u8; 10]; // Small buffer to force multiple reads
 
-        let (bytes, fds1) = read.read(&mut buf).await.unwrap();
-        assert!(bytes > 0);
-        assert!(!fds1.is_empty());
+        let result = read.read(&mut buf).await.unwrap();
+        assert!(result.bytes_read() > 0);
+        assert!(!result.fds().is_empty());
 
-        let (bytes, fds2) = read.read(&mut buf).await.unwrap();
-        assert!(bytes > 0);
-        assert!(fds2.is_empty());
+        let result = read.read(&mut buf).await.unwrap();
+        assert!(result.bytes_read() > 0);
+        assert!(result.fds().is_empty());
     }
 }

--- a/zlink-core/src/test_utils/mock_socket.rs
+++ b/zlink-core/src/test_utils/mock_socket.rs
@@ -186,17 +186,17 @@ impl connection::socket::FetchPeerCredentials for MockReadHalf {
 
             let process_fd = rustix::process::pidfd_open(pid, PidfdFlags::empty())?;
             Ok(connection::Credentials::new(
-                uid,
-                gid,
+                connection::PassedCredentials::new(uid, gid, pid),
                 vec![],
-                pid,
                 process_fd,
             ))
         }
 
         #[cfg(not(target_os = "linux"))]
         {
-            Ok(connection::Credentials::new(uid, gid, pid))
+            Ok(connection::Credentials::new(
+                connection::PassedCredentials::new(uid, gid, pid),
+            ))
         }
     }
 }

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -57,6 +57,15 @@ pub fn recvmsg(fd: impl AsFd, buf: &mut [u8]) -> io::Result<ReadResult> {
         .map_err(io::Error::from)
 }
 
+/// Enable receiving of peer credentials (`SO_PASSCRED`) on the given unix socket.
+///
+/// Without this, the kernel discards any `SCM_CREDENTIALS` ancillary data sent by the peer.
+#[cfg(target_os = "linux")]
+#[doc(hidden)]
+pub fn enable_passcred(fd: impl AsFd) -> io::Result<()> {
+    rustix::net::sockopt::set_socket_passcred(fd.as_fd(), true).map_err(io::Error::from)
+}
+
 /// Send a message to a Unix socket, including any file descriptors.
 ///
 /// This is a low-level helper that performs the `sendmsg` syscall.

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -11,7 +11,7 @@ use std::{
     os::fd::{AsFd, BorrowedFd},
 };
 
-use crate::connection::{Credentials, socket::ReadResult};
+use crate::connection::{Credentials, PassedCredentials, socket::ReadResult};
 
 /// Receive a message from a Unix socket, including any file descriptors.
 ///
@@ -175,9 +175,13 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
         };
 
         #[cfg(target_os = "android")]
-        let creds = Credentials::new(uid, primary_gid, pid);
+        let creds = Credentials::new(PassedCredentials::new(uid, primary_gid, pid));
         #[cfg(target_os = "linux")]
-        let creds = Credentials::new(uid, primary_gid, supplementary_gids, pid, process_fd);
+        let creds = Credentials::new(
+            PassedCredentials::new(uid, primary_gid, pid),
+            supplementary_gids,
+            process_fd,
+        );
 
         Ok(creds)
     }
@@ -298,7 +302,7 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
         #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))]
         let pid = rustix::process::Pid::from_raw(0).unwrap();
 
-        Ok(Credentials::new(uid, gid, pid))
+        Ok(Credentials::new(PassedCredentials::new(uid, gid, pid)))
     }
 
     #[cfg(not(any(

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -21,22 +21,36 @@ pub fn recvmsg(fd: impl AsFd, buf: &mut [u8]) -> io::Result<ReadResult> {
     use rustix::net::{RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, recvmsg};
     use std::io::IoSliceMut;
 
+    #[cfg(target_os = "linux")]
+    let mut cmsg_buf =
+        [MaybeUninit::<u8>::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS), ScmCredentials(1))];
+    #[cfg(not(target_os = "linux"))]
     let mut cmsg_buf = [MaybeUninit::<u8>::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS))];
     let mut control = RecvAncillaryBuffer::new(&mut cmsg_buf);
 
     let mut iov = [IoSliceMut::new(buf)];
     recvmsg(fd.as_fd(), &mut iov, &mut control, RecvFlags::empty())
         .map(|msg| {
-            // Extract file descriptors from ancillary data.
+            // Extract file descriptors and credentials from ancillary data.
             let mut fds = alloc::vec::Vec::new();
+            #[cfg(target_os = "linux")]
+            let mut creds = None;
             for m in control.drain() {
-                if let RecvAncillaryMessage::ScmRights(rights) = m {
-                    fds.extend(rights);
+                match m {
+                    RecvAncillaryMessage::ScmRights(rights) => fds.extend(rights),
+                    #[cfg(target_os = "linux")]
+                    RecvAncillaryMessage::ScmCredentials(ucreds) => {
+                        creds = Some(PassedCredentials::new(ucreds.uid, ucreds.gid, ucreds.pid));
+                    }
+                    // Ignore the rest (currently non on Linux).
+                    _ => (),
                 }
             }
             let result = ReadResult::new(msg.bytes);
             #[cfg(feature = "std")]
             let result = result.set_fds(fds);
+            #[cfg(all(feature = "std", target_os = "linux"))]
+            let result = result.set_credentials(creds);
 
             result
         })

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -79,6 +79,7 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
     #[cfg(any(target_os = "android", target_os = "linux"))]
     {
         use std::os::fd::FromRawFd;
+
         // Get SO_PEERCRED (uid, gid, pid).
         let ucred = rustix::net::sockopt::socket_peercred(fd)?;
         let uid = ucred.uid;

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -61,10 +61,19 @@ pub fn recvmsg(fd: impl AsFd, buf: &mut [u8]) -> io::Result<ReadResult> {
 ///
 /// This is a low-level helper that performs the `sendmsg` syscall.
 #[doc(hidden)]
-pub fn sendmsg(fd: impl AsFd, buf: &[u8], fds: &[BorrowedFd<'_>]) -> io::Result<usize> {
+pub fn sendmsg(
+    fd: impl AsFd,
+    buf: &[u8],
+    fds: &[BorrowedFd<'_>],
+    #[cfg(target_os = "linux")] creds: Option<&crate::connection::PassedCredentials>,
+) -> io::Result<usize> {
     use rustix::net::{SendAncillaryBuffer, SendAncillaryMessage, SendFlags, sendmsg};
     use std::io::IoSlice;
 
+    #[cfg(target_os = "linux")]
+    let mut cmsg_buf =
+        [MaybeUninit::<u8>::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS), ScmCredentials(1))];
+    #[cfg(not(target_os = "linux"))]
     let mut cmsg_buf = [MaybeUninit::<u8>::uninit(); rustix::cmsg_space!(ScmRights(MAX_FDS))];
     let mut control = SendAncillaryBuffer::new(&mut cmsg_buf);
 
@@ -73,6 +82,21 @@ pub fn sendmsg(fd: impl AsFd, buf: &[u8], fds: &[BorrowedFd<'_>]) -> io::Result<
             io::ErrorKind::InvalidInput,
             "too many file descriptors to send",
         ));
+    }
+
+    #[cfg(target_os = "linux")]
+    if let Some(creds) = creds {
+        let ucred = rustix::net::UCred {
+            pid: creds.process_id(),
+            uid: creds.unix_user_id(),
+            gid: creds.unix_primary_group_id(),
+        };
+        if !control.push(SendAncillaryMessage::ScmCredentials(ucred)) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "failed to push credentials",
+            ));
+        }
     }
 
     let iov = [IoSlice::new(buf)];

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -4,18 +4,20 @@
 //! runtime-specific socket implementations.
 
 use core::mem::MaybeUninit;
+#[cfg(target_os = "linux")]
+use std::os::fd::OwnedFd;
 use std::{
     io,
-    os::fd::{AsFd, BorrowedFd, OwnedFd},
+    os::fd::{AsFd, BorrowedFd},
 };
 
-use crate::connection::Credentials;
+use crate::connection::{Credentials, socket::ReadResult};
 
 /// Receive a message from a Unix socket, including any file descriptors.
 ///
 /// This is a low-level helper that performs the `recvmsg` syscall.
 #[doc(hidden)]
-pub fn recvmsg(fd: impl AsFd, buf: &mut [u8]) -> io::Result<(usize, alloc::vec::Vec<OwnedFd>)> {
+pub fn recvmsg(fd: impl AsFd, buf: &mut [u8]) -> io::Result<ReadResult> {
     use rustix::net::{RecvAncillaryBuffer, RecvAncillaryMessage, RecvFlags, recvmsg};
     use std::io::IoSliceMut;
 
@@ -32,7 +34,11 @@ pub fn recvmsg(fd: impl AsFd, buf: &mut [u8]) -> io::Result<(usize, alloc::vec::
                     fds.extend(rights);
                 }
             }
-            (msg.bytes, fds)
+            let result = ReadResult::new(msg.bytes);
+            #[cfg(feature = "std")]
+            let result = result.set_fds(fds);
+
+            result
         })
         .map_err(io::Error::from)
 }

--- a/zlink-smol/src/unix/listener.rs
+++ b/zlink-smol/src/unix/listener.rs
@@ -26,7 +26,7 @@ impl crate::Listener for Listener {
 
     async fn accept(&mut self) -> Result<Option<Connection<Self::Socket>>> {
         let (stream, _) = self.listener.accept().await?;
-        Ok(Some(super::Stream::from(stream).into()))
+        Ok(Some(super::Stream::try_from(stream)?.into()))
     }
 }
 

--- a/zlink-smol/src/unix/stream.rs
+++ b/zlink-smol/src/unix/stream.rs
@@ -22,9 +22,9 @@ where
 {
     Async::<StdUnixStream>::connect(path)
         .await
-        .map(Stream)
-        .map(Connection::new)
         .map_err(Into::into)
+        .and_then(TryInto::try_into)
+        .map(Connection::new)
 }
 
 /// The [`Socket`] implementation using Unix Domain Sockets.
@@ -44,9 +44,11 @@ impl Socket for Stream {
     }
 }
 
-impl From<Async<StdUnixStream>> for Stream {
-    fn from(stream: Async<StdUnixStream>) -> Self {
-        Self(stream)
+impl TryFrom<Async<StdUnixStream>> for Stream {
+    type Error = crate::Error;
+
+    fn try_from(stream: Async<StdUnixStream>) -> Result<Self> {
+        Ok(Self(stream))
     }
 }
 
@@ -55,7 +57,7 @@ impl TryFrom<StdUnixStream> for Stream {
 
     fn try_from(stream: StdUnixStream) -> Result<Self> {
         stream.set_nonblocking(true)?;
-        Ok(Self(Async::new(stream)?))
+        Async::new(stream)?.try_into()
     }
 }
 

--- a/zlink-smol/src/unix/stream.rs
+++ b/zlink-smol/src/unix/stream.rs
@@ -106,7 +106,12 @@ impl socket::UnixSocket for ReadHalf {}
 pub struct WriteHalf(Arc<Async<StdUnixStream>>);
 
 impl socket::WriteHalf for WriteHalf {
-    async fn write(&mut self, buf: &[u8], fds: &[impl AsFd]) -> Result<()> {
+    async fn write(
+        &mut self,
+        buf: &[u8],
+        fds: &[impl AsFd],
+        #[cfg(target_os = "linux")] creds: Option<&crate::connection::PassedCredentials>,
+    ) -> Result<()> {
         use std::{future::poll_fn, task::Poll};
 
         // Convert to BorrowedFd for rustix.
@@ -119,7 +124,13 @@ impl socket::WriteHalf for WriteHalf {
 
             let n: usize = poll_fn(|cx| {
                 loop {
-                    match crate::unix_utils::sendmsg(self.0.as_ref(), &buf[pos..], fds_to_send) {
+                    match crate::unix_utils::sendmsg(
+                        self.0.as_ref(),
+                        &buf[pos..],
+                        fds_to_send,
+                        #[cfg(target_os = "linux")]
+                        creds,
+                    ) {
                         Ok(bytes_sent) => return Poll::Ready(Ok::<_, crate::Error>(bytes_sent)),
                         Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                             match self.0.poll_writable(cx) {

--- a/zlink-smol/src/unix/stream.rs
+++ b/zlink-smol/src/unix/stream.rs
@@ -48,6 +48,8 @@ impl TryFrom<Async<StdUnixStream>> for Stream {
     type Error = crate::Error;
 
     fn try_from(stream: Async<StdUnixStream>) -> Result<Self> {
+        #[cfg(target_os = "linux")]
+        zlink_core::unix_utils::enable_passcred(&stream)?;
         Ok(Self(stream))
     }
 }

--- a/zlink-smol/src/unix/stream.rs
+++ b/zlink-smol/src/unix/stream.rs
@@ -5,11 +5,12 @@ use crate::{
 use async_io::Async;
 use std::{
     os::{
-        fd::{AsFd, BorrowedFd, OwnedFd},
+        fd::{AsFd, BorrowedFd},
         unix::net::UnixStream as StdUnixStream,
     },
     sync::Arc,
 };
+use zlink_core::connection::socket::ReadResult;
 
 /// The connection type that uses Unix Domain Sockets for transport.
 pub type Connection = crate::Connection<Stream>;
@@ -71,7 +72,7 @@ impl socket::UnixSocket for Stream {}
 pub struct ReadHalf(Arc<Async<StdUnixStream>>);
 
 impl socket::ReadHalf for ReadHalf {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<(usize, Vec<OwnedFd>)> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<ReadResult> {
         use std::{future::poll_fn, task::Poll};
 
         poll_fn(|cx| {

--- a/zlink-tokio/src/unix/listener.rs
+++ b/zlink-tokio/src/unix/listener.rs
@@ -25,8 +25,8 @@ impl crate::Listener for Listener {
         self.listener
             .accept()
             .await
-            .map(|(stream, _)| Some(super::Stream::from(stream).into()))
             .map_err(Into::into)
+            .and_then(|(stream, _)| super::Stream::try_from(stream).map(Into::into).map(Some))
     }
 }
 

--- a/zlink-tokio/src/unix/stream.rs
+++ b/zlink-tokio/src/unix/stream.rs
@@ -106,7 +106,12 @@ impl socket::UnixSocket for ReadHalf {}
 pub struct WriteHalf(unix::OwnedWriteHalf);
 
 impl socket::WriteHalf for WriteHalf {
-    async fn write(&mut self, buf: &[u8], fds: &[impl AsFd]) -> Result<()> {
+    async fn write(
+        &mut self,
+        buf: &[u8],
+        fds: &[impl AsFd],
+        #[cfg(target_os = "linux")] creds: Option<&crate::connection::PassedCredentials>,
+    ) -> Result<()> {
         use std::{future::poll_fn, task::Poll};
 
         // Convert to BorrowedFd for rustix.
@@ -121,7 +126,13 @@ impl socket::WriteHalf for WriteHalf {
                 loop {
                     let stream: &UnixStream = self.0.as_ref();
                     match stream.try_io(tokio::io::Interest::WRITABLE, || {
-                        crate::unix_utils::sendmsg(stream, &buf[pos..], fds_to_send)
+                        crate::unix_utils::sendmsg(
+                            stream,
+                            &buf[pos..],
+                            fds_to_send,
+                            #[cfg(target_os = "linux")]
+                            creds,
+                        )
                     }) {
                         Ok(bytes_sent) => return Poll::Ready(Ok::<_, crate::Error>(bytes_sent)),
                         Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {

--- a/zlink-tokio/src/unix/stream.rs
+++ b/zlink-tokio/src/unix/stream.rs
@@ -19,9 +19,9 @@ where
 {
     UnixStream::connect(path)
         .await
-        .map(Stream)
-        .map(Connection::new)
         .map_err(Into::into)
+        .and_then(TryInto::try_into)
+        .map(Connection::new)
 }
 
 /// The [`Socket`] implementation using Unix Domain Sockets.
@@ -41,9 +41,11 @@ impl Socket for Stream {
     }
 }
 
-impl From<UnixStream> for Stream {
-    fn from(stream: UnixStream) -> Self {
-        Self(stream)
+impl TryFrom<UnixStream> for Stream {
+    type Error = crate::Error;
+
+    fn try_from(stream: UnixStream) -> Result<Self> {
+        Ok(Self(stream))
     }
 }
 
@@ -52,7 +54,9 @@ impl TryFrom<StdUnixStream> for Stream {
 
     fn try_from(stream: StdUnixStream) -> Result<Self> {
         stream.set_nonblocking(true)?;
-        UnixStream::from_std(stream).map(Self).map_err(Into::into)
+        UnixStream::from_std(stream)
+            .map_err(Into::into)
+            .and_then(TryInto::try_into)
     }
 }
 
@@ -188,8 +192,8 @@ mod tests {
         std_a.set_nonblocking(true).unwrap();
         std_b.set_nonblocking(true).unwrap();
 
-        let conn_a = Connection::new(Stream::from(UnixStream::from_std(std_a).unwrap()));
-        let conn_b = Connection::new(Stream::from(UnixStream::from_std(std_b).unwrap()));
+        let conn_a = Connection::new(UnixStream::from_std(std_a).unwrap().try_into().unwrap());
+        let conn_b = Connection::new(UnixStream::from_std(std_b).unwrap().try_into().unwrap());
 
         let (_, mut write_a) = conn_a.split();
         let (mut read_b, _) = conn_b.split();

--- a/zlink-tokio/src/unix/stream.rs
+++ b/zlink-tokio/src/unix/stream.rs
@@ -45,6 +45,8 @@ impl TryFrom<UnixStream> for Stream {
     type Error = crate::Error;
 
     fn try_from(stream: UnixStream) -> Result<Self> {
+        #[cfg(target_os = "linux")]
+        zlink_core::unix_utils::enable_passcred(&stream)?;
         Ok(Self(stream))
     }
 }

--- a/zlink-tokio/src/unix/stream.rs
+++ b/zlink-tokio/src/unix/stream.rs
@@ -3,10 +3,11 @@ use crate::{
     connection::socket::{self, Socket},
 };
 use std::os::{
-    fd::{AsFd, BorrowedFd, OwnedFd},
+    fd::{AsFd, BorrowedFd},
     unix::net::UnixStream as StdUnixStream,
 };
 use tokio::net::{UnixStream, unix};
+use zlink_core::connection::socket::ReadResult;
 
 /// The connection type that uses Unix Domain Sockets for transport.
 pub type Connection = crate::Connection<Stream>;
@@ -68,7 +69,7 @@ impl AsFd for Stream {
 pub struct ReadHalf(unix::OwnedReadHalf);
 
 impl socket::ReadHalf for ReadHalf {
-    async fn read(&mut self, buf: &mut [u8]) -> Result<(usize, Vec<OwnedFd>)> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<ReadResult> {
         use std::{future::poll_fn, task::Poll};
 
         poll_fn(|cx| {

--- a/zlink/tests/peer_credentials.rs
+++ b/zlink/tests/peer_credentials.rs
@@ -68,3 +68,53 @@ async fn peer_credentials_unix_socket() {
 
     let _stream = connect_task.await.unwrap();
 }
+
+/// Verify that explicitly-set credentials are sent via `SCM_CREDENTIALS` and received on the peer.
+#[cfg(target_os = "linux")]
+#[tokio::test]
+async fn passed_credentials_over_unix_socket() {
+    use serde::{Deserialize, Serialize};
+    use serde_prefix_all::prefix_all;
+    use zlink::{Call, connection::PassedCredentials};
+
+    #[prefix_all("org.example.")]
+    #[derive(Debug, Serialize, Deserialize)]
+    #[serde(tag = "method", content = "parameters")]
+    enum Method {
+        Ping,
+    }
+
+    let temp_dir = TempDir::new().unwrap();
+    let socket_path = temp_dir.path().join("passed_creds.sock");
+
+    let mut listener = zlink::unix::bind(&socket_path).unwrap();
+
+    let socket_path_clone = socket_path.clone();
+    let client_task = tokio::spawn(async move {
+        let mut client = zlink::unix::connect(&socket_path_clone).await.unwrap();
+
+        let creds = PassedCredentials::new(
+            rustix::process::getuid(),
+            rustix::process::getgid(),
+            rustix::process::getpid(),
+        );
+        client.set_credentials(Some(creds));
+
+        client
+            .send_call(&Call::new(Method::Ping), vec![])
+            .await
+            .unwrap();
+    });
+
+    let mut server = listener.accept().await.unwrap().unwrap();
+    let _ = server.receive_call::<Method>().await.unwrap();
+
+    let received = server
+        .received_credentials()
+        .expect("credentials should be received");
+    assert_eq!(received.unix_user_id(), rustix::process::getuid());
+    assert_eq!(received.unix_primary_group_id(), rustix::process::getgid());
+    assert_eq!(received.process_id(), rustix::process::getpid());
+
+    client_task.await.unwrap();
+}


### PR DESCRIPTION
## Summary

Adds support for passing peer credentials (`SCM_CREDENTIALS`) over Unix domain sockets on Linux, both sending and receiving.

- `PassedCredentials` type holding uid/gid/pid (no `Clone`/`Copy` — future-proofed for non-`Copy` fields like a process FD).
- `Connection::set_credentials()` to attach credentials to outgoing messages; stored as `Arc<PassedCredentials>` internally and on the `WriteHalf` trait so cheap cloning works without requiring `Clone` on the inner type.
- `Connection::received_credentials()` exposes credentials received with the most recent message.
- `SO_PASSCRED` is auto-enabled on Unix `Stream` construction (both `zlink-tokio` and `zlink-smol`).
- `ReadResult` gains `take_fds` and `take_credentials` (alongside the existing `into_*`) so the receive path can move out by `&mut`.

## Breaking changes

- `Socket::read` now returns a named `ReadResult` struct instead of a tuple.
- `From<UnixStream>`/`From<Async<UnixStream>>` for `Stream` becomes `TryFrom` — `SO_PASSCRED` setup can now fail and we propagate that error rather than silently ignoring it.

## Test plan

- [x] `cargo test --all-features` (428 passed)
- [x] New integration test `passed_credentials_over_unix_socket` round-trips uid/gid/pid via `SCM_CREDENTIALS`
- [x] Existing `peer_credentials_unix_socket` test still passes
- [x] CI

Fixes #267.