### PR TITLE
⬆️ Bump bytes and time to fix Dependabot security alerts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
           ]
     env:
       RUSTFLAGS: -D warnings
-      MSRV: 1.85.0
+      MSRV: 1.88.0
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,9 +1084,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-traits"
@@ -1622,9 +1622,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "num-conv",
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT"
 repository = "https://github.com/z-galaxy/zlink/"
 authors = ["Zeeshan Ali Khan<zeenix@gmail.com>"]

--- a/zlink-core/src/introspect/assert.rs
+++ b/zlink-core/src/introspect/assert.rs
@@ -34,14 +34,14 @@ pub const fn assert_params_declared(params: &[&idl::Parameter<'_>], declared: &[
 /// Panics at compile time if `ty` is (or contains) a `Custom(name)` that is not in
 /// `declared`.
 pub const fn assert_type_declared(ty: &idl::Type<'_>, declared: &[&str]) {
-    if let Some(name) = custom_type_name(ty) {
-        if !name_in_list(name, declared) {
-            panic!(
-                "custom type used in method signature is not declared in `types = [...]`; \
+    if let Some(name) = custom_type_name(ty)
+        && !name_in_list(name, declared)
+    {
+        panic!(
+            "custom type used in method signature is not declared in `types = [...]`; \
                  add it to the `types` list on the `#[zlink(interface = \"...\", types = [...])]` \
                  attribute"
-            );
-        }
+        );
     }
 }
 

--- a/zlink-macros/src/proxy.rs
+++ b/zlink-macros/src/proxy.rs
@@ -48,12 +48,12 @@ fn proxy_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Erro
             let mut param_attrs_map: HashMap<String, ParamAttrs> = HashMap::new();
             for arg in method.sig.inputs.iter_mut().skip(1) {
                 // Skip &mut self
-                if let FnArg::Typed(pat_type) = arg {
-                    if let Pat::Ident(pat_ident) = &*pat_type.pat {
-                        let param_name = pat_ident.ident.to_string();
-                        let attrs = extract_param_attrs(&mut pat_type.attrs)?;
-                        param_attrs_map.insert(param_name, attrs);
-                    }
+                if let FnArg::Typed(pat_type) = arg
+                    && let Pat::Ident(pat_ident) = &*pat_type.pat
+                {
+                    let param_name = pat_ident.ident.to_string();
+                    let attrs = extract_param_attrs(&mut pat_type.attrs)?;
+                    param_attrs_map.insert(param_name, attrs);
                 }
             }
 

--- a/zlink-macros/src/proxy/utils.rs
+++ b/zlink-macros/src/proxy/utils.rs
@@ -119,13 +119,12 @@ where
         }
 
         // Parse all meta items in this zlink attribute
-        if meta_items_to_process.is_none() {
-            if let Ok(meta_items) =
+        if meta_items_to_process.is_none()
+            && let Ok(meta_items) =
                 list.parse_args_with(Punctuated::<Meta, syn::Token![,]>::parse_terminated)
-            {
-                meta_items_to_process = Some(meta_items);
-                zlink_attr_indices.push(i);
-            }
+        {
+            meta_items_to_process = Some(meta_items);
+            zlink_attr_indices.push(i);
         }
     }
 
@@ -217,14 +216,14 @@ pub(super) fn build_combined_where_clause(
 
     // Add generic bounds to where clause
     for param in &generics.params {
-        if let syn::GenericParam::Type(type_param) = param {
-            if !type_param.bounds.is_empty() {
-                let type_name = &type_param.ident;
-                let bounds = &type_param.bounds;
-                where_clause
-                    .predicates
-                    .push(syn::parse_quote!(#type_name: #bounds));
-            }
+        if let syn::GenericParam::Type(type_param) = param
+            && !type_param.bounds.is_empty()
+        {
+            let type_name = &type_param.ident;
+            let bounds = &type_param.bounds;
+            where_clause
+                .predicates
+                .push(syn::parse_quote!(#type_name: #bounds));
         }
     }
 

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -46,10 +46,10 @@ fn collect_interfaces(methods_info: &[MethodInfo]) -> Vec<String> {
     let mut seen = HashSet::new();
     let mut interfaces = Vec::new();
     for method in methods_info {
-        if let Some(ref iface) = method.interface {
-            if seen.insert(iface.clone()) {
-                interfaces.push(iface.clone());
-            }
+        if let Some(ref iface) = method.interface
+            && seen.insert(iface.clone())
+        {
+            interfaces.push(iface.clone());
         }
     }
     interfaces

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -459,10 +459,10 @@ fn extract_param_attrs(attrs: &[Attribute]) -> ParamAttrs {
         for meta in nested {
             match &meta {
                 Meta::NameValue(nv) if nv.path.is_ident("rename") => {
-                    if let Expr::Lit(expr_lit) = &nv.value {
-                        if let Lit::Str(lit_str) = &expr_lit.lit {
-                            result.rename = Some(lit_str.value());
-                        }
+                    if let Expr::Lit(expr_lit) = &nv.value
+                        && let Lit::Str(lit_str) = &expr_lit.lit
+                    {
+                        result.rename = Some(lit_str.value());
                     }
                 }
                 Meta::Path(path) if path.is_ident("connection") => {
@@ -545,10 +545,10 @@ pub(super) fn extract_stream_item_type(ty: &Type) -> Option<Type> {
         // Handle `impl Stream<Item = T> + ...` (impl trait syntax).
         Type::ImplTrait(impl_trait) => {
             for bound in &impl_trait.bounds {
-                if let syn::TypeParamBound::Trait(trait_bound) = bound {
-                    if let Some(item_type) = extract_stream_item_from_trait_bound(trait_bound) {
-                        return Some(item_type);
-                    }
+                if let syn::TypeParamBound::Trait(trait_bound) = bound
+                    && let Some(item_type) = extract_stream_item_from_trait_bound(trait_bound)
+                {
+                    return Some(item_type);
                 }
             }
             None
@@ -556,10 +556,10 @@ pub(super) fn extract_stream_item_type(ty: &Type) -> Option<Type> {
         // Handle dyn trait syntax (e.g., `Box<dyn Stream<Item = T>>`).
         Type::TraitObject(trait_object) => {
             for bound in &trait_object.bounds {
-                if let syn::TypeParamBound::Trait(trait_bound) = bound {
-                    if let Some(item_type) = extract_stream_item_from_trait_bound(trait_bound) {
-                        return Some(item_type);
-                    }
+                if let syn::TypeParamBound::Trait(trait_bound) = bound
+                    && let Some(item_type) = extract_stream_item_from_trait_bound(trait_bound)
+                {
+                    return Some(item_type);
                 }
             }
             None
@@ -599,10 +599,10 @@ fn extract_stream_item_from_trait_bound(trait_bound: &syn::TraitBound) -> Option
 
     // Find the `Item = T` binding.
     for arg in &args.args {
-        if let GenericArgument::AssocType(assoc_type) = arg {
-            if assoc_type.ident == "Item" {
-                return Some(assoc_type.ty.clone());
-            }
+        if let GenericArgument::AssocType(assoc_type) = arg
+            && assoc_type.ident == "Item"
+        {
+            return Some(assoc_type.ty.clone());
         }
     }
 

--- a/zlink-macros/src/utils.rs
+++ b/zlink-macros/src/utils.rs
@@ -58,14 +58,13 @@ pub(crate) fn extract_doc_comments(attrs: &[Attribute]) -> Vec<String> {
             // Try different parsing methods
             if let Ok(lit_str) = attr.parse_args::<syn::LitStr>() {
                 comments.push(lit_str.value());
-            } else if let syn::Meta::NameValue(meta_name_value) = &attr.meta {
-                if let syn::Expr::Lit(syn::ExprLit {
+            } else if let syn::Meta::NameValue(meta_name_value) = &attr.meta
+                && let syn::Expr::Lit(syn::ExprLit {
                     lit: syn::Lit::Str(lit_str),
                     ..
                 }) = &meta_name_value.value
-                {
-                    comments.push(lit_str.value());
-                }
+            {
+                comments.push(lit_str.value());
             }
         }
     }


### PR DESCRIPTION
## Summary

Addresses the two open Dependabot security alerts for this repository.

| Dependency | Severity | Advisory | Fix |
|------------|----------|----------|-----|
| `bytes` | Medium | Integer overflow in `BytesMut::reserve` (affects `>= 1.2.1, < 1.11.1`) | 1.10.1 → 1.11.1 |
| `time` | Medium | Stack exhaustion (denial of service) (affects `>= 0.3.6, < 0.3.47`) | 0.3.44 → 0.3.47 |

### MSRV bump to 1.88

The only patched `time` release (0.3.47) requires **rustc 1.88**, so this raises the workspace MSRV
(and the CI MSRV gate) from 1.85 to 1.88. Current stable is well ahead of 1.88, so this is a
conservative floor.

Raising the MSRV to 1.88 also stabilizes let-chains, which makes clippy's `collapsible_if` flag
several nested `if let` blocks (they were allowed at the old 1.85 MSRV). Those are collapsed in a
dedicated commit to keep `clippy -D warnings` green — no behavior change.

## Commits

- `⬆️ Update bytes to v1.11.1` — lockfile only
- `⬆️ Raise MSRV to 1.88` — `Cargo.toml` + CI MSRV env
- `🎨 Collapse nested ifs into let-chains` — clippy `collapsible_if`, newly enabled by the 1.88 MSRV
- `⬆️ Update time to v0.3.47` — lockfile only

## Verification

- `cargo test --all-features` — passes
- `cargo clippy --all-features -- -D warnings` — clean
- `cargo +1.88.0 --locked check --all-features` (matches the CI MSRV gate) — passes
- `cargo +nightly fmt --all --check` — clean
