### PR TITLE
📝 Fix 0.6.0 changelogs mis-generated from a shallow clone

### DIFF
--- a/zlink-codegen/CHANGELOG.md
+++ b/zlink-codegen/CHANGELOG.md
@@ -12,34 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ✨ Introduce generate_files() function.
 - ✨ Introduce an error.rs.
 
-### Changed
-- 🔧 Replace hardcoded /tmp socket paths.
-- 🏗️ ReplyError derive no longer requires specific field order.
-- 🏗️ Drop support for `no_alloc`. #144
-
-### Dependencies
-- ⬆️ Update chrono to v0.4.42 (#107).
-
-### Documentation
-- 📝 Update docs as per the recent changes.
-- 📝 Drop explicit lifetimes in Server example.
-- 📝 Advertise the new Matrix channel.
-- 📝 Redesign the top part, now that we have a nice logo.
-- 📝 Add logo to the docs.
-
-### Fixed
-- 🐛 Fix the example varlink interface. #145
-- 🐛 Add `rename` attributes to method parameters. #129
-- 🐛 add `zlink` instead of `serde` attribute for ReplyError.
-
 ### Other
 - 🚨 Fix clippy warnings from latest stable Rust.
 - ♻ Refactor main.rs to use generate_files().
-- 📄 Add license file to individual crates. #131
 
 ### Testing
 - ✅ Update test-integration to use generate_files().
-- 🧪 Add tests for camelCase params/fields.
 
 ## 0.5.0 - 2026-05-03
 

--- a/zlink-core/CHANGELOG.md
+++ b/zlink-core/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💥 Let Listener::accept signal exhaustion.
 
 ### Changed
-- 🔧 Replace hardcoded /tmp socket paths.
 - 🎨 A micro refactor.
 
 ### Documentation

--- a/zlink-macros/CHANGELOG.md
+++ b/zlink-macros/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💥 Require rename for underscore-prefixed method params. #278
 
 ### Changed
+- 🔧 Replace hardcoded /tmp socket paths.
 - 🔧 Replace hardcoded /tmp socket paths with tempfile.
 
 ### Documentation

--- a/zlink-macros/CHANGELOG.md
+++ b/zlink-macros/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💥 Require rename for underscore-prefixed method params. #278
 
 ### Changed
-- 🔧 Replace hardcoded /tmp socket paths.
 - 🔧 Replace hardcoded /tmp socket paths with tempfile.
 
 ### Documentation

--- a/zlink-smol/CHANGELOG.md
+++ b/zlink-smol/CHANGELOG.md
@@ -17,9 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💥 Socket::read now returns a named struct.
 - 💥 Let Listener::accept signal exhaustion.
 
-### Changed
-- 🔧 Replace hardcoded /tmp socket paths.
-
 ## 0.5.0 - 2026-05-03
 
 ### Fixed

--- a/zlink-tokio/CHANGELOG.md
+++ b/zlink-tokio/CHANGELOG.md
@@ -17,9 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 💥 Socket::read now returns a named struct.
 - 💥 Let Listener::accept signal exhaustion.
 
-### Changed
-- 🔧 Replace hardcoded /tmp socket paths.
-
 ## 0.5.0 - 2026-05-03
 
 ### Fixed


### PR DESCRIPTION
<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->

## What

Corrects the `0.6.0` sections of all six crate changelogs. They were previously generated by release-plz running against a **shallow clone**, whose truncated commit graph caused two classes of error:

1. Already-released (pre-`0.5.0`) commits were swept into the `0.6.0` sections — most heavily in `zlink-codegen` (no_alloc, chrono `#107`, license files `#131`, logo/docs, example fixes, etc.).
2. The cross-crate "Replace hardcoded /tmp socket paths" commit (`ce4f4a7`, which touches only `zlink` and `zlink-macros`) leaked into crates it never touched, while being *missing* from `zlink-macros` where it belongs.

Each crate's `0.6.0` section is now rebuilt to exactly the commits in `<crate>-0.5.0..<crate>-0.6.0` that modify that crate.

## Changes per crate

| Crate | Change | Bullets |
| --- | --- | --- |
| `zlink` | none (already correct) | 8 |
| `zlink-core` | remove spurious `🔧 …/tmp…` | 15 |
| `zlink-macros` | add genuine `🔧 …/tmp…` (was missing) | 10 |
| `zlink-tokio` | remove spurious `🔧 …/tmp…` (+ empty group) | 6 |
| `zlink-smol` | remove spurious `🔧 …/tmp…` (+ empty group) | 6 |
| `zlink-codegen` | remove 14 spurious pre-`0.5.0` entries, keep the 6 genuine `asn-codegen` entries | 6 |

Bullet counts now match each crate's genuine post-`0.5.0` commit set.

## Note

`zlink-macros` intentionally lists two near-duplicate `/tmp` lines — `Replace hardcoded /tmp socket paths.` (`ce4f4a7`) and `…with tempfile.` (`6cd2697`) — as they are two distinct genuine commits touching the crate.

## After merge

The `*-0.6.0` tags should be moved onto the merge commit so the published tags point at the corrected changelogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TxxwofHAhUCGNoHbj1Yysw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TxxwofHAhUCGNoHbj1Yysw)_