### PR TITLE
🚨 Fix clippy warnings from latest stable Rust

### DIFF
--- a/zlink-codegen/test-integration/src/lib.rs
+++ b/zlink-codegen/test-integration/src/lib.rs
@@ -233,7 +233,7 @@ mod tests {
         // This is important for testing the string reference handling in arrays.
         // The search method takes query: &str and tags: &[&str] for the tags parameter.
         // The proxy macro should handle the conversion properly.
-        let tags_to_search = vec!["important".to_string(), "urgent".to_string()];
+        let tags_to_search = ["important".to_string(), "urgent".to_string()];
         let tags_refs: Vec<&str> = tags_to_search.iter().map(|s| s.as_str()).collect();
 
         let result = conn

--- a/zlink-core/benches/benchmarks.rs
+++ b/zlink-core/benches/benchmarks.rs
@@ -418,11 +418,11 @@ impl ReadHalf for BiPipeReadHalf {
                 let to_read = self.buffer.len().min(buf.len());
                 buf[..to_read].copy_from_slice(&self.buffer[..to_read]);
                 self.pos = to_read;
-                return Ok(zlink_core::connection::socket::ReadResult::new(to_read));
+                Ok(zlink_core::connection::socket::ReadResult::new(to_read))
             }
             None => {
                 // Connection closed.
-                return Ok(zlink_core::connection::socket::ReadResult::new(0));
+                Ok(zlink_core::connection::socket::ReadResult::new(0))
             }
         }
     }

