### PR TITLE
🐛 core: Accept empty `parameters` object in method calls

### DIFF
--- a/zlink-core/src/call/de.rs
+++ b/zlink-core/src/call/de.rs
@@ -1,13 +1,19 @@
 use core::{cell::Cell, fmt, marker::PhantomData};
 
+use alloc::string::String;
+
 use serde::{
     Deserialize, Deserializer,
     de::{
-        self, DeserializeSeed, IntoDeserializer, MapAccess, Visitor, value::MapAccessDeserializer,
+        self, DeserializeSeed, MapAccess, Visitor,
+        value::{BorrowedStrDeserializer, MapAccessDeserializer},
     },
 };
 
 use super::Call;
+
+mod empty_params;
+use empty_params::{EmptyParamsSeed, SyntheticMethodMap};
 
 impl<'de, M> Deserialize<'de> for Call<M>
 where
@@ -36,17 +42,53 @@ where
             where
                 A: MapAccess<'de>,
             {
-                // 1) Prepare interior-mutable storage for optionals
-                let oneway_cell = Cell::new(None);
-                let more_cell = Cell::new(None);
-                let upgrade_cell = Cell::new(None);
+                // The deserializer streams the outer map once, capturing the `oneway`/`more`/
+                // `upgrade` flags into cells and forwarding the method/parameters to `M`. The cells
+                // below also track whether the empty-params fallback (re-deserializing `M` from a
+                // synthetic `{method, parameters: {}}` map) is needed; see `empty_params`.
+                let oneway_cell = Cell::new(None::<bool>);
+                let more_cell = Cell::new(None::<bool>);
+                let upgrade_cell = Cell::new(None::<bool>);
+                // Set when an empty/null `parameters` value was forwarded as `visit_unit()`.
+                let needs_retry = Cell::new(false);
+                // Set once the `parameters` key is seen at all; its *absence* for a struct variant
+                // is the other case the fallback handles.
+                let saw_parameters = Cell::new(false);
+                // Set if a flag (`oneway`/`more`/`upgrade`) value failed to parse. Such an error is
+                // a genuine envelope error that must never be masked by the fallback.
+                let flag_error = Cell::new(false);
+                // Captures the method name string so the fallback can rebuild the synthetic map.
+                let method_capture: Cell<Option<String>> = Cell::new(None);
 
-                // 2) Streaming adapter capturing booleans by Cell refs
+                // Streaming adapter capturing the flags by Cell refs while forwarding the
+                // method/parameters entries to `M`.
                 struct FilterMap<'a, MAcc> {
                     inner: MAcc,
                     oneway: &'a Cell<Option<bool>>,
                     more: &'a Cell<Option<bool>>,
                     upgrade: &'a Cell<Option<bool>>,
+                    needs_retry: &'a Cell<bool>,
+                    saw_parameters: &'a Cell<bool>,
+                    flag_error: &'a Cell<bool>,
+                    method_capture: &'a Cell<Option<String>>,
+                    // True when the key just surfaced to the inner method enum was
+                    // `parameters`, so the matching `next_value_seed` knows to apply the
+                    // empty-object workaround (see `empty_params`).
+                    at_parameters: bool,
+                    // True when the key just surfaced was `method`, so we can capture its value.
+                    capture_method: bool,
+                }
+                impl<'de, 'a, MAcc> FilterMap<'a, MAcc>
+                where
+                    MAcc: MapAccess<'de>,
+                {
+                    /// Read a boolean flag value, recording a `flag_error` if it is malformed so
+                    /// the fallback never masks a genuine envelope error.
+                    fn flag_value(&mut self) -> Result<bool, MAcc::Error> {
+                        self.inner.next_value().inspect_err(|_| {
+                            self.flag_error.set(true);
+                        })
+                    }
                 }
                 impl<'de, 'a, MAcc> MapAccess<'de> for FilterMap<'a, MAcc>
                 where
