### PR TITLE
🔖 Releases

### DIFF
--- a/zlink-codegen/CHANGELOG.md
+++ b/zlink-codegen/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - 2026-07-11
+
+### Added
+- ✨ Add --rustfmt to zlink-codegen.
+- ✨ Introduce generate_files() function.
+- ✨ Introduce an error.rs.
+
+### Changed
+- 🔧 Replace hardcoded /tmp socket paths.
+- 🏗️ ReplyError derive no longer requires specific field order.
+- 🏗️ Drop support for `no_alloc`. #144
+
+### Dependencies
+- ⬆️ Update chrono to v0.4.42 (#107).
+
+### Documentation
+- 📝 Update docs as per the recent changes.
+- 📝 Drop explicit lifetimes in Server example.
+- 📝 Advertise the new Matrix channel.
+- 📝 Redesign the top part, now that we have a nice logo.
+- 📝 Add logo to the docs.
+
+### Fixed
+- 🐛 Fix the example varlink interface. #145
+- 🐛 Add `rename` attributes to method parameters. #129
+- 🐛 add `zlink` instead of `serde` attribute for ReplyError.
+
+### Other
+- 🚨 Fix clippy warnings from latest stable Rust.
+- ♻ Refactor main.rs to use generate_files().
+- 📄 Add license file to individual crates. #131
+
+### Testing
+- ✅ Update test-integration to use generate_files().
+- 🧪 Add tests for camelCase params/fields.
+
 ## 0.5.0 - 2026-05-03
 
 ### Fixed

--- a/zlink-core/CHANGELOG.md
+++ b/zlink-core/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - 2026-07-11
+
+### Added
+- ✨ Auto-enable SO_PASSCRED on unix sockets.
+- ✨ Send credentials over unix sockets.
+- ✨ Implement credentials receiving from unix sockets. #267
+- ✨ API for receiving credentials.
+- ✨ Add PassedCredentials.
+- ✨ ReadyListener signals exhaustion after handing out its socket.
+- ✨ Support custom types per interface in introspection.
+
+### Breaking
+- 💥 Socket::read now returns a named struct.
+- 💥 Let Listener::accept signal exhaustion.
+
+### Changed
+- 🔧 Replace hardcoded /tmp socket paths.
+- 🎨 A micro refactor.
+
+### Documentation
+- 📝 Drop redundant internal docs.
+
+### Fixed
+- 🐛 Exit Server::run when a listener signals exhaustion.
+
+### Other
+- 🚨 Fix clippy warnings from latest stable Rust.
+- 🦺 add safety check to getsockopt call.
+
+### Security
+- 🔒️ remove pidfd_open fallback.
+
 ## 0.5.0 - 2026-05-03
 
 ### Added

--- a/zlink-macros/CHANGELOG.md
+++ b/zlink-macros/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - 2026-07-11
+
+### Added
+- ✨ Support custom types per interface in introspection.
+
+### Breaking
+- 💥 Require rename for underscore-prefixed method params. #278
+
+### Changed
+- 🔧 Replace hardcoded /tmp socket paths with tempfile.
+
+### Documentation
+- 💡 Fix stale comment about server task in tests.
+- 📝 Add doc-comments to BankAccount test service.
+
+### Fixed
+- 🐛 Fix introspection to include method & interface doc-comments.
+
+### Other
+- 🚨 Fix clippy warnings from latest stable Rust.
+
+### Testing
+- ✅ Add test for underscore-prefixed method params.
+- ✅ Add tests for method & interface doc-comment introspection.
+
 ## 0.5.0 - 2026-05-03
 
 ### Added

--- a/zlink-smol/CHANGELOG.md
+++ b/zlink-smol/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - 2026-07-11
+
+### Added
+- ✨ Auto-enable SO_PASSCRED on unix sockets.
+- ✨ Send credentials over unix sockets.
+- ✨ Construct unix::Stream from std::os::unix::net::UnixStream.
+
+### Breaking
+- 💥 TryFrom instead of From for unix Stream.
+- 💥 Socket::read now returns a named struct.
+- 💥 Let Listener::accept signal exhaustion.
+
+### Changed
+- 🔧 Replace hardcoded /tmp socket paths.
+
 ## 0.5.0 - 2026-05-03
 
 ### Fixed

--- a/zlink-tokio/CHANGELOG.md
+++ b/zlink-tokio/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - 2026-07-11
+
+### Added
+- ✨ Auto-enable SO_PASSCRED on unix sockets.
+- ✨ Send credentials over unix sockets.
+- ✨ Construct unix::Stream from std::os::unix::net::UnixStream.
+
+### Breaking
+- 💥 TryFrom instead of From for unix Stream.
+- 💥 Socket::read now returns a named struct.
+- 💥 Let Listener::accept signal exhaustion.
+
+### Changed
+- 🔧 Replace hardcoded /tmp socket paths.
+
 ## 0.5.0 - 2026-05-03
 
 ### Fixed

--- a/zlink/CHANGELOG.md
+++ b/zlink/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.0 - 2026-07-11
+
+### Breaking
+- 💥 Require rename for underscore-prefixed method params. #278
+- 💥 Let Listener::accept signal exhaustion.
+
+### Changed
+- 🔧 Replace hardcoded /tmp socket paths.
+
+### Documentation
+- 💡 Fix stale comment about server task in tests.
+
+### Other
+- 🚨 Fix clippy warnings from latest stable Rust.
+
+### Security
+- 🔒️ remove pidfd_open fallback.
+
+### Testing
+- ✅ Test for passing credentials over unix sockets.
+- ✅ Regression test for ReadyListener-driven server exit.
+
 ## 0.5.0 - 2026-05-03
 
 ### Fixed


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->

Prepared by [release-plz](https://release-plz.dev/) for the **0.6.0** release of all workspace crates.

The crate versions in `Cargo.toml` were already at `0.6.0` (ahead of the `0.5.0` published on crates.io), so release-plz only regenerated the changelogs from the gimoji-style commit history since the `*-0.5.0` tags.

## Versions

| Crate | From | To |
| --- | --- | --- |
| `zlink-core` | 0.5.0 | 0.6.0 |
| `zlink-macros` | 0.5.0 | 0.6.0 |
| `zlink-tokio` | 0.5.0 | 0.6.0 |
| `zlink-smol` | 0.5.0 | 0.6.0 |
| `zlink-codegen` | 0.5.0 | 0.6.0 |
| `zlink` | 0.5.0 | 0.6.0 |

## Highlights

- **`zlink-core`**: credential passing over unix sockets (`SO_PASSCRED`, `PassedCredentials`), listener-exhaustion signalling (breaking `Socket::read` / `Listener::accept` changes), custom types per interface in introspection, and the removal of the `pidfd_open` fallback.
- **`zlink-tokio` / `zlink-smol`**: credential support, `unix::Stream` construction from `std` unix streams (breaking `TryFrom` change), and the `Listener::accept` exhaustion signal.
- **`zlink-macros`**: introspection now includes method & interface doc-comments; underscore-prefixed method params now require an explicit `rename` (breaking).
- **`zlink-codegen`**: new `--rustfmt` flag, `generate_files()` API, dedicated `error.rs`, and dropped `no_alloc` support.

## Changes

Only the six `CHANGELOG.md` files are touched — one new `## 0.6.0 - 2026-07-11` section per crate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxxwofHAhUCGNoHbj1Yysw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxxwofHAhUCGNoHbj1Yysw)_