### PR TITLE
📝 core: Document fd-passing wire contract and message association

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ applications. zlink makes it easy to implement Varlink services in Rust with:
 - **Type safety**: Leverage Rust's type system with derive macros and code generation.
 - **Multiple transports**: Unix domain sockets and (upcoming) USB support.
 - **Code generation**: Generate Rust code from Varlink IDL files.
+- **File descriptor passing**: Pass file descriptors alongside messages over Unix sockets,
+  wire-compatible with systemd's `sd-varlink` (the de-facto convention for FD passing over
+  Varlink). See the [`connection` module docs] for details.
 
 ## Project Structure
 
@@ -424,3 +427,4 @@ This project is licensed under the [MIT License][license].
 [`zlink-codegen`]: https://docs.rs/zlink-codegen
 [`zlink-macros`]: https://docs.rs/zlink-macros
 [`Server::run` docs]: https://docs.rs/zlink/latest/zlink/struct.Server.html#method.run
+[`connection` module docs]: https://docs.rs/zlink-core/latest/zlink_core/connection/index.html#file-descriptor-passing

--- a/zlink-core/src/connection/mod.rs
+++ b/zlink-core/src/connection/mod.rs
@@ -38,9 +38,35 @@
 //! to message sending and receiving via methods like [`Connection::send_call`],
 //! [`Connection::receive_reply`], and [`Connection::chain_call`] for pipelining.
 //!
+//! # File descriptor passing
+//!
+//! On transports that support it (Unix domain sockets, `std` only), zlink can pass file
+//! descriptors alongside messages. FD passing is not part of the Varlink protocol itself; it is
+//! an `AF_UNIX` transport feature (`SCM_RIGHTS` ancillary data). A transport advertises the
+//! capability via [`Socket::CAN_TRANSFER_FDS`] (`true` for Unix domain sockets). It is unavailable
+//! under `no_std`.
+//!
+//! Because the Varlink spec does not define FD passing, there is no formal standard for it.
+//! systemd's `sd-varlink` has implemented it over `AF_UNIX` since 2023 and ships it across many
+//! system services, making its design the de-facto convention for "FD passing over Varlink".
+//! zlink deliberately follows that convention so the two interoperate (verified against a live
+//! systemd service). Its rules:
+//!
+//! * **First-byte association.** FDs belong to the message on whose **first byte** they arrive.
+//!   zlink attaches a message's FDs to the write carrying its first byte, and on receive hands each
+//!   batch of received FDs to the next message in arrival order.
+//! * **At most 253 FDs per message** — the Linux `SCM_RIGHTS` kernel limit, which `sd-varlink` also
+//!   enforces (along with a cap of 16384 incoming FDs per connection).
+//! * **`SO_PASSRIGHTS` opt-in (Linux >= 6.16).** Recent `sd-varlink` only *receives* FDs if it has
+//!   opted in; a peer that has not may have FDs it is sent silently dropped by the kernel.
+//! * **No in-band negotiation.** Varlink has no handshake for FD passing; both peers must opt in
+//!   out of band (zlink by using an FD-capable [`Socket`]).
+//!
 //! [`proxy`]: macro@crate::proxy
 //! [`service`]: macro@crate::service
 //! [`Service`]: crate::service::Service
+//! [`Socket`]: socket::Socket
+//! [`Socket::CAN_TRANSFER_FDS`]: socket::Socket::CAN_TRANSFER_FDS
 
 #[cfg(feature = "std")]
 mod credentials;

--- a/zlink-core/src/connection/socket.rs
+++ b/zlink-core/src/connection/socket.rs
@@ -27,7 +27,15 @@ pub trait Socket: core::fmt::Debug {
 pub trait ReadHalf: core::fmt::Debug {
     /// Read from a socket.
     ///
-    /// On completion, the number of bytes read and any file descriptors received are returned.
+    /// On completion, the number of bytes read and any file descriptors received are returned
+    /// (see [`ReadResult`]).
+    ///
+    /// Any file descriptors returned here are taken to belong to the message whose first byte
+    /// arrives in this read. The [`connection`](crate::connection#file-descriptor-passing) module
+    /// docs describe the full FD-to-message association contract; in short, implementers must
+    /// return the FDs received by a given `recvmsg` together with the bytes received by that same
+    /// `recvmsg`, so the positional association upheld by [`ReadConnection`](super::ReadConnection)
+    /// is correct.
     ///
     /// Notes for implementers:
     ///
@@ -44,7 +52,12 @@ pub trait ReadHalf: core::fmt::Debug {
 pub trait WriteHalf: core::fmt::Debug {
     /// Write to the socket.
     ///
-    /// The `fds` parameter contains file descriptors to send along with the data (std only).
+    /// The `fds` parameter contains file descriptors to send along with the data (std only). The
+    /// implementation must attach the given `fds` to the `sendmsg` that carries the first byte of
+    /// `buf` (e.g. via `SCM_RIGHTS`), so that the receiver can associate them with the message
+    /// starting at that byte. [`WriteConnection`](super::WriteConnection) only ever calls this with
+    /// `fds` for a `buf` that begins at a message boundary; see the
+    /// [`connection`](crate::connection#file-descriptor-passing) module docs for the full contract.
     ///
     /// The returned future has the same requirements as that of [`ReadHalf::read`].
     fn write(


### PR DESCRIPTION
The zlink fd-passing architecture is compatible with systemd's, but let's document this better.

Assisted-by: OpenCode (Claude Opus 4.8)