@@ -58,25 +100,39 @@ where
                     where
                         K: DeserializeSeed<'de>,
                     {
-                        while let Some(key) = self.inner.next_key::<&str>()? {
+                        self.at_parameters = false;
+                        self.capture_method = false;
+                        while let Some(key) = self.inner.next_key::<&'de str>()? {
                             match key {
                                 "oneway" => {
-                                    let v = self.inner.next_value()?;
+                                    let v = self.flag_value()?;
                                     self.oneway.set(Some(v));
                                     continue;
                                 }
                                 "more" => {
-                                    let v = self.inner.next_value()?;
+                                    let v = self.flag_value()?;
                                     self.more.set(Some(v));
                                     continue;
                                 }
                                 "upgrade" => {
-                                    let v = self.inner.next_value()?;
+                                    let v = self.flag_value()?;
                                     self.upgrade.set(Some(v));
                                     continue;
                                 }
+                                "method" => {
+                                    self.capture_method = true;
+                                    let de = BorrowedStrDeserializer::new(key);
+                                    return seed.deserialize(de).map(Some);
+                                }
                                 other => {
-                                    let de = other.into_deserializer();
+                                    // Remember whether this is the `parameters` key so the
+                                    // following `next_value_seed` can normalise an empty or
+                                    // null value into an absent one (see `empty_params`).
+                                    self.at_parameters = other == "parameters";
+                                    if self.at_parameters {
+                                        self.saw_parameters.set(true);
+                                    }
+                                    let de = BorrowedStrDeserializer::new(other);
                                     return seed.deserialize(de).map(Some);
                                 }
                             }
@@ -88,21 +144,120 @@ where
                     where
                         V: DeserializeSeed<'de>,
                     {
-                        self.inner.next_value_seed(seed)
+                        if core::mem::take(&mut self.capture_method) {
+                            // Capture the method value as an owned String in case the fallback
+                            // needs it, then re-feed it to the seed via a StrDeserializer.
+                            let method_str: String = self.inner.next_value()?;
+                            let result = seed.deserialize(serde::de::value::StrDeserializer::<
+                                MAcc::Error,
+                            >::new(
+                                method_str.as_str()
+                            ));
+                            self.method_capture.set(Some(method_str));
+                            result
+                        } else if core::mem::take(&mut self.at_parameters) {
+                            // Wrap the inner method enum's content seed so that an empty object
+                            // (`{}`) or `null` is forwarded as `visit_unit()`. `EmptyParamsSeed`
+                            // sets `needs_retry` when it does so, marking this call as eligible for
+                            // the empty-params fallback if it fails.
+                            let result = self
+                                .inner
+                                .next_value_seed(EmptyParamsSeed::new(seed, self.needs_retry));
+
+                            // When empty params were forwarded as a unit but the method is actually
+                            // a struct variant, the inner deserialize errors mid-stream (and
+                            // `needs_retry` is set). Drain the rest of the outer map so the
+                            // underlying deserializer is left in a clean state and any trailing
+                            // `oneway`/`more`/`upgrade` flag is still captured for the fallback.
+                            // The drain is strict: a malformed flag
+                            // value records `flag_error` so the
+                            // fallback cannot mask it.
+                            if result.is_err() && self.needs_retry.get() {
+                                loop {
+                                    match self.inner.next_key::<&'de str>() {
+                                        Ok(Some(key)) => {
+                                            let drained = match key {
+                                                "oneway" => self.flag_value().map(|v| {
+                                                    self.oneway.set(Some(v));
+                                                }),
+                                                "more" => self.flag_value().map(|v| {
+                                                    self.more.set(Some(v));
+                                                }),
+                                                "upgrade" => self.flag_value().map(|v| {
+                                                    self.upgrade.set(Some(v));
+                                                }),
+                                                _ => self
+                                                    .inner
+                                                    .next_value::<de::IgnoredAny>()
+                                                    .map(|_| ()),
+                                            };
+                                            if drained.is_err() {
+                                                self.flag_error.set(true);
+                                                break;
+                                            }
+                                        }
+                                        Ok(None) => break,
+                                        Err(_) => {
+                                            self.flag_error.set(true);
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+
+                            result
+                        } else {
+                            self.inner.next_value_seed(seed)
+                        }
                     }
                 }
 
-                // 3) Deserialize method: M using our FilterMap
+                // Deserialize M using the streaming FilterMap.
                 let filter = FilterMap {
                     inner: map,
                     oneway: &oneway_cell,
                     more: &more_cell,
                     upgrade: &upgrade_cell,
+                    needs_retry: &needs_retry,
+                    saw_parameters: &saw_parameters,
+                    flag_error: &flag_error,
+                    method_capture: &method_capture,
+                    at_parameters: false,
+                    capture_method: false,
                 };
-                let method = M::deserialize(MapAccessDeserializer::new(filter))
-                    .map_err(de::Error::custom)?;
+                let streamed =
+                    M::deserialize(MapAccessDeserializer::new(filter)).map_err(de::Error::custom);
 
-                // 4) Extract boolean fields from Cells
+                // The empty-params fallback runs when the streaming deserialize failed and the
+                // parameters were either empty/null (`needs_retry`) or entirely absent
+                // (`!saw_parameters`). Both reduce to "no arguments", which an all-optional struct
+                // variant accepts as an empty map. The captured method name is the safety
+                // interlock: a required-field struct variant still errors against the synthetic
+                // empty map, so the fallback never invents data.
+                //
+                // A malformed flag (`flag_error`) is a genuine envelope error, so it suppresses the
+                // fallback and lets the streaming error surface instead of being masked.
+                let use_fallback = streamed.is_err()
+                    && !flag_error.get()
+                    && (needs_retry.get() || !saw_parameters.get());
+                let method = if use_fallback {
+                    // Re-deserialize M from a synthetic `{"method": <captured>, "parameters": {}}`
+                    // map, which presents `parameters` as an empty map so all-optional struct
+                    // variants populate their fields with `None`.
+                    if let Some(method_str) = method_capture.take() {
+                        M::deserialize(MapAccessDeserializer::new(
+                            SyntheticMethodMap::<A::Error>::new(&method_str),
+                        ))
+                        .map_err(de::Error::custom)?
+                    } else {
+                        // No method captured; propagate the original error.
+                        streamed?
+                    }
+                } else {
+                    streamed?
+                };
+
+                // Extract the captured flags, defaulting absent ones to `false`.
                 let oneway = oneway_cell.get().unwrap_or_default();
                 let more = more_cell.get().unwrap_or_default();
                 let upgrade = upgrade_cell.get().unwrap_or_default();

--- a/zlink-core/src/call/de/empty_params.rs
+++ b/zlink-core/src/call/de/empty_params.rs
@@ -1,0 +1,389 @@
+//! Workaround for serde#2045 on the `parameters` field of a method [`Call`].
+//!
+//! Varlink no-argument methods are unit variants of an adjacently-tagged enum
+//! (`#[serde(tag = "method", content = "parameters")]`). serde refuses to deserialize an empty
+//! object (`{}`) into a unit variant, even though an absent `parameters` key works fine. Real
+//! clients such as `varlinkctl` send `{"method":"...","parameters":{}}`, so we must accept it.
+//!
+//! For all-optional-field struct variants (e.g. `List { name: Option<String>, … }`) the opposite
+//! is true: `{}` must deserialize as a map so all fields receive `None`. `null`/absent works fine.
+//!
+//! These two requirements are mutually exclusive under a single serde pass. `serde_derive` routes
+//! the `content` payload of *both* unit and struct variants through the type-erased
+//! `Deserializer::deserialize_any`, so this adapter has no static signal for which shape the
+//! variant's visitor expects, and the visitor is consumed by value (so it cannot be tried twice).
+//! Yielding `visit_unit()` fails struct variants; yielding `visit_map(empty)` fails unit variants.
+//!
+//! The resolution (driven from [`de`]) has two paths:
+//!
+//! * **Streaming path**: empty `{}`, `null`, or absent `parameters` is forwarded as `visit_unit()`,
+//!   which satisfies unit variants. Non-empty objects are forwarded verbatim, preserving zero-copy
+//!   `&'de` borrows in field values.
+//! * **Empty-params fallback**: only when the streaming path fails *and* the parameters were
+//!   empty/null/absent, `M` is re-deserialized from a synthetic map `{"method": <captured>,
+//!   "parameters": {}}` whose parameters value is an empty map access. This satisfies all-optional
+//!   struct variants, which need `visit_map(empty)` to fill every field with `None`. The captured
+//!   method name acts as a safety interlock: a struct variant with a required field still errors
+//!   against the empty map, so the fallback never invents data.
+//!
+//! The items in this module implement the streaming path (`EmptyParamsSeed` →
+//! `EmptyParamsDeserializer` → `PeekVisitor`) and the fallback's empty map
+//! (`SyntheticMethodMap` → `EmptyMapAccess`).
+//!
+//! [`de`]: super
+//! [`Call`]: super::Call
+
+use core::{cell::Cell, fmt, marker::PhantomData};
+
+use alloc::borrow::Cow;
+
+use serde::de::{
+    DeserializeSeed, Deserializer, IntoDeserializer, MapAccess, Visitor,
+    value::{BorrowedStrDeserializer, MapAccessDeserializer, StrDeserializer},
+};
+
+// ── EmptyParamsSeed ──────────────────────────────────────────────────────────
+
+/// A [`DeserializeSeed`] that wraps the inner content seed with [`EmptyParamsDeserializer`].
+///
+/// The `needs_retry` cell is set to `true` when an empty/null parameters value is encountered so
+/// the caller knows to run the empty-params fallback if this deserialization fails.
+pub(super) struct EmptyParamsSeed<'r, S> {
+    inner: S,
+    needs_retry: &'r Cell<bool>,
+}
+
+impl<'r, S> EmptyParamsSeed<'r, S> {
+    pub(super) fn new(inner: S, needs_retry: &'r Cell<bool>) -> Self {
+        Self { inner, needs_retry }
+    }
+}
+
+impl<'de, 'r, S> DeserializeSeed<'de> for EmptyParamsSeed<'r, S>
+where
+    S: DeserializeSeed<'de>,
+{
+    type Value = S::Value;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        self.inner.deserialize(EmptyParamsDeserializer {
+            inner: deserializer,
+            needs_retry: self.needs_retry,
+        })
+    }
+}
+
+// ── EmptyParamsDeserializer ──────────────────────────────────────────────────
+
+/// Forwards to the wrapped deserializer but wraps the visitor so empty/null is forwarded as
+/// `visit_unit()` (satisfying unit variants). Sets `needs_retry` when it does so, signalling that
+/// the empty-params fallback should run if this deserialization fails.
+struct EmptyParamsDeserializer<'r, D> {
+    inner: D,
+    needs_retry: &'r Cell<bool>,
+}
+
+impl<'de, 'r, D> Deserializer<'de> for EmptyParamsDeserializer<'r, D>
+where
+    D: Deserializer<'de>,
+{
+    type Error = D::Error;
+
+    fn deserialize_any<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.deserialize_any(PeekVisitor {
+            inner: visitor,
+            needs_retry: self.needs_retry,
+        })
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.deserialize_option(PeekVisitor {
+            inner: visitor,
+            needs_retry: self.needs_retry,
+        })
+    }
+
+    fn deserialize_map<V>(self, visitor: V) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.deserialize_map(PeekVisitor {
+            inner: visitor,
+            needs_retry: self.needs_retry,
+        })
+    }
+
+    fn deserialize_struct<V>(
+        self,
+        name: &'static str,
+        fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error>
+    where
+        V: Visitor<'de>,
+    {
+        self.inner.deserialize_struct(
+            name,
+            fields,
+            PeekVisitor {
+                inner: visitor,
+                needs_retry: self.needs_retry,
+            },
+        )
+    }
+
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
+        bytes byte_buf unit unit_struct newtype_struct seq tuple tuple_struct
+        enum identifier ignored_any
+    }
+}
+
+// ── PeekVisitor ──────────────────────────────────────────────────────────────
+
+/// Wraps the real content visitor.
+///
+/// * Empty map / `null` / `none` → `visit_unit()` (the unit-variant path). Also sets `needs_retry`
+///   so the empty-params fallback can run if this fails.
+/// * Non-empty map → peeked key restored, forwarded verbatim (preserves zero-copy borrows).
+/// * `visit_some` → unwrap and re-apply peek logic.
+struct PeekVisitor<'r, V> {
+    inner: V,
+    needs_retry: &'r Cell<bool>,
+}
+
+impl<'de, 'r, V> Visitor<'de> for PeekVisitor<'r, V>
+where
+    V: Visitor<'de>,
+{
+    type Value = V::Value;
+
+    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner.expecting(f)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        // Peek only the first key to decide what to do.
+        //
+        // * Empty map → set `needs_retry`, forward as `visit_unit()` (unit variants accept this;
+        //   struct variants error here and recover via the empty-params fallback).
+        // * Non-empty map → restore the peeked key and forward the full map intact so that `&'de`
+        //   borrows in field *values* are not consumed.
+        match map.next_key::<Cow<'de, str>>()? {
+            None => {
+                self.needs_retry.set(true);
+                self.inner.visit_unit()
+            }
+            Some(first_key) => self.inner.visit_map(PrefixedMap {
+                first_key: Some(first_key),
+                rest: map,
+            }),
+        }
+    }
+
+    fn visit_unit<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        // A bare `null` content arrives here via `deserialize_any` (serde_json calls `visit_unit`,
+        // not `visit_none`, outside of `deserialize_option`). Treat it like empty parameters: set
+        // `needs_retry` so an all-optional struct variant can recover via the synthetic-map retry.
+        self.needs_retry.set(true);
+        self.inner.visit_unit()
+    }
+
+    fn visit_none<E>(self) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        // `null` → treat as absent → visit_unit (same as no parameters key).
+        self.needs_retry.set(true);
+        self.inner.visit_unit()
+    }
+
+    fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // Unwrap the option and re-apply the peek logic to the inner value.
+        deserializer.deserialize_any(self)
+    }
+}
+
+// ── EmptyMapAccess ───────────────────────────────────────────────────────────
+
+/// A [`MapAccess`] that is always empty (no entries).
+///
+/// Used by the empty-params fallback to present `parameters: {}` as an empty map visit so that
+/// all-optional-field struct variants can populate every field with `None`.
+pub(super) struct EmptyMapAccess<E> {
+    _error: PhantomData<E>,
+}
+
+impl<E> EmptyMapAccess<E> {
+    pub(super) fn new() -> Self {
+        Self {
+            _error: PhantomData,
+        }
+    }
+}
+
+impl<'de, E> MapAccess<'de> for EmptyMapAccess<E>
+where
+    E: serde::de::Error,
+{
+    type Error = E;
+
+    fn next_key_seed<K>(&mut self, _seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        Ok(None)
+    }
+
+    fn next_value_seed<Vv>(&mut self, _seed: Vv) -> Result<Vv::Value, Self::Error>
+    where
+        Vv: DeserializeSeed<'de>,
+    {
+        // Should never be called since `next_key_seed` always returns `None`.
+        Err(E::custom("EmptyMapAccess: next_value called unexpectedly"))
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        Some(0)
+    }
+}
+
+// ── PrefixedMap ──────────────────────────────────────────────────────────────
+
+/// A [`MapAccess`] that yields one cached key before delegating to the underlying map.
+///
+/// Only the key is cached; the matching value is still pending in `rest`, so a single unconditional
+/// delegation to `rest.next_value_seed` is correct for both the cached first entry and the rest.
+struct PrefixedMap<'de, A> {
+    first_key: Option<Cow<'de, str>>,
+    rest: A,
+}
+
+impl<'de, A> MapAccess<'de> for PrefixedMap<'de, A>
+where
+    A: MapAccess<'de>,
+{
+    type Error = A::Error;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        match self.first_key.take() {
+            // Preserve the `&'de` borrow when the key came from self-describing input.
+            Some(Cow::Borrowed(key)) => seed
+                .deserialize(BorrowedStrDeserializer::new(key))
+                .map(Some),
+            // Buffered-content replay path: the key is owned.
+            Some(Cow::Owned(key)) => seed
+                .deserialize(StrDeserializer::new(key.as_str()))
+                .map(Some),
+            None => self.rest.next_key_seed(seed),
+        }
+    }
+
+    fn next_value_seed<Vv>(&mut self, seed: Vv) -> Result<Vv::Value, Self::Error>
+    where
+        Vv: DeserializeSeed<'de>,
+    {
+        self.rest.next_value_seed(seed)
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        self.rest
+            .size_hint()
+            .map(|n| n + usize::from(self.first_key.is_some()))
+    }
+}
+
+// ── SyntheticMethodMap ────────────────────────────────────────────────────────
+
+/// A [`MapAccess`] used by the empty-params fallback: yields exactly two entries,
+/// `"method" → <captured_method_str>` and `"parameters" → <EmptyMapAccess>`,
+/// so that all-optional struct variants receive a `visit_map(empty)` for parameters.
+pub(super) struct SyntheticMethodMap<'a, E> {
+    state: SyntheticState,
+    method: &'a str,
+    _error: PhantomData<E>,
+}
+
+enum SyntheticState {
+    Method,
+    Parameters,
+    Done,
+}
+
+impl<'a, E> SyntheticMethodMap<'a, E> {
+    pub(super) fn new(method: &'a str) -> Self {
+        Self {
+            state: SyntheticState::Method,
+            method,
+            _error: PhantomData,
+        }
+    }
+}
+
+impl<'de, 'a, E> MapAccess<'de> for SyntheticMethodMap<'a, E>
+where
+    E: serde::de::Error,
+{
+    type Error = E;
+
+    fn next_key_seed<K>(&mut self, seed: K) -> Result<Option<K::Value>, Self::Error>
+    where
+        K: DeserializeSeed<'de>,
+    {
+        match self.state {
+            SyntheticState::Method => seed
+                .deserialize(StrDeserializer::<E>::new("method"))
+                .map(Some),
+            SyntheticState::Parameters => seed
+                .deserialize(StrDeserializer::<E>::new("parameters"))
+                .map(Some),
+            SyntheticState::Done => Ok(None),
+        }
+    }
+
+    fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value, Self::Error>
+    where
+        V: DeserializeSeed<'de>,
+    {
+        match self.state {
+            SyntheticState::Method => {
+                self.state = SyntheticState::Parameters;
+                seed.deserialize(self.method.into_deserializer())
+            }
+            SyntheticState::Parameters => {
+                self.state = SyntheticState::Done;
+                seed.deserialize(MapAccessDeserializer::new(EmptyMapAccess::<E>::new()))
+            }
+            SyntheticState::Done => Err(E::custom("SyntheticMethodMap: exhausted")),
+        }
+    }
+
+    fn size_hint(&self) -> Option<usize> {
+        match self.state {
+            SyntheticState::Method => Some(2),
+            SyntheticState::Parameters => Some(1),
+            SyntheticState::Done => Some(0),
+        }
+    }
+}

