### PR TITLE
📝 Fix obsolete information in docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ This is a Rust workspace implementing an asynchronous Varlink IPC library. The a
 
 - `idl`: Support for IDL type representations.
 - `introspection`: Enable runtime introspection of service interfaces.
-- `idl-parse`: Parse Varlink IDL files at runtime (requires `std`).
+- `idl-parse`: Parse Varlink IDL at runtime (works in `no_std`).
 
 ### Development Patterns
 - Uses workspace-level package metadata (edition, rust-version, license, repository)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ This is a Rust workspace implementing an asynchronous Varlink IPC library. The a
 - **zlink-core**: No-std foundation providing core APIs. Not used directly.
 - **zlink-macros**: Contains the attribute and derive macros. Not used directly.
 - **zlink-tokio**: Tokio runtime integration and transport implementations. Not used directly.
+- **zlink-smol**: smol runtime integration and transport implementations. Not used directly.
 - **zlink**: Main unified API crate that re-exports appropriate subcrates based on cargo features.
 
 ### Key Components

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ applications. zlink makes it easy to implement Varlink services in Rust with:
 
 - **Async-first design**: Built on async/await for efficient concurrent operations.
 - **Type safety**: Leverage Rust's type system with derive macros and code generation.
-- **Multiple transports**: Unix domain sockets and (upcoming) USB support.
+- **Unix domain sockets**: Communicate over Unix domain socket transports.
+- **Runtime choice**: Use either the Tokio or smol async runtime.
 - **Code generation**: Generate Rust code from Varlink IDL files.
 
 ## Project Structure
@@ -38,6 +39,7 @@ The zlink project consists of several subcrates:
 - **[`zlink-core`]**: Core no-std foundation providing essential Varlink types and traits.
 - **[`zlink-macros`]**: Contains the attribute and derive macros.
 - **[`zlink-tokio`]**: `Tokio`-based transport implementations and runtime integration.
+- **[`zlink-smol`]**: `smol`-based transport implementations and runtime integration.
 - **[`zlink-codegen`]**: Code generation tool for creating Rust bindings from Varlink IDL files.
 
 ## Examples
@@ -431,6 +433,7 @@ This project is licensed under the [MIT License][license].
 [`zlink`]: https://docs.rs/zlink
 [`zlink-core`]: https://docs.rs/zlink-core
 [`zlink-tokio`]: https://docs.rs/zlink-tokio
+[`zlink-smol`]: https://docs.rs/zlink-smol
 [`zlink-codegen`]: https://docs.rs/zlink-codegen
 [`zlink-macros`]: https://docs.rs/zlink-macros
 [`Server::run` docs]: https://docs.rs/zlink/latest/zlink/struct.Server.html#method.run

--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ impl Calculator {
 > **Note**: Typically you would want to spawn the server in a separate task but that's not what we
 > did in the example above. Please refer to [`Server::run` docs] for the reason.
 
+For ready-to-run examples you can execute with `cargo run`, see the [`examples`](zlink/examples)
+directory.
+
 ## Code Generation from IDL
 
 zlink-codegen can generate Rust code from Varlink interface description files:
@@ -375,24 +378,6 @@ struct BatchResult {
 enum ProcessError {
     InvalidRequest { message: String },
 }
-```
-
-## Examples
-
-The repository includes a few examples:
-
-- **[resolved.rs](zlink/examples/resolved.rs)**: DNS resolution using systemd-resolved's Varlink
-  service
-- **[varlink-inspect.rs](zlink/examples/varlink-inspect.rs)**: Service introspection tool
-
-Run examples with:
-
-```bash
-cargo run --example resolved -- example.com systemd.io
-cargo run \
-  --example varlink-inspect \
-  --features idl-parse,introspection -- \
-  /run/systemd/resolve/io.systemd.Resolve
 ```
 
 ## Features

--- a/zlink/examples/README.md
+++ b/zlink/examples/README.md
@@ -2,6 +2,23 @@
 
 This directory contains examples demonstrating the usage of the zlink library.
 
+## resolved
+
+A CLI tool that resolves hostnames to IP addresses using `systemd-resolved`'s Varlink service.
+
+### Description
+
+The `resolved` example demonstrates how to use the `#[proxy]` macro to generate a type-safe client
+API, and how to use request pipelining to send multiple resolution requests at once. It connects to
+`systemd-resolved` over its Unix domain socket and prints the resolved addresses for each hostname.
+
+### Usage
+
+```bash
+# Resolve one or more hostnames
+cargo run --example resolved -- example.com systemd.io
+```
+
 ## varlink-inspect
 
 A CLI tool for inspecting Varlink services via Unix domain sockets.


### PR DESCRIPTION
## Summary

The README (and the `AGENTS.md` architecture doc) carried some obsolete/incorrect information. This cleans it up across four atomic commits.

## Changes

- **Remove the never-implemented "(upcoming) USB support" transport.** There is no USB code anywhere in the tree — only that stale README line mentioned it. The misleading "Multiple transports" bullet is replaced with accurate ones (Unix domain sockets + a choice of Tokio or smol runtime).
- **Add `zlink-smol` to the Project Structure list** in the README, and to the Core Architecture list in `AGENTS.md`. It is a real workspace member but was missing from both (the README Features section already referenced the `smol` runtime, so the docs were internally inconsistent).
- **Document the `resolved` example** in `zlink/examples/README.md`. The root README lists both examples, but the examples README only described `varlink-inspect`.
- **Correct the `idl-parse` note in `AGENTS.md`.** It claimed the feature requires `std`, but the same file's own commands build/test it with `--no-default-features`, and it compiles cleanly in `no_std` (verified with `cargo check -p zlink-core --no-default-features --features idl-parse,proxy,defmt`).

All six per-crate `README.md` files are symlinks to the root `README.md`, so the README changes propagate to every crate. `CLAUDE.md` is a symlink to `AGENTS.md`.

## Notes

Docs-only change; no code is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGwiSzPgfKxRGRWq9CZLVV

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGwiSzPgfKxRGRWq9CZLVV)_