--- a/zlink-core/src/connection/chain/mod.rs
+++ b/zlink-core/src/connection/chain/mod.rs
@@ -406,9 +406,9 @@ mod tests {
         #[derive(Debug, Serialize, Deserialize)]
         #[serde(untagged)]
         enum HeterogeneousErrors {
-            UserError(ApiError),
-            PostError(PostError),
-            DeleteError(DeleteError),
+            User(ApiError),
+            Post(PostError),
+            Delete(DeleteError),
         }
 
         #[derive(Debug, Serialize, Deserialize)]

--- a/zlink-core/src/connection/tests/chain_fds_tests.rs
+++ b/zlink-core/src/connection/tests/chain_fds_tests.rs
@@ -268,8 +268,8 @@ async fn chain_receive_fds_from_server() {
     assert_eq!(fds.len(), 3);
 
     // Remaining results have no FDs (no new read operations).
-    for i in 1..3 {
-        let (reply, fds) = results[i].as_ref().unwrap();
+    for (i, result) in results.iter().enumerate().skip(1) {
+        let (reply, fds) = result.as_ref().unwrap();
         let user = reply.as_ref().unwrap();
         assert_eq!(user.parameters().unwrap().id, (i + 1) as u32);
         assert_eq!(fds.len(), 0);

--- a/zlink-core/src/connection/tests/read_connection_tests.rs
+++ b/zlink-core/src/connection/tests/read_connection_tests.rs
@@ -49,7 +49,7 @@ async fn malformed_json_deeply_nested_objects() {
     for _ in 0..10000 {
         malicious.push_str(r#"{"a":"#);
     }
-    malicious.push_str("0");
+    malicious.push('0');
     for _ in 0..10000 {
         malicious.push('}');
     }
@@ -72,7 +72,7 @@ async fn malformed_json_deeply_nested_arrays() {
     for _ in 0..10000 {
         malicious.push('[');
     }
-    malicious.push_str("0");
+    malicious.push('0');
     for _ in 0..10000 {
         malicious.push(']');
     }

--- a/zlink-core/src/connection/tests/write_connection_tests.rs
+++ b/zlink-core/src/connection/tests/write_connection_tests.rs
@@ -198,8 +198,7 @@ async fn call_pipelining() {
     assert_eq!(null_count, 3);
 
     // Verify each null terminator is at the end of a complete JSON object.
-    for i in 0..null_count {
-        let pos = null_positions[i];
+    for &pos in &null_positions[..null_count] {
         assert!(
             pos > 0,
             "Null terminator at position {pos} should not be at start"

--- a/zlink-core/src/introspect/custom_type.rs
+++ b/zlink-core/src/introspect/custom_type.rs
@@ -60,7 +60,7 @@ mod tests {
             static VARIANT_ACTIVE: EnumVariant<'static> = EnumVariant::new("Active", &[]);
             static VARIANT_INACTIVE: EnumVariant<'static> = EnumVariant::new("Inactive", &[]);
             static VARIANT_PENDING: EnumVariant<'static> = EnumVariant::new("Pending", &[]);
-            static VARIANTS: &[&'static EnumVariant<'static>] =
+            static VARIANTS: &[&EnumVariant<'static>] =
                 &[&VARIANT_ACTIVE, &VARIANT_INACTIVE, &VARIANT_PENDING];
 
             idl::CustomType::Enum(CustomEnum::new("Status", VARIANTS, &[]))

--- a/zlink-core/src/introspect/type/tests.rs
+++ b/zlink-core/src/introspect/type/tests.rs
@@ -91,7 +91,7 @@ fn smart_pointer_types() {
 
 #[test]
 fn cell_types() {
-    use std::cell::{Cell, RefCell};
+    use core::cell::{Cell, RefCell};
     // Test Cell<f64>
     assert_eq!(*<Cell<f64>>::TYPE, idl::Type::Float);
 

--- a/zlink-core/src/json_ser.rs
+++ b/zlink-core/src/json_ser.rs
@@ -1311,8 +1311,8 @@ mod tests {
         let n = to_slice(&-42i64, &mut buf).unwrap();
         assert_eq!(&buf[..n], b"-42");
 
-        let n = to_slice(&3.14f64, &mut buf).unwrap();
-        assert_eq!(&buf[..n], b"3.14");
+        let n = to_slice(&2.5f64, &mut buf).unwrap();
+        assert_eq!(&buf[..n], b"2.5");
 
         let n = to_slice(&"hello", &mut buf).unwrap();
         assert_eq!(&buf[..n], b"\"hello\"");

--- a/zlink-core/src/varlink_service/info.rs
+++ b/zlink-core/src/varlink_service/info.rs
@@ -156,8 +156,7 @@ mod tests {
 
     #[test]
     fn serialization() {
-        let mut interfaces = Vec::new();
-        interfaces.push("com.example.test");
+        let interfaces = alloc::vec!["com.example.test"];
 
         let info = Info::new(
             "Test Vendor",
@@ -196,9 +195,7 @@ mod tests {
 
     #[test]
     fn round_trip_serialization() {
-        let mut interfaces = Vec::new();
-        interfaces.push("com.example.test");
-        interfaces.push("com.example.other");
+        let interfaces = alloc::vec!["com.example.test", "com.example.other"];
 
         let original = Info::new(
             "Test Vendor",

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -47,7 +47,7 @@ pub(super) fn generate_chain_method(
     }
 
     // Generate chain method name
-    let chain_method_name = syn::Ident::new(&format!("chain_{}", &method_name_str), method_span);
+    let chain_method_name = syn::Ident::new(&format!("chain_{method_name_str}"), method_span);
 
     let converted_name = snake_case_to_pascal_case(&method_name_str);
     let actual_method_name = method_attrs.rename.as_deref().unwrap_or(&converted_name);

--- a/zlink-macros/tests/introspect-reply-error.rs
+++ b/zlink-macros/tests/introspect-reply-error.rs
@@ -4,62 +4,53 @@ use zlink::introspect::ReplyError;
 
 #[test]
 fn simple_error_enum() {
-    match ServiceError::VARIANTS {
-        variants => {
-            assert_eq!(variants.len(), 3);
+    let variants = ServiceError::VARIANTS;
+    assert_eq!(variants.len(), 3);
 
-            assert_eq!(variants[0].name(), "NotFound");
-            assert!(variants[0].has_no_fields());
+    assert_eq!(variants[0].name(), "NotFound");
+    assert!(variants[0].has_no_fields());
 
-            assert_eq!(variants[1].name(), "PermissionDenied");
-            assert!(variants[1].has_no_fields());
+    assert_eq!(variants[1].name(), "PermissionDenied");
+    assert!(variants[1].has_no_fields());
 
-            assert_eq!(variants[2].name(), "InternalError");
-            assert!(variants[2].has_no_fields());
-        }
-    }
+    assert_eq!(variants[2].name(), "InternalError");
+    assert!(variants[2].has_no_fields());
 }
 
 #[test]
 fn single_variant_error() {
-    match SingleError::VARIANTS {
-        variants => {
-            assert_eq!(variants.len(), 1);
-            assert_eq!(variants[0].name(), "OnlyError");
-            assert!(variants[0].has_no_fields());
-        }
-    }
+    let variants = SingleError::VARIANTS;
+    assert_eq!(variants.len(), 1);
+    assert_eq!(variants[0].name(), "OnlyError");
+    assert!(variants[0].has_no_fields());
 }
 
 #[test]
 fn multi_variant_error() {
-    match NetworkError::VARIANTS {
-        variants => {
-            assert_eq!(variants.len(), 5);
-            assert_eq!(variants[0].name(), "Timeout");
-            assert_eq!(variants[1].name(), "ConnectionRefused");
-            assert_eq!(variants[2].name(), "HostUnreachable");
-            assert_eq!(variants[3].name(), "InvalidResponse");
-            assert_eq!(variants[4].name(), "Unauthorized");
+    let variants = NetworkError::VARIANTS;
+    assert_eq!(variants.len(), 5);
+    assert_eq!(variants[0].name(), "Timeout");
+    assert_eq!(variants[1].name(), "ConnectionRefused");
+    assert_eq!(variants[2].name(), "HostUnreachable");
+    assert_eq!(variants[3].name(), "InvalidResponse");
+    assert_eq!(variants[4].name(), "Unauthorized");
 
-            // Verify all have no fields
-            for variant in variants {
-                assert!(variant.has_no_fields());
-            }
-        }
+    // Verify all have no fields
+    for variant in variants {
+        assert!(variant.has_no_fields());
     }
 }
 
 // Test that the macro generates const-compatible code
 #[test]
 fn const_compatibility() {
-    const _: &'static [&'static zlink::idl::Error<'static>] = ServiceError::VARIANTS;
-    const _: &'static [&'static zlink::idl::Error<'static>] = SingleError::VARIANTS;
-    const _: &'static [&'static zlink::idl::Error<'static>] = NetworkError::VARIANTS;
-    const _: &'static [&'static zlink::idl::Error<'static>] = DatabaseError::VARIANTS;
-    const _: &'static [&'static zlink::idl::Error<'static>] = ValidationError::VARIANTS;
-    const _: &'static [&'static zlink::idl::Error<'static>] = TupleError::VARIANTS;
-    const _: &'static [&'static zlink::idl::Error<'static>] = MixedTupleError::VARIANTS;
+    const _: &[&zlink::idl::Error<'static>] = ServiceError::VARIANTS;
+    const _: &[&zlink::idl::Error<'static>] = SingleError::VARIANTS;
+    const _: &[&zlink::idl::Error<'static>] = NetworkError::VARIANTS;
+    const _: &[&zlink::idl::Error<'static>] = DatabaseError::VARIANTS;
+    const _: &[&zlink::idl::Error<'static>] = ValidationError::VARIANTS;
+    const _: &[&zlink::idl::Error<'static>] = TupleError::VARIANTS;
+    const _: &[&zlink::idl::Error<'static>] = MixedTupleError::VARIANTS;
 }
 
 #[test]
@@ -78,114 +69,102 @@ fn error_names_match_variants() {
 
 #[test]
 fn mixed_variants_error() {
-    match DatabaseError::VARIANTS {
-        variants => {
-            assert_eq!(variants.len(), 4);
+    let variants = DatabaseError::VARIANTS;
+    assert_eq!(variants.len(), 4);
 
-            // Unit variant
-            assert_eq!(variants[0].name(), "ConnectionFailed");
-            assert!(variants[0].has_no_fields());
+    // Unit variant
+    assert_eq!(variants[0].name(), "ConnectionFailed");
+    assert!(variants[0].has_no_fields());
 
-            // Variant with named fields
-            assert_eq!(variants[1].name(), "InvalidQuery");
-            assert!(!variants[1].has_no_fields());
-            let fields: Vec<_> = variants[1].fields().collect();
-            assert_eq!(fields.len(), 2);
-            assert_eq!(fields[0].name(), "message");
-            assert_eq!(fields[1].name(), "line");
+    // Variant with named fields
+    assert_eq!(variants[1].name(), "InvalidQuery");
+    assert!(!variants[1].has_no_fields());
+    let fields: Vec<_> = variants[1].fields().collect();
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name(), "message");
+    assert_eq!(fields[1].name(), "line");
 
-            // Another variant with named fields
-            assert_eq!(variants[2].name(), "Timeout");
-            assert!(!variants[2].has_no_fields());
-            let fields: Vec<_> = variants[2].fields().collect();
-            assert_eq!(fields.len(), 1);
-            assert_eq!(fields[0].name(), "seconds");
+    // Another variant with named fields
+    assert_eq!(variants[2].name(), "Timeout");
+    assert!(!variants[2].has_no_fields());
+    let fields: Vec<_> = variants[2].fields().collect();
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name(), "seconds");
 
-            // Variant with multiple named fields
-            assert_eq!(variants[3].name(), "AccessDenied");
-            assert!(!variants[3].has_no_fields());
-            let fields: Vec<_> = variants[3].fields().collect();
-            assert_eq!(fields.len(), 3);
-            assert_eq!(fields[0].name(), "user");
-            assert_eq!(fields[1].name(), "resource");
-            assert_eq!(fields[2].name(), "action");
-        }
-    }
+    // Variant with multiple named fields
+    assert_eq!(variants[3].name(), "AccessDenied");
+    assert!(!variants[3].has_no_fields());
+    let fields: Vec<_> = variants[3].fields().collect();
+    assert_eq!(fields.len(), 3);
+    assert_eq!(fields[0].name(), "user");
+    assert_eq!(fields[1].name(), "resource");
+    assert_eq!(fields[2].name(), "action");
 }
 
 #[test]
 fn named_fields_only_error() {
-    match ValidationError::VARIANTS {
-        variants => {
-            assert_eq!(variants.len(), 2);
+    let variants = ValidationError::VARIANTS;
+    assert_eq!(variants.len(), 2);
 
-            // All variants should have fields
-            for variant in variants {
-                assert!(!variant.has_no_fields());
-            }
-
-            assert_eq!(variants[0].name(), "FieldMissing");
-            let fields: Vec<_> = variants[0].fields().collect();
-            assert_eq!(fields.len(), 1);
-            assert_eq!(fields[0].name(), "field_name");
-
-            assert_eq!(variants[1].name(), "InvalidFormat");
-            let fields: Vec<_> = variants[1].fields().collect();
-            assert_eq!(fields.len(), 3);
-            assert_eq!(fields[0].name(), "field_name");
-            assert_eq!(fields[1].name(), "expected");
-            assert_eq!(fields[2].name(), "actual");
-        }
+    // All variants should have fields
+    for variant in variants {
+        assert!(!variant.has_no_fields());
     }
+
+    assert_eq!(variants[0].name(), "FieldMissing");
+    let fields: Vec<_> = variants[0].fields().collect();
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name(), "field_name");
+
+    assert_eq!(variants[1].name(), "InvalidFormat");
+    let fields: Vec<_> = variants[1].fields().collect();
+    assert_eq!(fields.len(), 3);
+    assert_eq!(fields[0].name(), "field_name");
+    assert_eq!(fields[1].name(), "expected");
+    assert_eq!(fields[2].name(), "actual");
 }
 
 #[test]
 fn tuple_variant_error() {
-    match TupleError::VARIANTS {
-        variants => {
-            assert_eq!(variants.len(), 2);
+    let variants = TupleError::VARIANTS;
+    assert_eq!(variants.len(), 2);
 
-            // Unit variant
-            assert_eq!(variants[0].name(), "Simple");
-            assert!(variants[0].has_no_fields());
+    // Unit variant
+    assert_eq!(variants[0].name(), "Simple");
+    assert!(variants[0].has_no_fields());
 
-            // Tuple variant with struct fields
-            assert_eq!(variants[1].name(), "Complex");
-            assert!(!variants[1].has_no_fields());
-            let fields: Vec<_> = variants[1].fields().collect();
-            assert_eq!(fields.len(), 2);
-            assert_eq!(fields[0].name(), "code");
-            assert_eq!(fields[1].name(), "description");
-        }
-    }
+    // Tuple variant with struct fields
+    assert_eq!(variants[1].name(), "Complex");
+    assert!(!variants[1].has_no_fields());
+    let fields: Vec<_> = variants[1].fields().collect();
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name(), "code");
+    assert_eq!(fields[1].name(), "description");
 }
 
 #[test]
 fn mixed_tuple_and_named_error() {
-    match MixedTupleError::VARIANTS {
-        variants => {
-            assert_eq!(variants.len(), 3);
+    let variants = MixedTupleError::VARIANTS;
+    assert_eq!(variants.len(), 3);
 
-            // Unit variant
-            assert_eq!(variants[0].name(), "NotFound");
-            assert!(variants[0].has_no_fields());
+    // Unit variant
+    assert_eq!(variants[0].name(), "NotFound");
+    assert!(variants[0].has_no_fields());
 
-            // Named field variant
-            assert_eq!(variants[1].name(), "InvalidInput");
-            assert!(!variants[1].has_no_fields());
-            let fields: Vec<_> = variants[1].fields().collect();
-            assert_eq!(fields.len(), 1);
-            assert_eq!(fields[0].name(), "message");
+    // Named field variant
+    assert_eq!(variants[1].name(), "InvalidInput");
+    assert!(!variants[1].has_no_fields());
+    let fields: Vec<_> = variants[1].fields().collect();
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name(), "message");
 
-            // Tuple variant
-            assert_eq!(variants[2].name(), "DatabaseError");
-            assert!(!variants[2].has_no_fields());
-            let fields: Vec<_> = variants[2].fields().collect();
-            assert_eq!(fields.len(), 2);
-            assert_eq!(fields[0].name(), "code");
-            assert_eq!(fields[1].name(), "description");
-        }
-    }
+    // Tuple variant
+    assert_eq!(variants[2].name(), "DatabaseError");
+    assert!(!variants[2].has_no_fields());
+    let fields: Vec<_> = variants[2].fields().collect();
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name(), "code");
+    assert_eq!(fields[1].name(), "description");
 }
 
 // Test basic service error enum

--- a/zlink-macros/tests/proxy/complex_lifetimes.rs
+++ b/zlink-macros/tests/proxy/complex_lifetimes.rs
@@ -5,6 +5,8 @@ async fn complex_lifetimes_test() {
     use std::collections::HashMap;
     use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
+    // The explicit lifetimes are the point of this test: the proxy macro must handle them.
+    #[allow(clippy::needless_lifetimes)]
     #[proxy("org.example.Complex")]
     trait ComplexProxy {
         async fn process_array(

--- a/zlink-macros/tests/proxy/lifetimes.rs
+++ b/zlink-macros/tests/proxy/lifetimes.rs
@@ -4,6 +4,8 @@ async fn lifetimes_test() {
     use serde_json::json;
     use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
 
+    // The explicit lifetimes are the point of this test: the proxy macro must handle them.
+    #[allow(clippy::needless_lifetimes)]
     #[proxy("org.example.Lifetimes")]
     trait LifetimeProxy {
         async fn process<'a>(

--- a/zlink-macros/tests/service/borrowed-types.rs
+++ b/zlink-macros/tests/service/borrowed-types.rs
@@ -85,7 +85,7 @@ impl Calculator {
             Err(CalculatorError::DivisionByZero {
                 message: "Cannot divide by zero",
             })
-        } else if dividend < -1000000.0 || dividend > 1000000.0 {
+        } else if !(-1000000.0..=1000000.0).contains(&dividend) {
             Err(CalculatorError::InvalidInput {
                 field: "dividend",
                 reason: "must be within range",

--- a/zlink-macros/tests/service/explicit-lifetimes.rs
+++ b/zlink-macros/tests/service/explicit-lifetimes.rs
@@ -19,6 +19,8 @@ enum EchoError<'a> {
 
 struct EchoService;
 
+// The explicit lifetimes are the point of this test: the service macro must handle them.
+#[allow(clippy::needless_lifetimes)]
 #[zlink::service(types = [EchoReply])]
 impl EchoService {
     #[zlink(interface = "org.example.ExplicitLifetimes")]

--- a/zlink-macros/tests/service/per_interface_types.rs
+++ b/zlink-macros/tests/service/per_interface_types.rs
@@ -21,7 +21,7 @@ async fn per_interface_types() -> Result<(), Box<dyn std::error::Error>> {
     let socket_path = dir.path().join("per-iface-types.sock");
 
     let listener = bind(&socket_path).unwrap();
-    let service = CatalogService::default();
+    let service = CatalogService;
     let server = Server::new(listener, service);
     tokio::select! {
         res = server.run() => res?,

--- a/zlink-macros/tests/tuple_variant_errors.rs
+++ b/zlink-macros/tests/tuple_variant_errors.rs
@@ -26,30 +26,27 @@ fn tuple_with_non_object_type_panics() {
 
 #[test]
 fn mixed_variants_with_valid_tuple() {
-    match MixedValidError::VARIANTS {
-        variants => {
-            assert_eq!(variants.len(), 3);
+    let variants = MixedValidError::VARIANTS;
+    assert_eq!(variants.len(), 3);
 
-            // Unit variant
-            assert_eq!(variants[0].name(), "Simple");
-            assert!(variants[0].has_no_fields());
+    // Unit variant
+    assert_eq!(variants[0].name(), "Simple");
+    assert!(variants[0].has_no_fields());
 
-            // Named fields variant
-            assert_eq!(variants[1].name(), "WithFields");
-            assert!(!variants[1].has_no_fields());
-            let fields: Vec<_> = variants[1].fields().collect();
-            assert_eq!(fields.len(), 1);
-            assert_eq!(fields[0].name(), "reason");
+    // Named fields variant
+    assert_eq!(variants[1].name(), "WithFields");
+    assert!(!variants[1].has_no_fields());
+    let fields: Vec<_> = variants[1].fields().collect();
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].name(), "reason");
 
-            // Valid single tuple variant
-            assert_eq!(variants[2].name(), "WithTuple");
-            assert!(!variants[2].has_no_fields());
-            let fields: Vec<_> = variants[2].fields().collect();
-            assert_eq!(fields.len(), 2);
-            assert_eq!(fields[0].name(), "code");
-            assert_eq!(fields[1].name(), "message");
-        }
-    }
+    // Valid single tuple variant
+    assert_eq!(variants[2].name(), "WithTuple");
+    assert!(!variants[2].has_no_fields());
+    let fields: Vec<_> = variants[2].fields().collect();
+    assert_eq!(fields.len(), 2);
+    assert_eq!(fields[0].name(), "code");
+    assert_eq!(fields[1].name(), "message");
 }
 
 // Valid enum with single tuple variant

--- a/zlink/tests/integration_test_custom_type.rs
+++ b/zlink/tests/integration_test_custom_type.rs
@@ -38,8 +38,7 @@ impl CustomType for Color {
         static VARIANT_RED: EnumVariant<'static> = EnumVariant::new("Red", &[]);
         static VARIANT_GREEN: EnumVariant<'static> = EnumVariant::new("Green", &[]);
         static VARIANT_BLUE: EnumVariant<'static> = EnumVariant::new("Blue", &[]);
-        static VARIANTS: &[&'static EnumVariant<'static>] =
-            &[&VARIANT_RED, &VARIANT_GREEN, &VARIANT_BLUE];
+        static VARIANTS: &[&EnumVariant<'static>] = &[&VARIANT_RED, &VARIANT_GREEN, &VARIANT_BLUE];
 
         idl::CustomType::Enum(CustomEnum::new("Color", VARIANTS, &[]))
     };

--- a/zlink/tests/mock_machined_service.rs
+++ b/zlink/tests/mock_machined_service.rs
@@ -202,6 +202,7 @@ mod server {
     }
 
     /// Mock systemd-machined service that serves hardcoded responses.
+    #[derive(Default)]
     pub struct MockMachinedService;
 
     impl MockMachinedService {
@@ -330,7 +331,7 @@ mod server {
             return Err(MachinedError::FetchPeerCredentialsFailed);
         };
         // Verify credentials match current process.
-        if creds_utils::verify_credentials(&creds).is_err() {
+        if creds_utils::verify_credentials(creds).is_err() {
             return Err(MachinedError::FetchPeerCredentialsFailed);
         }
         Ok(())

--- a/zlink/tests/peer_credentials.rs
+++ b/zlink/tests/peer_credentials.rs
@@ -33,7 +33,7 @@ async fn peer_credentials_unix_socket() {
     let creds = connection.peer_credentials().await.unwrap();
 
     // Verify all credentials match current process using shared utilities.
-    creds_utils::verify_credentials(&creds).expect("Credentials should match current process");
+    creds_utils::verify_credentials(creds).expect("Credentials should match current process");
 
     // Save values for comparison.
     let uid1 = creds.unix_user_id();


### PR DESCRIPTION
The latest stable toolchain introduced new lint findings across the
workspace. Apply the suggested fixes:

* Replace the `3.14f64` test value that triggered the deny-by-default
  `approx_constant` lint.
* Drop the redundant `Error` postfix from `HeterogeneousErrors` test
  variants (`enum_variant_names`).
* Use `vec!` instead of `Vec::new` + `push` (`vec_init_then_push`).
* Iterate directly instead of indexing (`needless_range_loop`).
* Replace single-binding `match` blocks with `let` statements
  (`match_single_binding`).
* Derive `Default` for `MockMachinedService` (`new_without_default`).
* Inline the format arg in `chain_method.rs` instead of passing a
  redundant reference (`useless_borrows_in_formatting`).
* Elide redundant `'static` lifetimes, `return` statements, `vec!`
  usage and other machine-applicable suggestions via `clippy --fix`.
* Allow `needless_lifetimes` in the proxy and service macro tests that
  intentionally exercise explicit lifetimes.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UvdnjjUJLjc5zyXDM4B5mh

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