--- a/zlink-core/src/call/tests.rs
+++ b/zlink-core/src/call/tests.rs
@@ -363,6 +363,412 @@ mod std {
         }
     }
 
+    /// Regression test: untagged outer enum wrapping adjacently-tagged inner enum,
+    /// where the matching variant has ALL-OPTIONAL fields and non-empty parameters.
+    ///
+    /// This reproduces the `machine_proxy` e2e failure:
+    /// `{"method":"io.systemd.Machine.List","parameters":{"name":".host"}}`
+    /// was failing with deserialization error due to a bug in EmptyParamsDeserializer.
+    #[test]
+    fn untagged_outer_all_optional_struct_variant_with_params() {
+        // Outer untagged enum (what `service` macro generates)
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(untagged)]
+        enum OuterEnum {
+            VarlinkService(VarlinkServiceMethods),
+            UserMethods(UserMethods),
+        }
+
+        // First inner: adjacently-tagged with some methods
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(tag = "method", content = "parameters")]
+        enum VarlinkServiceMethods {
+            #[serde(rename = "org.varlink.service.GetInfo")]
+            GetInfo,
+            #[serde(rename = "org.varlink.service.GetInterfaceDescription")]
+            GetInterfaceDescription { interface: String },
+        }
+
+        // Second inner: multiple struct variants, several with ALL-OPTIONAL fields
+        // (mirrors mock_machined_service structure)
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(tag = "method", content = "parameters")]
+        enum UserMethods {
+            #[serde(rename = "X.Register")]
+            Register { name: String, class: String },
+            #[serde(rename = "X.Unregister")]
+            Unregister {
+                name: Option<String>,
+                pid: Option<i64>,
+            },
+            #[serde(rename = "X.Terminate")]
+            Terminate {
+                name: Option<String>,
+                pid: Option<i64>,
+            },
+            #[serde(rename = "X.Kill")]
+            Kill {
+                name: Option<String>,
+                pid: Option<i64>,
+                whom: Option<String>,
+                signal: Option<i64>,
+            },
+            #[serde(rename = "X.List")]
+            List {
+                name: Option<String>,
+                pid: Option<i64>,
+            },
+            #[serde(rename = "X.Open")]
+            Open {
+                name: Option<String>,
+                pid: Option<i64>,
+                mode: String,
+                user: Option<String>,
+            },
+        }
+
+        // Case 1: unit variant with empty params (serde#2045 case — must still pass)
+        let json = r#"{"method":"org.varlink.service.GetInfo","parameters":{}}"#;
+        let result: Result<Call<OuterEnum>, _> = serde_json::from_str(json);
+        let call: Call<OuterEnum> =
+            result.unwrap_or_else(|e| panic!("unit+empty params failed: {e}"));
+        assert!(
+            matches!(
+                call.method(),
+                OuterEnum::VarlinkService(VarlinkServiceMethods::GetInfo)
+            ),
+            "expected GetInfo, got {:?}",
+            call.method()
+        );
+
+        // Case 2: all-optional struct variant with non-empty params — THIS IS THE BUG
+        let json = r#"{"method":"X.List","parameters":{"name":".host"}}"#;
+        let call: Call<OuterEnum> = serde_json::from_str(json)
+            .unwrap_or_else(|e| panic!("all-opt struct variant with params failed: {e}"));
+        assert!(
+            matches!(
+                call.method(),
+                OuterEnum::UserMethods(UserMethods::List {
+                    name: Some(_),
+                    pid: None
+                })
+            ),
+            "expected List{{name: Some(\".host\")}}, got {:?}",
+            call.method()
+        );
+        if let OuterEnum::UserMethods(UserMethods::List { name: Some(n), .. }) = call.method() {
+            assert_eq!(n, ".host", "name field should be .host");
+        }
+
+        // Case 3: all-optional struct variant with EMPTY params (all None)
+        let json = r#"{"method":"X.List","parameters":{}}"#;
+        let call: Call<OuterEnum> = serde_json::from_str(json)
+            .unwrap_or_else(|e| panic!("all-opt struct variant with empty params failed: {e}"));
+        assert!(
+            matches!(
+                call.method(),
+                OuterEnum::UserMethods(UserMethods::List {
+                    name: None,
+                    pid: None,
+                })
+            ),
+            "expected List{{name: None, pid: None}}, got {:?}",
+            call.method()
+        );
+
+        // Case 4: struct variant with required field still works
+        let json = r#"{"method":"X.Register","parameters":{"name":"vm1","class":"container"}}"#;
+        let call: Call<OuterEnum> = serde_json::from_str(json)
+            .unwrap_or_else(|e| panic!("required-field struct variant failed: {e}"));
+        assert!(
+            matches!(
+                call.method(),
+                OuterEnum::UserMethods(UserMethods::Register { name, class })
+                if name == "vm1" && class == "container"
+            ),
+            "expected Register{{name:\"vm1\"}}, got {:?}",
+            call.method()
+        );
+
+        // Case 5 (regression): empty params on a struct variant, followed by `more:true`.
+        // Attempt 1 aborts when the empty map is forwarded as a unit to the struct visitor;
+        // the retry must still recover `more` from the outer map and leave the stream clean.
+        let json = r#"{"method":"X.List","parameters":{},"more":true}"#;
+        let call: Call<OuterEnum> = serde_json::from_str(json)
+            .unwrap_or_else(|e| panic!("empty params then `more` flag failed: {e}"));
+        assert!(
+            matches!(
+                call.method(),
+                OuterEnum::UserMethods(UserMethods::List {
+                    name: None,
+                    pid: None,
+                })
+            ),
+            "expected List{{None,None}}, got {:?}",
+            call.method()
+        );
+        assert!(
+            call.more(),
+            "`more` flag after empty params must be preserved"
+        );
+    }
+
+    /// Direct (non-untagged) adjacently-tagged enum: empty params on a struct variant followed
+    /// by `more:true`. Unlike the untagged path (which buffers the whole map first), here the
+    /// `FilterMap` streams the outer map, so this guards against the empty-params retry losing a
+    /// trailing flag or corrupting the stream.
+    #[test]
+    fn direct_struct_variant_empty_params_then_flag() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        #[serde(tag = "method", content = "parameters")]
+        enum Method {
+            #[serde(rename = "Ping")]
+            Ping,
+            #[serde(rename = "List")]
+            List {
+                name: Option<String>,
+                pid: Option<i64>,
+            },
+        }
+
+        // No-arg variant, empty params, trailing flag.
+        let call: Call<Method> =
+            serde_json::from_str(r#"{"method":"Ping","parameters":{},"more":true}"#)
+                .expect("Ping with empty params and flag");
+        assert!(matches!(call.method(), Method::Ping));
+        assert!(call.more());
+
+        // All-optional struct variant, empty params, trailing flag.
+        let call: Call<Method> =
+            serde_json::from_str(r#"{"method":"List","parameters":{},"oneway":true}"#)
+                .expect("List with empty params and flag");
+        assert!(matches!(
+            call.method(),
+            Method::List {
+                name: None,
+                pid: None
+            }
+        ));
+        assert!(call.oneway());
+    }
+
+    /// A method enum exercising the three shapes that interact with the empty-`parameters`
+    /// workaround (serde#2045): a no-argument unit variant, an all-optional struct variant,
+    /// and a struct variant with a required field.
+    #[derive(Debug, Deserialize, PartialEq)]
+    #[serde(tag = "method", content = "parameters")]
+    enum WireMethod {
+        #[serde(rename = "org.example.Ping")]
+        Ping,
+        #[serde(rename = "org.example.List")]
+        List {
+            name: Option<String>,
+            limit: Option<u32>,
+        },
+        #[serde(rename = "org.example.Get")]
+        Get { id: u32 },
+    }
+
+    /// What a parsed [`WireMethod`] call is expected to look like, kept simple so the test
+    /// table below reads as plain data.
+    #[derive(Debug, PartialEq)]
+    struct Expected {
+        method: WireMethod,
+        oneway: bool,
+        more: bool,
+        upgrade: bool,
+    }
+
+    impl Expected {
+        const fn new(method: WireMethod) -> Self {
+            Self {
+                method,
+                oneway: false,
+                more: false,
+                upgrade: false,
+            }
+        }
+        const fn oneway(mut self) -> Self {
+            self.oneway = true;
+            self
+        }
+        const fn more(mut self) -> Self {
+            self.more = true;
+            self
+        }
+        const fn upgrade(mut self) -> Self {
+            self.upgrade = true;
+            self
+        }
+    }
+
+    /// Comprehensive table of concrete incoming JSON wire strings that MUST deserialize, paired
+    /// with the exact `Call` they should produce. This is the canonical specification of how zlink
+    /// accepts method calls — especially the empty/absent/null `parameters` matrix that motivated
+    /// the serde#2045 workaround.
+    #[test]
+    fn parse_incoming_method_calls() {
+        use WireMethod::*;
+
+        let list_none = || List {
+            name: None,
+            limit: None,
+        };
+
+        let cases: &[(&str, Expected)] = &[
+            // --- No-argument unit variant: parameters absent / empty / null all map to the unit.
+            // ---
+            (r#"{"method":"org.example.Ping"}"#, Expected::new(Ping)),
+            (
+                r#"{"method":"org.example.Ping","parameters":{}}"#,
+                Expected::new(Ping),
+            ),
+            (
+                r#"{"method":"org.example.Ping","parameters":null}"#,
+                Expected::new(Ping),
+            ),
+            // Unit variant with trailing flags, including empty params before the flag.
+            (
+                r#"{"method":"org.example.Ping","oneway":true}"#,
+                Expected::new(Ping).oneway(),
+            ),
+            (
+                r#"{"method":"org.example.Ping","parameters":{},"more":true}"#,
+                Expected::new(Ping).more(),
+            ),
+            (
+                r#"{"method":"org.example.Ping","parameters":{},"upgrade":true}"#,
+                Expected::new(Ping).upgrade(),
+            ),
+            // Flag before an empty-params unit variant (key order independence).
+            (
+                r#"{"oneway":true,"method":"org.example.Ping","parameters":{}}"#,
+                Expected::new(Ping).oneway(),
+            ),
+            // --- All-optional struct variant: empty/absent/null => all fields None. ---
+            (
+                r#"{"method":"org.example.List","parameters":{}}"#,
+                Expected::new(list_none()),
+            ),
+            (
+                r#"{"method":"org.example.List","parameters":null}"#,
+                Expected::new(list_none()),
+            ),
+            (
+                r#"{"method":"org.example.List"}"#,
+                Expected::new(list_none()),
+            ),
+            // Absent parameters on a struct variant, followed by a flag (retry path with no
+            // mid-stream drain; the flag is captured during Attempt 1's full map walk).
+            (
+                r#"{"method":"org.example.List","oneway":true}"#,
+                Expected::new(list_none()).oneway(),
+            ),
+            // All-optional struct variant with actual values.
+            (
+                r#"{"method":"org.example.List","parameters":{"name":".host"}}"#,
+                Expected::new(List {
+                    name: Some(".host".into()),
+                    limit: None,
+                }),
+            ),
+            (
+                r#"{"method":"org.example.List","parameters":{"name":"vm1","limit":10}}"#,
+                Expected::new(List {
+                    name: Some("vm1".into()),
+                    limit: Some(10),
+                }),
+            ),
+            // Empty params on a struct variant, followed by each flag (the stream-drain
+            // regression).
+            (
+                r#"{"method":"org.example.List","parameters":{},"oneway":true}"#,
+                Expected::new(list_none()).oneway(),
+            ),
+            (
+                r#"{"method":"org.example.List","parameters":{},"more":true}"#,
+                Expected::new(list_none()).more(),
+            ),
+            (
+                r#"{"method":"org.example.List","parameters":{},"upgrade":true}"#,
+                Expected::new(list_none()).upgrade(),
+            ),
+            // Populated struct variant with all flags, in a shuffled key order.
+            (
+                r#"{"upgrade":true,"parameters":{"name":"x","limit":3},"method":"org.example.List","oneway":true}"#,
+                Expected::new(List {
+                    name: Some("x".into()),
+                    limit: Some(3),
+                })
+                .oneway()
+                .upgrade(),
+            ),
+            // --- Struct variant with a required field: normal path, unaffected by the workaround.
+            // ---
+            (
+                r#"{"method":"org.example.Get","parameters":{"id":42}}"#,
+                Expected::new(Get { id: 42 }),
+            ),
+            (
+                r#"{"method":"org.example.Get","parameters":{"id":7},"more":true}"#,
+                Expected::new(Get { id: 7 }).more(),
+            ),
+            // Unknown extra top-level fields are ignored.
+            (
+                r#"{"method":"org.example.Ping","extra":"ignored","trailing":[1,2,3]}"#,
+                Expected::new(Ping),
+            ),
+        ];
+
+        for (json, expected) in cases {
+            let call: Call<WireMethod> = serde_json::from_str(json)
+                .unwrap_or_else(|e| panic!("failed to parse {json}: {e}"));
+            let actual = Expected {
+                method: match call.method() {
+                    Ping => Ping,
+                    List { name, limit } => List {
+                        name: name.clone(),
+                        limit: *limit,
+                    },
+                    Get { id } => Get { id: *id },
+                },
+                oneway: call.oneway(),
+                more: call.more(),
+                upgrade: call.upgrade(),
+            };
+            assert_eq!(&actual, expected, "mismatch parsing {json}");
+        }
+    }
+
+    /// Wire strings that MUST be rejected: a missing required field, an unknown method, a
+    /// non-empty `parameters` on a no-argument method, and malformed flag values. These guard
+    /// against the empty-params workaround becoming overly permissive or masking real errors.
+    #[test]
+    fn reject_invalid_method_calls() {
+        let cases: &[&str] = &[
+            // Missing required field `id`.
+            r#"{"method":"org.example.Get","parameters":{}}"#,
+            r#"{"method":"org.example.Get"}"#,
+            // Unknown method name.
+            r#"{"method":"org.example.Nope","parameters":{}}"#,
+            // No-argument method given real parameters.
+            r#"{"method":"org.example.Ping","parameters":{"unexpected":1}}"#,
+            // Malformed flag values must not be silently swallowed by the empty-params retry.
+            r#"{"method":"org.example.List","more":"not-a-bool"}"#,
+            r#"{"method":"org.example.List","parameters":null,"more":123}"#,
+            r#"{"method":"org.example.Ping","oneway":123}"#,
+        ];
+
+        for json in cases {
+            let result: Result<Call<WireMethod>, _> = serde_json::from_str(json);
+            assert!(
+                result.is_err(),
+                "expected {json} to be rejected, but it parsed as {:?}",
+                result.unwrap().method()
+            );
+        }
+    }
+
     #[test]
     fn serde_flatten_in_variant() {
         // Test serialization with multiple layers of flattened parameters.

--- a/zlink-core/src/varlink_service/api.rs
+++ b/zlink-core/src/varlink_service/api.rs
@@ -395,4 +395,110 @@ mod tests {
         let deserialized: Error<'_> = serde_json::from_str(&json).unwrap();
         assert_eq!(*original, deserialized);
     }
+
+    // ---- Method deserialization tests (fix for GitHub issue #233) ----
+
+    use crate::Call;
+
+    /// Deserialize a [`Call`] of `Method` the way the server actually does.
+    ///
+    /// Going through `Call`'s deserializer is what makes an empty/`null` `parameters` object
+    /// behave like an absent one for no-argument methods (the serde#2045 workaround). The
+    /// `Method` enum itself keeps a plain derived `Deserialize`.
+    fn deserialize_method(json: &str) -> Call<Method<'_>> {
+        serde_json::from_str(json).unwrap()
+    }
+
+    #[test]
+    fn method_deserialize_get_info_variants() {
+        // Exact varlinkctl payload: parameters present as empty object.
+        let m = deserialize_method(r#"{"method":"org.varlink.service.GetInfo","parameters":{}}"#);
+        assert!(
+            matches!(m.method(), Method::GetInfo),
+            "parameters:{{}} should yield GetInfo"
+        );
+
+        // No parameters key at all.
+        let m = deserialize_method(r#"{"method":"org.varlink.service.GetInfo"}"#);
+        assert!(
+            matches!(m.method(), Method::GetInfo),
+            "absent parameters should yield GetInfo"
+        );
+
+        // parameters: null.
+        let m = deserialize_method(r#"{"method":"org.varlink.service.GetInfo","parameters":null}"#);
+        assert!(
+            matches!(m.method(), Method::GetInfo),
+            "parameters:null should yield GetInfo"
+        );
+
+        // Reversed key order: parameters before method.
+        let m = deserialize_method(r#"{"parameters":{},"method":"org.varlink.service.GetInfo"}"#);
+        assert!(
+            matches!(m.method(), Method::GetInfo),
+            "reversed key order should still yield GetInfo"
+        );
+    }
+
+    #[test]
+    fn method_deserialize_get_interface_description() {
+        // Normal key order.
+        let m = deserialize_method(
+            r#"{"method":"org.varlink.service.GetInterfaceDescription","parameters":{"interface":"org.example.Foo"}}"#,
+        );
+        assert!(
+            matches!(
+                m.method(),
+                Method::GetInterfaceDescription {
+                    interface: "org.example.Foo"
+                }
+            ),
+            "should deserialize GetInterfaceDescription with correct interface"
+        );
+
+        // Reversed key order: parameters before method.
+        let m = deserialize_method(
+            r#"{"parameters":{"interface":"org.example.Bar"},"method":"org.varlink.service.GetInterfaceDescription"}"#,
+        );
+        assert!(
+            matches!(
+                m.method(),
+                Method::GetInterfaceDescription {
+                    interface: "org.example.Bar"
+                }
+            ),
+            "reversed key order should still deserialize GetInterfaceDescription correctly"
+        );
+    }
+
+    #[test]
+    fn method_deserialize_unknown_tag_errors() {
+        let result: core::result::Result<Call<Method<'_>>, _> =
+            serde_json::from_str(r#"{"method":"org.varlink.service.NonExistent","parameters":{}}"#);
+        assert!(result.is_err(), "unknown method tag should return an error");
+    }
+
+    #[test]
+    fn method_serialize_wire_format() {
+        // GetInfo must serialize WITHOUT a `parameters` key (existing wire behavior).
+        let json = serde_json::to_string(&Method::GetInfo).unwrap();
+        assert_eq!(
+            json, r#"{"method":"org.varlink.service.GetInfo"}"#,
+            "GetInfo must serialize without a parameters key"
+        );
+
+        // GetInterfaceDescription must include parameters.
+        let json = serde_json::to_string(&Method::GetInterfaceDescription {
+            interface: "org.example.Foo",
+        })
+        .unwrap();
+        assert!(
+            json.contains(r#""parameters""#),
+            "GetInterfaceDescription must serialize with a parameters key"
+        );
+        assert!(
+            json.contains("org.example.Foo"),
+            "GetInterfaceDescription parameters must contain the interface name"
+        );
+    }
 }

--- a/zlink/tests/ftl.rs
+++ b/zlink/tests/ftl.rs
@@ -9,6 +9,8 @@ use std::{pin::pin, time::Duration};
 use futures_util::{TryStreamExt, pin_mut, stream::StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio::{select, time::sleep};
+#[cfg(feature = "tokio")]
+use zlink::ReadyListener;
 use zlink::{
     introspect::{self, CustomType, ReplyError as _, Type},
     notified::{self, traits::State as _},
@@ -507,6 +509,483 @@ async fn reply_error_derive_works() {
     let fields: Vec<_> = FtlError::VARIANTS[3].fields().collect();
     assert_eq!(fields.len(), 1);
     assert_eq!(fields[0].name(), "temperature");
+}
+
+/// Test that a server correctly handles a `GetInfo` call with `"parameters":{}` in the request.
+///
+/// Regression test for issue #233: `varlinkctl info` sends the raw bytes
+/// `{"method":"org.varlink.service.GetInfo","parameters":{}}\0` but zlink previously rejected
+/// this with a deserialization error because the no-arg `GetInfo` is a unit variant and serde
+/// rejects an empty-object `parameters` for unit variants.  The fix is a hand-written
+/// `Deserialize for Method` that accepts absent, null, or empty `parameters` for `GetInfo`.
+#[cfg(feature = "tokio")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn varlinkctl_get_info_with_empty_parameters() -> Result<(), Box<dyn std::error::Error>> {
+    let (server_conn, client) = connected_pair()?;
+    let service = Ftl::new(DriveCondition {
+        state: DriveState::Idle,
+        tylium_level: 100,
+    });
+    let server = zlink::Server::new(ReadyListener::new(server_conn), service);
+
+    select! {
+        res = server.run() => res?,
+        res = run_varlinkctl_client(client) => res?,
+    }
+
+    Ok(())
+}
+
+#[cfg(feature = "tokio")]
+async fn run_varlinkctl_client(
+    mut stream: tokio::net::UnixStream,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    // This is the exact byte sequence that `varlinkctl info` sends (strace from issue #233).
+    // The key difference from zlink's own client: it includes `"parameters":{}` for the
+    // no-argument GetInfo method, which previously triggered a deserialization error.
+    let msg = b"{\"method\":\"org.varlink.service.GetInfo\",\"parameters\":{}}\0";
+    stream.write_all(msg).await?;
+
+    // Read the NUL-terminated reply.
+    let mut buf = Vec::new();
+    loop {
+        match stream.read_u8().await {
+            Ok(0) => break,
+            Ok(b) => buf.push(b),
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    // Parse and validate the reply.  The Varlink wire format for a successful reply is:
+    //   {"parameters":{"vendor":"...","product":"...","version":"...","url":"...","interfaces":[...
+    // ]}}
+    let reply: serde_json::Value = serde_json::from_slice(&buf)?;
+
+    // Must be a successful reply (no "error" key).
+    assert!(
+        reply.get("error").is_none(),
+        "server returned an error: {reply}"
+    );
+
+    let params = reply
+        .get("parameters")
+        .expect("reply missing 'parameters' key");
+
+    assert_eq!(params["vendor"], VENDOR, "vendor mismatch");
+    assert_eq!(params["product"], PRODUCT, "product mismatch");
+    assert_eq!(params["version"], VERSION, "version mismatch");
+    assert_eq!(params["url"], URL, "url mismatch");
+
+    let interfaces: Vec<&str> = params["interfaces"]
+        .as_array()
+        .expect("interfaces must be an array")
+        .iter()
+        .map(|v| v.as_str().expect("interface entry must be a string"))
+        .collect();
+    assert!(
+        interfaces.contains(&"org.example.ftl"),
+        "missing org.example.ftl in interfaces: {interfaces:?}"
+    );
+    assert!(
+        interfaces.contains(&"org.varlink.service"),
+        "missing org.varlink.service in interfaces: {interfaces:?}"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Issue #233 regression tests: user-method enum with empty `parameters:{}`
+// ============================================================================
+
+/// Send a NUL-terminated message on a fresh connection from `conn` and read the NUL-terminated
+/// reply.
+#[cfg(feature = "tokio")]
+async fn raw_call(
+    conn: &Connector,
+    msg: &[u8],
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut stream = conn.connect();
+    stream.write_all(msg).await?;
+
+    let mut buf = Vec::new();
+    loop {
+        match stream.read_u8().await {
+            Ok(0) => break,
+            Ok(b) => buf.push(b),
+            Err(e) => return Err(e.into()),
+        }
+    }
+
+    Ok(serde_json::from_slice(&buf)?)
+}
+
+/// Hands out client-side sockets that are already connected to the running server, eliminating the
+/// listener/accept race that path-based `connect()` would otherwise require us to poll around.
+///
+/// Each [`connect`](Self::connect) creates a `socketpair`, pushes the server end to the
+/// [`PairListener`] driving the server, and returns the client end.
+#[cfg(feature = "tokio")]
+#[derive(Clone)]
+struct Connector {
+    tx: tokio::sync::mpsc::UnboundedSender<zlink::unix::Stream>,
+}
+
+#[cfg(feature = "tokio")]
+impl Connector {
+    fn connect(&self) -> tokio::net::UnixStream {
+        let (server_end, client_end) = tokio::net::UnixStream::pair().expect("socketpair");
+        self.tx
+            .send(server_end.try_into().expect("socketpair into Stream"))
+            .expect("server still running");
+        client_end
+    }
+}
+
+/// A [`Listener`] fed by a [`Connector`]: it yields each pushed server-side socket and reports
+/// closure once every `Connector` has been dropped.
+#[cfg(feature = "tokio")]
+#[derive(Debug)]
+struct PairListener {
+    rx: tokio::sync::mpsc::UnboundedReceiver<zlink::unix::Stream>,
+}
+
+#[cfg(feature = "tokio")]
+impl zlink::Listener for PairListener {
+    type Socket = zlink::unix::Stream;
+
+    async fn accept(&mut self) -> zlink::Result<Option<zlink::Connection<Self::Socket>>> {
+        Ok(self.rx.recv().await.map(zlink::Connection::new))
+    }
+}
+
+/// Build a [`Connector`]/[`PairListener`] pair sharing one channel.
+#[cfg(feature = "tokio")]
+fn connector_pair() -> (Connector, PairListener) {
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    (Connector { tx }, PairListener { rx })
+}
+
+/// Create a single connected `(server, client)` socket pair for one-shot server tests.
+#[cfg(feature = "tokio")]
+fn connected_pair()
+-> Result<(zlink::unix::Stream, tokio::net::UnixStream), Box<dyn std::error::Error>> {
+    let (server_end, client_end) = tokio::net::UnixStream::pair()?;
+    Ok((server_end.try_into()?, client_end))
+}
+
+/// Spin up a short-lived FTL server fed by socketpairs, run `client_fn`, then shut down.
+#[cfg(feature = "tokio")]
+async fn with_server<F, Fut>(client_fn: F) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: FnOnce(Connector) -> Fut,
+    Fut: std::future::Future<Output = Result<(), Box<dyn std::error::Error>>>,
+{
+    let (connector, listener) = connector_pair();
+    let service = Ftl::new(DriveCondition {
+        state: DriveState::Idle,
+        tylium_level: 100,
+    });
+    let server = zlink::Server::new(listener, service);
+    select! {
+        res = server.run() => res?,
+        res = client_fn(connector) => res?,
+    }
+    Ok(())
+}
+
+/// Regression test (issue #233): no-arg user method with `"parameters":{}` must succeed.
+///
+/// `varlinkctl call org.example.ftl.GetCoordinates '{}'` sends
+/// `{"method":"org.example.ftl.GetCoordinates","parameters":{}}\0`
+/// and previously got back `invalid type: map, expected unit variant`.
+#[cfg(feature = "tokio")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn user_method_no_arg_empty_parameters_object() -> Result<(), Box<dyn std::error::Error>> {
+    with_server(|conn| async move {
+        let reply = raw_call(
+            &conn,
+            b"{\"method\":\"org.example.ftl.GetCoordinates\",\"parameters\":{}}\0",
+        )
+        .await?;
+        assert!(
+            reply.get("error").is_none(),
+            "server returned error for no-arg method with {{}}:  {reply}"
+        );
+        let params = reply
+            .get("parameters")
+            .expect("reply missing 'parameters' key");
+        // GetCoordinates returns Coordinate { longitude, latitude, distance }
+        assert!(
+            params.get("longitude").is_some(),
+            "reply params missing 'longitude': {params}"
+        );
+        assert!(
+            params.get("latitude").is_some(),
+            "reply params missing 'latitude': {params}"
+        );
+        assert!(
+            params.get("distance").is_some(),
+            "reply params missing 'distance': {params}"
+        );
+        Ok(())
+    })
+    .await
+}
+
+/// No-arg user method: three parameter variants must all succeed identically.
+#[cfg(feature = "tokio")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn user_method_no_arg_parameter_variants() -> Result<(), Box<dyn std::error::Error>> {
+    with_server(|conn| async move {
+        // (a) no parameters key
+        let r1 = raw_call(&conn, b"{\"method\":\"org.example.ftl.GetCoordinates\"}\0").await?;
+        // (b) parameters: null
+        let r2 = raw_call(
+            &conn,
+            b"{\"method\":\"org.example.ftl.GetCoordinates\",\"parameters\":null}\0",
+        )
+        .await?;
+        // (c) parameters: {}
+        let r3 = raw_call(
+            &conn,
+            b"{\"method\":\"org.example.ftl.GetCoordinates\",\"parameters\":{}}\0",
+        )
+        .await?;
+
+        for (label, reply) in [
+            ("no-params", &r1),
+            ("null-params", &r2),
+            ("empty-params", &r3),
+        ] {
+            assert!(
+                reply.get("error").is_none(),
+                "server returned error for {label}: {reply}"
+            );
+            assert!(
+                reply.get("parameters").is_some(),
+                "reply missing 'parameters' for {label}: {reply}"
+            );
+        }
+        // All three should return the same coordinates.
+        assert_eq!(
+            r1.get("parameters"),
+            r2.get("parameters"),
+            "no-params and null-params replies differ"
+        );
+        assert_eq!(
+            r1.get("parameters"),
+            r3.get("parameters"),
+            "no-params and empty-params replies differ"
+        );
+        Ok(())
+    })
+    .await
+}
+
+/// No-arg user method: params key BEFORE method key must succeed.
+#[cfg(feature = "tokio")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn user_method_no_arg_params_before_method() -> Result<(), Box<dyn std::error::Error>> {
+    with_server(|conn| async move {
+        let reply = raw_call(
+            &conn,
+            b"{\"parameters\":{},\"method\":\"org.example.ftl.GetCoordinates\"}\0",
+        )
+        .await?;
+        assert!(
+            reply.get("error").is_none(),
+            "server returned error when params precede method: {reply}"
+        );
+        assert!(
+            reply.get("parameters").is_some(),
+            "reply missing 'parameters': {reply}"
+        );
+        Ok(())
+    })
+    .await
+}
+
+/// Struct-variant user method with populated params (method-first) must succeed.
+#[cfg(feature = "tokio")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn user_method_struct_variant_with_params() -> Result<(), Box<dyn std::error::Error>> {
+    with_server(|conn| async move {
+        // SetDriveCondition takes condition: DriveCondition { state, tylium_level }
+        let reply = raw_call(
+            &conn,
+            b"{\"method\":\"org.example.ftl.SetDriveCondition\",\
+              \"parameters\":{\"condition\":{\"state\":\"spooling\",\"tylium_level\":80}}}\0",
+        )
+        .await?;
+        assert!(
+            reply.get("error").is_none(),
+            "server returned error for struct variant method: {reply}"
+        );
+        // SetDriveCondition returns the updated DriveCondition.
+        let params = reply.get("parameters").expect("reply missing 'parameters'");
+        assert!(
+            params.get("state").is_some(),
+            "reply missing 'state': {params}"
+        );
+        assert!(
+            params.get("tylium_level").is_some(),
+            "reply missing 'tylium_level': {params}"
+        );
+        Ok(())
+    })
+    .await
+}
+
+/// Unknown method tag returns MethodNotFound, not a panic or deserialisation error.
+#[cfg(feature = "tokio")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn user_method_unknown_tag_returns_method_not_found() -> Result<(), Box<dyn std::error::Error>>
+{
+    with_server(|conn| async move {
+        let reply = raw_call(
+            &conn,
+            b"{\"method\":\"org.example.ftl.DoesNotExist\",\"parameters\":{}}\0",
+        )
+        .await?;
+        let error = reply
+            .get("error")
+            .expect("expected an error reply for unknown method");
+        assert_eq!(
+            error, "org.varlink.service.MethodNotFound",
+            "wrong error variant: {error}"
+        );
+        Ok(())
+    })
+    .await
+}
+
+/// Struct-variant method with missing required params must not succeed (no parameters reply).
+///
+/// When required fields are absent, the server either returns an error reply or closes the
+/// connection with a parse failure.  Either outcome is acceptable; what must NOT happen is
+/// a successful reply (no "error" key) being returned.
+#[cfg(feature = "tokio")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn user_method_struct_variant_missing_required_params()
+-> Result<(), Box<dyn std::error::Error>> {
+    with_server(|conn| async move {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let mut stream = conn.connect();
+
+        // SetDriveCondition requires `condition` but we send an empty object.
+        stream
+            .write_all(
+                b"{\"method\":\"org.example.ftl.SetDriveCondition\",\"parameters\":{}}\0",
+            )
+            .await?;
+
+        let mut buf = Vec::new();
+        loop {
+            match stream.read_u8().await {
+                Ok(0) => break,
+                Ok(b) => buf.push(b),
+                // EOF / connection closed by server — parse failure is acceptable.
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    return Ok(());
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        let reply: serde_json::Value = serde_json::from_slice(&buf)?;
+        // If a reply was returned it MUST be an error, never a success.
+        assert!(
+            reply.get("error").is_some(),
+            "expected an error reply (or connection close) for missing required params, got: {reply}"
+        );
+        Ok(())
+    })
+    .await
+}
+
+// ============================================================================
+// Single-struct-variant order-independence tests
+// ============================================================================
+
+/// A tiny service with exactly ONE struct-variant method.
+/// Used to prove that the generated deserializer is fully order-independent
+/// when there is only one method that takes parameters.
+#[cfg(feature = "tokio")]
+struct Echo;
+
+/// Reply struct for the Echo service.
+#[cfg(feature = "tokio")]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct EchoReply {
+    message: String,
+}
+
+#[cfg(feature = "tokio")]
+#[zlink::service(
+    interface = "org.example.echo",
+    vendor = "Test",
+    product = "Echo",
+    version = "1",
+    url = "https://example.org/",
+    types = [EchoReply]
+)]
+impl Echo {
+    /// Echo the message back.
+    async fn echo(&self, message: String) -> EchoReply {
+        EchoReply { message }
+    }
+}
+
+/// Helper: spin up a short-lived Echo server fed by socketpairs.
+#[cfg(feature = "tokio")]
+async fn with_echo_server<F, Fut>(client_fn: F) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: FnOnce(Connector) -> Fut,
+    Fut: std::future::Future<Output = Result<(), Box<dyn std::error::Error>>>,
+{
+    let (connector, listener) = connector_pair();
+    let server = zlink::Server::new(listener, Echo);
+    select! {
+        res = server.run() => res?,
+        res = client_fn(connector) => res?,
+    }
+    Ok(())
+}
+
+/// Single-struct-variant service: `parameters` BEFORE `method` must succeed.
+///
+/// This is the key order-independence proof: when there is exactly one struct-variant
+/// method in the service, the generated deserializer can eagerly capture `parameters`
+/// into the only possible slot even before the `method` key is seen.
+#[cfg(feature = "tokio")]
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn single_struct_variant_params_before_method_succeeds()
+-> Result<(), Box<dyn std::error::Error>> {
+    with_echo_server(|conn| async move {
+        let reply = raw_call(
+            &conn,
+            b"{\"parameters\":{\"message\":\"hello\"},\"method\":\"org.example.echo.Echo\"}\0",
+        )
+        .await?;
+        assert!(
+            reply.get("error").is_none(),
+            "single-struct-variant service returned error for params-before-method: {reply}"
+        );
+        let params = reply.get("parameters").expect("reply missing 'parameters'");
+        assert_eq!(
+            params.get("message").and_then(|v| v.as_str()),
+            Some("hello"),
+            "echo reply has wrong message: {params}"
+        );
+        Ok(())
+    })
+    .await
 }
 
 // ============================================================================


### PR DESCRIPTION
`varlinkctl info` sends `{"method":"org.varlink.service.GetInfo","parameters":{}}`, but zlink rejected it with "data did not match any variant". The Varlink spec is underspecified here and other implementations accept an empty `parameters` object as a valid call to a no-argument method, so zlink should too.

The root problem is https://github.com/serde-rs/serde/issues/2045: no-argument methods are unit variants of an adjacently-tagged enum (`#[serde(tag="method", content="parameters")]`), and serde refuses to deserialize an empty map into a unit variant.

Today, it's possible for zlink users to work around this by accepting a unit struct instead of `()`, but that's mildly annoying.

I burned some tokens on this, and...it's quite intricate, but this is an improvement on some previous attempts.

Generated-by: OpenCode (Claude Opus 4.8, Gemini 3.1 Pro)

Closes: https://github.com/z-galaxy/zlink/issues/233