### PR TITLE
🔒️ core: remove pidfd_open fallback

### DIFF
--- a/zlink-core/src/connection/credentials.rs
+++ b/zlink-core/src/connection/credentials.rs
@@ -9,7 +9,7 @@ pub struct Credentials {
     #[cfg(target_os = "linux")]
     unix_supplementary_group_ids: Vec<Gid>,
     #[cfg(target_os = "linux")]
-    process_fd: std::os::fd::OwnedFd,
+    process_fd: Option<std::os::fd::OwnedFd>,
 }
 
 impl Credentials {
@@ -17,7 +17,7 @@ impl Credentials {
     pub(crate) fn new(
         basic: PassedCredentials,
         #[cfg(target_os = "linux")] unix_supplementary_group_ids: Vec<Gid>,
-        #[cfg(target_os = "linux")] process_fd: std::os::fd::OwnedFd,
+        #[cfg(target_os = "linux")] process_fd: Option<std::os::fd::OwnedFd>,
     ) -> Self {
         Self {
             basic,
@@ -59,11 +59,13 @@ impl Credentials {
     /// to identify a process than the ProcessID, as the latter is subject to re-use attacks, while
     /// the FD cannot be recycled. If the original process no longer exists the FD will no longer
     /// be resolvable.
+    /// The SO_PEERPIDFD socket option was added to Linux in version 6.5. This method will return
+    /// None on older kernel versions.
     #[cfg(target_os = "linux")]
-    pub fn process_fd(&self) -> std::os::fd::BorrowedFd<'_> {
+    pub fn process_fd(&self) -> Option<std::os::fd::BorrowedFd<'_>> {
         use std::os::fd::AsFd;
 
-        self.process_fd.as_fd()
+        self.process_fd.as_ref().map(|fd| fd.as_fd())
     }
 }
 

--- a/zlink-core/src/test_utils/mock_socket.rs
+++ b/zlink-core/src/test_utils/mock_socket.rs
@@ -184,13 +184,10 @@ impl connection::socket::FetchPeerCredentials for MockReadHalf {
 
         #[cfg(target_os = "linux")]
         {
-            use rustix::process::PidfdFlags;
-
-            let process_fd = rustix::process::pidfd_open(pid, PidfdFlags::empty())?;
             Ok(connection::Credentials::new(
                 connection::PassedCredentials::new(uid, gid, pid),
                 vec![],
-                process_fd,
+                None,
             ))
         }
 

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -119,7 +119,7 @@ pub fn sendmsg(
 /// # Platform Support
 ///
 /// - **Linux/Android**: Uses `SO_PEERCRED` to get uid and pid. On Linux, also gets `SO_PEERPIDFD`
-///   for process FD (falls back to `pidfd_open` if not available).
+///   for process FD.
 /// - **macOS/iOS**: Uses `getpeereid()` for uid and `LOCAL_PEERPID` for pid.
 /// - **OpenBSD**: Uses `getpeereid()` for uid and `SO_PEERCRED` for pid.
 /// - **NetBSD**: Uses `getpeereid()` for uid and `LOCAL_PEEREID` for pid.
@@ -209,15 +209,15 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
             // `getsockopt` returns `0` on success or `-1` on error.
             if ret == 0 {
                 let pidfd = unsafe { pidfd.assume_init() };
-                unsafe { OwnedFd::from_raw_fd(pidfd) }
+                Some(unsafe { OwnedFd::from_raw_fd(pidfd) })
             } else {
                 let err = io::Error::last_os_error();
                 // ENOPROTOOPT means the kernel doesn't support this feature.
                 if err.raw_os_error() != Some(libc::ENOPROTOOPT) {
                     return Err(err);
                 }
-                // If SO_PEERPIDFD is not supported, we fall back to using pidfd_open.
-                rustix::process::pidfd_open(pid, rustix::process::PidfdFlags::empty())?
+                // No error, but SO_PEERPIDFD is not supported
+                None
             }
         };
 

--- a/zlink-core/src/unix_utils.rs
+++ b/zlink-core/src/unix_utils.rs
@@ -208,6 +208,11 @@ pub(crate) fn get_peer_credentials(fd: impl AsFd) -> io::Result<Credentials> {
 
             // `getsockopt` returns `0` on success or `-1` on error.
             if ret == 0 {
+                assert_eq!(
+                    len as usize,
+                    size_of::<libc::c_int>(),
+                    "unexpected getsockopt size"
+                );
                 let pidfd = unsafe { pidfd.assume_init() };
                 Some(unsafe { OwnedFd::from_raw_fd(pidfd) })
             } else {

--- a/zlink/tests/creds-utils.rs
+++ b/zlink/tests/creds-utils.rs
@@ -66,7 +66,11 @@ fn is_pid_valid(actual: Pid, expected: Pid) -> bool {
 pub fn verify_pidfd(creds: &Credentials) -> Result<(), &'static str> {
     use std::os::fd::{AsFd, AsRawFd};
 
-    let fd_num = creds.process_fd().as_fd().as_raw_fd();
+    let fd_num = creds
+        .process_fd()
+        .ok_or("No Process FD")?
+        .as_fd()
+        .as_raw_fd();
     if fd_num < 0 {
         return Err("Process FD is invalid");
     }

--- a/zlink/tests/peer_credentials.rs
+++ b/zlink/tests/peer_credentials.rs
@@ -40,7 +40,7 @@ async fn peer_credentials_unix_socket() {
     let pid1 = creds.process_id();
     let gid1 = creds.unix_primary_group_id();
     #[cfg(target_os = "linux")]
-    let pidfd1 = creds.process_fd().as_raw_fd();
+    let pidfd1 = creds.process_fd().map(|fd| fd.as_raw_fd());
     #[cfg(target_os = "linux")]
     let gids1 = creds.unix_supplementary_group_ids().to_owned();
 
@@ -56,7 +56,7 @@ async fn peer_credentials_unix_socket() {
     #[cfg(target_os = "linux")]
     assert_eq!(
         pidfd1,
-        creds2.process_fd().as_raw_fd(),
+        creds2.process_fd().map(|fd| fd.as_raw_fd()),
         "Cached pidfd should match"
     );
     #[cfg(target_os = "linux")]


### PR DESCRIPTION
The previous server code on Linux would first attempt to obtain the peer pid via SO_PEERPIDFD, but then fall back to using `pidfd_open`.

This delay between receiving the socket message and opening the pidfd introduces a race condition, which is an issue for certain workflows such as Polkit authentication. This commit modifies the `process_fd` method to return an `Option`, and will return `None` if the pidfd could not be obtained via the secure socket option. A server that needs a pidfd but is okay with the race condition can call `pidfd_open` on the `process_id` themselves.

This does mean that process_fd can now fail, which is a breaking change, but since zlink isn't 1.0 I don't think it matters.

Closes #276

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
