### PR TITLE
🐛 macros: Fix introspection to include method & interface doc-comments

### DIFF
--- a/zlink-macros/src/introspect/mod.rs
+++ b/zlink-macros/src/introspect/mod.rs
@@ -2,4 +2,4 @@ pub(crate) mod custom_type;
 pub(crate) mod reply_error;
 pub(crate) mod r#type;
 
-mod shared;
+pub(crate) mod shared;

--- a/zlink-macros/src/introspect/shared.rs
+++ b/zlink-macros/src/introspect/shared.rs
@@ -5,7 +5,7 @@ use syn::{DataEnum, Error, Fields, FieldsNamed, FieldsUnnamed};
 use crate::utils;
 
 /// Generate comment objects from a list of comments.
-pub(super) fn generate_comment_objects(
+pub(crate) fn generate_comment_objects(
     comments: &[String],
     crate_path: &TokenStream2,
 ) -> Vec<TokenStream2> {

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -60,6 +60,7 @@ pub(super) fn generate_service_impl(
     item_impl: &ItemImpl,
     methods_info: &[MethodInfo],
     service_attrs: &ServiceAttrs,
+    impl_comments: &[String],
 ) -> Result<TokenStream, Error> {
     let crate_path = &service_attrs.crate_path;
     let self_ty = &item_impl.self_ty;
@@ -109,6 +110,7 @@ pub(super) fn generate_service_impl(
         &interfaces,
         crate_path,
         &type_name,
+        impl_comments,
     )?;
 
     // Generate the ReplyStreamParams enum for streaming methods.
@@ -907,6 +909,7 @@ fn generate_interface_descriptions(
     interfaces: &[String],
     crate_path: &TokenStream,
     type_name: &str,
+    impl_comments: &[String],
 ) -> Result<TokenStream, Error> {
     let mut descriptions: Vec<TokenStream> = Vec::new();
 
@@ -1056,6 +1059,11 @@ fn generate_interface_descriptions(
                     }
                 });
 
+                let comment_objects = crate::introspect::shared::generate_comment_objects(
+                    &method.comments,
+                    crate_path,
+                );
+
                 Ok(quote! {
                     const #method_const_name: &#crate_path::idl::Method<'static> = &{
                         #in_params_const
@@ -1072,7 +1080,7 @@ fn generate_interface_descriptions(
                             #method_name,
                             __IN_PARAMS,
                             __OUT_PARAMS,
-                            &[],
+                            &[#(#comment_objects),*],
                         )
                     };
                 })
@@ -1151,6 +1159,9 @@ fn generate_interface_descriptions(
             })
             .collect();
 
+        let interface_comment_objects =
+            crate::introspect::shared::generate_comment_objects(impl_comments, crate_path);
+
         descriptions.push(quote! {
             #[doc(hidden)]
             const #const_name: &#crate_path::idl::Interface<'static> = &{
@@ -1160,7 +1171,7 @@ fn generate_interface_descriptions(
                     &[#(#method_refs),*],
                     &[#(#custom_types),*],
                     #error_variants_expr,
-                    &[],
+                    &[#(#interface_comment_objects),*],
                 )
             };
 

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -41,6 +41,8 @@ pub(super) struct MethodInfo {
     pub stream_uses_impl_trait: bool,
     /// Whether this method returns file descriptors (`#[zlink(return_fds)]`).
     pub return_fds: bool,
+    /// Doc-comments on this method, for introspection.
+    pub comments: Vec<String>,
 }
 
 impl MethodInfo {
@@ -51,6 +53,9 @@ impl MethodInfo {
         current_interface: &mut Option<String>,
     ) -> Result<Self, Error> {
         let name = method.sig.ident.clone();
+
+        // Extract doc comments before any attribute processing.
+        let comments = crate::utils::extract_doc_comments(&method.attrs);
 
         // Extract method attributes.
         let method_attrs = MethodAttrs::extract(&mut method.attrs)?;
@@ -303,6 +308,7 @@ impl MethodInfo {
             stream_return_type,
             stream_uses_impl_trait,
             return_fds,
+            comments,
         })
     }
 

--- a/zlink-macros/src/service/mod.rs
+++ b/zlink-macros/src/service/mod.rs
@@ -28,6 +28,9 @@ fn service_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Er
     // Parse macro attributes.
     let service_attrs = ServiceAttrs::parse(&attr, &item_impl)?;
 
+    // Extract doc-comments from the impl block for interface-level introspection.
+    let impl_comments = crate::utils::extract_doc_comments(&item_impl.attrs);
+
     // Validate impl block.
     validate_impl(&item_impl)?;
 
@@ -76,7 +79,8 @@ fn service_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Er
     }
 
     // Generate the Service trait implementation (uses generics from item_impl if present).
-    let service_impl = codegen::generate_service_impl(&item_impl, &methods_info, &service_attrs)?;
+    let service_impl =
+        codegen::generate_service_impl(&item_impl, &methods_info, &service_attrs, &impl_comments)?;
 
     // Prepare the output impl block.
     let mut output_impl = item_impl;

--- a/zlink-macros/tests/service/basic.rs
+++ b/zlink-macros/tests/service/basic.rs
@@ -88,8 +88,11 @@ pub(crate) struct Balance {
 #[derive(Debug, Clone, PartialEq, zlink::ReplyError, introspect::ReplyError)]
 #[zlink(interface = "org.example.bank")]
 pub(crate) enum BankError {
+    /// Not enough funds available.
     InsufficientFunds { available: i64, requested: i64 },
+    /// The requested amount is invalid.
     InvalidAmount { amount: i64 },
+    /// The account is locked.
     AccountLocked,
 }
 
@@ -108,10 +111,10 @@ impl BankAccount {
     }
 }
 
-// Apply the service macro.
+/// A simple bank account service for testing.
 #[zlink::service(types = [Balance])]
 impl BankAccount {
-    // Method that returns a plain value (not Result).
+    /// Get the current account balance.
     #[zlink(interface = "org.example.bank")]
     async fn get_balance(&self) -> Balance {
         Balance {
@@ -119,7 +122,7 @@ impl BankAccount {
         }
     }
 
-    // Method that can fail - returns Result<Balance, BankError>.
+    /// Deposit funds into the account.
     async fn deposit(&mut self, amount: i64) -> Result<Balance, BankError> {
         if self.locked {
             return Err(BankError::AccountLocked);
@@ -133,7 +136,9 @@ impl BankAccount {
         })
     }
 
-    // Another method that can fail.
+    /// Withdraw funds from the account.
+    ///
+    /// Returns an error if the balance is insufficient.
     async fn withdraw(&mut self, amount: i64) -> Result<Balance, BankError> {
         if self.locked {
             return Err(BankError::AccountLocked);
@@ -153,7 +158,7 @@ impl BankAccount {
         })
     }
 
-    // Method returning Result<(), BankError> (void success, can fail).
+    /// Lock the account to prevent further transactions.
     async fn lock_account(&mut self) -> Result<(), BankError> {
         if self.locked {
             return Err(BankError::AccountLocked);

--- a/zlink-macros/tests/service/introspection.rs
+++ b/zlink-macros/tests/service/introspection.rs
@@ -88,6 +88,46 @@ async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::er
         }
     }
 
+    // Verify method doc-comments are propagated through the full round-trip
+    // (compile-time constant → IDL text → parse).
+    for method in interface.methods() {
+        let comment_text: Vec<_> = method.comments().map(|c| c.content()).collect();
+        match method.name() {
+            "GetBalance" => {
+                assert_eq!(comment_text, ["Get the current account balance."]);
+            }
+            "Deposit" => {
+                assert_eq!(comment_text, ["Deposit funds into the account."]);
+            }
+            "Withdraw" => {
+                // Multi-line doc-comment: the blank `///` line survives
+                // the round-trip as an empty comment.
+                assert_eq!(
+                    comment_text,
+                    [
+                        "Withdraw funds from the account.",
+                        "",
+                        "Returns an error if the balance is insufficient."
+                    ]
+                );
+            }
+            "LockAccount" => {
+                assert_eq!(
+                    comment_text,
+                    ["Lock the account to prevent further transactions."]
+                );
+            }
+            x => panic!("Unknown method: {x}"),
+        }
+    }
+
+    // Verify interface-level doc-comments are propagated.
+    let interface_comments: Vec<_> = interface.comments().map(|c| c.content()).collect();
+    assert_eq!(
+        interface_comments,
+        ["A simple bank account service for testing."]
+    );
+
     // Verify the interface contains exactly the expected errors.
     let error_names: Vec<_> = interface.errors().map(|e| e.name()).collect();
     assert_eq!(
@@ -95,6 +135,23 @@ async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::er
         ["InsufficientFunds", "InvalidAmount", "AccountLocked"],
         "Unexpected errors"
     );
+
+    // Verify error doc-comments are propagated.
+    for error in interface.errors() {
+        let comment_text: Vec<_> = error.comments().map(|c| c.content()).collect();
+        match error.name() {
+            "InsufficientFunds" => {
+                assert_eq!(comment_text, ["Not enough funds available."]);
+            }
+            "InvalidAmount" => {
+                assert_eq!(comment_text, ["The requested amount is invalid."]);
+            }
+            "AccountLocked" => {
+                assert_eq!(comment_text, ["The account is locked."]);
+            }
+            x => panic!("Unknown error: {x}"),
+        }
+    }
 
     // Verify the interface contains exactly the expected custom types.
     let type_names: Vec<_> = interface.custom_types().map(|t| t.name()).collect();


### PR DESCRIPTION
The service macro extracted doc-comments for struct fields (via the Type
derive) but discarded them on methods and the impl block itself — the
generated Method::new() and Interface::new() always passed &[] for
comments.  This meant GetInterfaceDescription returned IDL without any
method or interface descriptions.

Extract #[doc] attributes from methods and the impl block, and thread
them through to the generated introspection constants.  Reuses the
existing extract_doc_comments and generate_comment_objects helpers by
widening their visibility to pub(crate).

LLM info: https://github.com/cgwalters/cgwalters#llms
Signed-off-by: Colin Walters <walters@verbum.org>