### PR TITLE
📝 Document top-down module ordering; point AGENTS.md to CONTRIBUTING.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,9 @@
 
 This file provides guidance to AI coding agents when working with code in this repository.
 
+For contribution conventions — commit-message format, atomic commits, code layout, and
+more — follow the guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
 ## Development Commands
 
 ### Testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,14 @@ Same rules apply here as for bug reports and feature requests. Plus:
   [`git-revise`](https://github.com/mystor/git-revise) extremely useful, especially if you're not
   very familiar with interactive rebasing and modifying commits in git.
 
+### Code layout
+
+Within a module, order items top-down, [as rustls does](https://github.com/rustls/rustls/blob/main/CONTRIBUTING.md#top-down-ordering-within-modules):
+items depend on items defined *below* them, not above. In practice: the
+public API sits near the top of the file, private helpers below the code
+that calls them, simple `const`s below their users, and `#[cfg(test)] mod
+tests` at the very bottom.
+
 ### Legal Notice
 
 When contributing to this project, you **implicitly** declare that:


### PR DESCRIPTION
Brings the top-down module-ordering convention (documented in pixel8) to this repo. zlink already uses the `AGENTS.md` name, so no rename is needed.

- **📝 Document top-down module ordering** in `CONTRIBUTING.md` (a new `### Code layout` section, the way rustls documents the same rule) and point `AGENTS.md` at `CONTRIBUTING.md` for it rather than repeating the text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hsPwJedhjrYeW8zyqiUcs

---
_Generated by [Claude Code](https://claude.ai/code/session_017hsPwJedhjrYeW8zyqiUcs)_