### PR TITLE
💥 macros: Require rename for underscore-prefixed method params

### DIFF
--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1038,7 +1038,9 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///
 /// ## On parameters:
 ///
-/// * `#[zlink(rename = "paramName")]` - Custom serialized parameter name.
+/// * `#[zlink(rename = "paramName")]` - Custom serialized parameter name. **Required** for
+///   parameter names starting with `_` (the Rust convention for unused parameters), since such
+///   names are not valid in the Varlink IDL.
 /// * `#[zlink(connection)]` - Mark this parameter to receive a mutable reference to the connection.
 ///   This is useful for accessing peer credentials or other connection-specific functionality.
 ///   **Requires an explicit generic socket type parameter** (e.g., `impl<Sock> MyService`).
@@ -1069,6 +1071,9 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 ///     }
 /// }
 /// ```
+///
+/// Similarly, parameter names starting with `_` are rejected because they are not valid in the
+/// Varlink IDL. Specify the wire name explicitly with `#[zlink(rename = "...")]`.
 ///
 /// # Generated Code
 ///

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -314,8 +314,11 @@ fn generate_method_call_enum(
                         let name = &param.name;
                         let converted_ty = convert_type_lifetimes(&param.ty, "'__de");
 
-                        let serde_attr = if let Some(ref renamed) = param.serialized_name {
-                            quote! { #[serde(rename = #renamed)] }
+                        // Rename whenever the wire name differs from the Rust name, so that
+                        // dispatch stays consistent with the introspection data.
+                        let wire_name = param.wire_name();
+                        let serde_attr = if *name != wire_name {
+                            quote! { #[serde(rename = #wire_name)] }
                         } else {
                             quote! {}
                         };
@@ -977,10 +980,7 @@ fn generate_interface_descriptions(
                 let in_params: Vec<TokenStream> = method
                     .serialized_params()
                     .map(|p| {
-                        // Strip leading underscores from parameter names for IDL (Rust convention
-                        // uses `_name` for unused params, but Varlink IDL doesn't allow that).
-                        let default_name = p.name.to_string().trim_start_matches('_').to_string();
-                        let param_name = p.serialized_name.as_ref().unwrap_or(&default_name);
+                        let param_name = p.wire_name();
                         let ty = convert_type_lifetimes(&p.ty, "'static");
                         quote! {
                             &#crate_path::idl::Parameter::new(

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -113,6 +113,21 @@ impl MethodInfo {
             }
         }
 
+        // Underscore-prefixed names are not valid Varlink field names, so serialized parameters
+        // (the ones that end up on the wire and in the IDL) must be given an explicit wire name.
+        for param in params
+            .iter()
+            .filter(|p| !p.is_connection && !p.is_more && !p.is_fds)
+        {
+            if param.serialized_name.is_none() && param.name.to_string().starts_with('_') {
+                return Err(Error::new_spanned(
+                    &param.name,
+                    "parameter names starting with `_` are not valid Varlink field names; \
+                     specify the wire name with `#[zlink(rename = \"...\")]`",
+                ));
+            }
+        }
+
         // Validate FD attributes.
         let return_fds = method_attrs.return_fds;
         let fds_params: Vec<_> = params.iter().filter(|p| p.is_fds).collect();

--- a/zlink-macros/src/service/types.rs
+++ b/zlink-macros/src/service/types.rs
@@ -1,5 +1,7 @@
 //! Types used in service macro processing.
 
+use std::borrow::Cow;
+
 use syn::{FnArg, Ident, Pat, Type};
 
 /// Information about a method parameter.
@@ -20,6 +22,18 @@ pub(super) struct ParamInfo {
 }
 
 impl ParamInfo {
+    /// The parameter name used on the wire (and in the IDL).
+    ///
+    /// This is the explicit `#[zlink(rename = "...")]` name if provided, the Rust parameter
+    /// name otherwise. Parameter names starting with `_` are rejected at extraction time, so
+    /// this is always a valid Varlink field name.
+    pub(super) fn wire_name(&self) -> Cow<'_, str> {
+        match &self.serialized_name {
+            Some(name) => Cow::Borrowed(name),
+            None => Cow::Owned(self.name.to_string()),
+        }
+    }
+
     /// Extract parameter information from a function argument.
     pub(super) fn from_fn_arg(arg: &FnArg) -> Option<Self> {
         let FnArg::Typed(pat_type) = arg else {

--- a/zlink-macros/tests/service.rs
+++ b/zlink-macros/tests/service.rs
@@ -27,3 +27,5 @@ mod streaming;
 mod streaming_errors;
 #[path = "service/streaming_fds.rs"]
 mod streaming_fds;
+#[path = "service/underscore_params.rs"]
+mod underscore_params;

--- a/zlink-macros/tests/service/basic.rs
+++ b/zlink-macros/tests/service/basic.rs
@@ -12,7 +12,7 @@ async fn service_macro_basic() -> Result<(), Box<dyn std::error::Error>> {
     let dir = tempfile::tempdir()?;
     let socket_path = dir.path().join("test.sock");
 
-    // Setup the server and run it in a separate task.
+    // Set up the server and run it concurrently with the client.
     let listener = bind(&socket_path).unwrap();
     let service = BankAccount::new(1000, false);
     let server = Server::new(listener, service);

--- a/zlink-macros/tests/service/underscore_params.rs
+++ b/zlink-macros/tests/service/underscore_params.rs
@@ -1,0 +1,124 @@
+//! Tests for underscore-prefixed (unused) method parameters.
+//!
+//! Underscore-prefixed names (the Rust convention for unused parameters) are not valid Varlink
+//! field names, so the service macro requires an explicit `#[zlink(rename = "...")]` wire name
+//! for them (rejecting them with a compile error otherwise). This test verifies that renamed
+//! underscore-prefixed parameters work end to end: dispatch accepts the wire name and the
+//! introspection data advertises it.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use zlink::{
+    Server,
+    introspect::{self, CustomType},
+    unix::{bind, connect},
+};
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn underscore_prefixed_params() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
+
+    // Set up the server and run it concurrently with the client.
+    let listener = bind(&socket_path).unwrap();
+    let service = Launcher;
+    let server = Server::new(listener, service);
+    tokio::select! {
+        res = server.run() => res?,
+        res = run_client(&socket_path) => res?,
+    }
+
+    Ok(())
+}
+
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = connect(socket_path).await?;
+
+    // Call the methods using the renamed parameter names, exactly as advertised by the
+    // introspection data.
+    let reply = conn
+        .uninstall("org.example.Foo.desktop", HashMap::new())
+        .await?
+        .unwrap();
+    assert_eq!(reply.desktop_file_id, "org.example.Foo.desktop");
+
+    // Also exercise the connection-param code path (the method body is inlined by the macro).
+    let reply = conn
+        .launch("org.example.Bar.desktop", HashMap::new())
+        .await?
+        .unwrap();
+    assert_eq!(reply.desktop_file_id, "org.example.Bar.desktop");
+
+    // The introspection data must advertise the renamed names.
+    {
+        use zlink::varlink_service::Proxy as VarlinkProxy;
+
+        let desc = conn
+            .get_interface_description("org.example.launcher")
+            .await?
+            .unwrap();
+        let interface = desc.parse()?;
+        for name in ["Uninstall", "Launch"] {
+            let method = interface
+                .methods()
+                .find(|m| m.name() == name)
+                .expect("method not found in introspection data");
+            let input_names: Vec<_> = method.inputs().map(|f| f.name()).collect();
+            assert_eq!(input_names.as_slice(), &["desktop_file_id", "options"]);
+        }
+    }
+
+    Ok(())
+}
+
+// Response type echoing back the desktop file ID.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct Launched {
+    desktop_file_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.launcher")]
+enum LauncherError {
+    NotFound,
+}
+
+struct Launcher;
+
+#[zlink::service(types = [Launched])]
+impl<Sock> Launcher {
+    /// Uninstall a launcher, ignoring the options.
+    #[zlink(interface = "org.example.launcher")]
+    async fn uninstall(
+        &mut self,
+        desktop_file_id: String,
+        #[zlink(rename = "options")] _options: HashMap<String, String>,
+    ) -> Result<Launched, LauncherError> {
+        Ok(Launched { desktop_file_id })
+    }
+
+    /// Launch an app, ignoring the options.
+    async fn launch(
+        &mut self,
+        desktop_file_id: String,
+        #[zlink(rename = "options")] _options: HashMap<String, String>,
+        #[zlink(connection)] _conn: &mut zlink::Connection<Sock>,
+    ) -> Result<Launched, LauncherError> {
+        Ok(Launched { desktop_file_id })
+    }
+}
+
+#[zlink::proxy("org.example.launcher")]
+trait LauncherProxy {
+    async fn uninstall(
+        &mut self,
+        desktop_file_id: &str,
+        options: HashMap<String, String>,
+    ) -> zlink::Result<Result<Launched, LauncherError>>;
+    async fn launch(
+        &mut self,
+        desktop_file_id: &str,
+        options: HashMap<String, String>,
+    ) -> zlink::Result<Result<Launched, LauncherError>>;
+}

--- a/zlink/tests/ftl.rs
+++ b/zlink/tests/ftl.rs
@@ -37,7 +37,7 @@ async fn ftl() -> Result<(), Box<dyn std::error::Error>> {
         },
     ];
 
-    // Setup the server and run it in a separate task.
+    // Set up the server and run it concurrently with the client.
     let listener = bind(&socket_path).unwrap();
     let service = Ftl::new(conditions[0]);
     let server = zlink::Server::new(listener, service);

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -227,11 +227,11 @@ mod server {
         #[allow(clippy::too_many_arguments)]
         async fn register(
             &self,
-            _name: String,
-            _id: Option<String>,
-            _service: Option<String>,
-            _class: String,
-            _leader: Option<u32>,
+            #[zlink(rename = "name")] _name: String,
+            #[zlink(rename = "id")] _id: Option<String>,
+            #[zlink(rename = "service")] _service: Option<String>,
+            #[zlink(rename = "class")] _class: String,
+            #[zlink(rename = "leader")] _leader: Option<u32>,
             #[zlink(rename = "leaderProcessId")] _leader_process_id: Option<ProcessId>,
             #[zlink(rename = "rootDirectory")] _root_directory: Option<String>,
             #[zlink(rename = "ifIndices")] _if_indices: Option<Vec<u64>>,
@@ -249,8 +249,8 @@ mod server {
 
         async fn unregister(
             &self,
-            _name: Option<String>,
-            _pid: Option<ProcessId>,
+            #[zlink(rename = "name")] _name: Option<String>,
+            #[zlink(rename = "pid")] _pid: Option<ProcessId>,
             #[zlink(rename = "allowInteractiveAuthentication")]
             _allow_interactive_authentication: Option<bool>,
             #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
@@ -261,8 +261,8 @@ mod server {
 
         async fn terminate(
             &self,
-            _name: Option<String>,
-            _pid: Option<ProcessId>,
+            #[zlink(rename = "name")] _name: Option<String>,
+            #[zlink(rename = "pid")] _pid: Option<ProcessId>,
             #[zlink(rename = "allowInteractiveAuthentication")]
             _allow_interactive_authentication: Option<bool>,
             #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
@@ -273,12 +273,12 @@ mod server {
 
         async fn kill(
             &self,
-            _name: Option<String>,
-            _pid: Option<ProcessId>,
+            #[zlink(rename = "name")] _name: Option<String>,
+            #[zlink(rename = "pid")] _pid: Option<ProcessId>,
             #[zlink(rename = "allowInteractiveAuthentication")]
             _allow_interactive_authentication: Option<bool>,
-            _whom: Option<String>,
-            _signal: i64,
+            #[zlink(rename = "whom")] _whom: Option<String>,
+            #[zlink(rename = "signal")] _signal: i64,
             #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
         ) -> Result<(), MachinedError> {
             verify_credentials(conn).await?;
@@ -287,8 +287,8 @@ mod server {
 
         async fn list(
             &self,
-            _name: Option<String>,
-            _pid: Option<ProcessId>,
+            #[zlink(rename = "name")] _name: Option<String>,
+            #[zlink(rename = "pid")] _pid: Option<ProcessId>,
             #[zlink(rename = "allowInteractiveAuthentication")]
             _allow_interactive_authentication: Option<bool>,
             #[zlink(rename = "acquireMetadata")] _acquire_metadata: Option<AcquireMetadata>,
@@ -301,15 +301,15 @@ mod server {
         #[allow(clippy::too_many_arguments)]
         async fn open(
             &self,
-            _name: Option<String>,
-            _pid: Option<ProcessId>,
+            #[zlink(rename = "name")] _name: Option<String>,
+            #[zlink(rename = "pid")] _pid: Option<ProcessId>,
             #[zlink(rename = "allowInteractiveAuthentication")]
             _allow_interactive_authentication: Option<bool>,
-            _mode: MachineOpenMode,
-            _user: Option<String>,
-            _path: Option<String>,
-            _args: Option<Vec<String>>,
-            _environment: Option<Vec<String>>,
+            #[zlink(rename = "mode")] _mode: MachineOpenMode,
+            #[zlink(rename = "user")] _user: Option<String>,
+            #[zlink(rename = "path")] _path: Option<String>,
+            #[zlink(rename = "args")] _args: Option<Vec<String>>,
+            #[zlink(rename = "environment")] _environment: Option<Vec<String>>,
             #[zlink(connection)] conn: &mut zlink::Connection<Sock>,
         ) -> Result<OpenReply, MachinedError> {
             verify_credentials(conn).await?;


### PR DESCRIPTION
Fixes #278.

The `#[service]` macro silently stripped leading underscores from parameter names in the generated introspection data (Rust convention uses `_name` for unused params, but such names are not valid in the Varlink IDL), while method dispatch deserialized parameters under their raw Rust names — so a call using the advertised name (e.g. `options` for `_options`) failed to find the method.

Rather than fixing the implicit stripping to be consistent, this PR removes it: underscore-prefixed serialized parameters now **require** an explicit `#[zlink(rename = "...")]` wire name and are rejected with a compile error otherwise. The wire name is part of the service's public API, so deriving it by silent transformation was the root of the inconsistency; with a single source of truth (`ParamInfo::wire_name`) the introspection data and dispatch can no longer disagree. Connection, `more`, and FD parameters are exempt since they never appear on the wire.

This is a compile-time breaking change for code that used underscore-prefixed parameters — but dispatch never worked for such parameters as advertised, so no working end-to-end setup can regress. The mock machined service test is adapted accordingly (its multi-word parameters already carried explicit renames).

Includes an end-to-end test for renamed underscore-prefixed params, covering both the regular dispatch path and the inlined `#[zlink(connection)]` path, plus the introspection output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvdnjjUJLjc5zyXDM4B5mh