### PR TITLE
Support renaming in zlink-macros derives

### DIFF
--- a/zlink-macros/src/introspect/custom_type.rs
+++ b/zlink-macros/src/introspect/custom_type.rs
@@ -2,7 +2,10 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Data, DataEnum, DeriveInput, Error, Fields};
 
-use crate::utils;
+use crate::{
+    naming::{self, RenameAll},
+    utils,
+};
 
 use super::shared;
 
@@ -18,7 +21,11 @@ pub(crate) fn derive_custom_type(input: proc_macro::TokenStream) -> proc_macro::
 
 fn derive_custom_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
     let name = &input.ident;
-    let name_str = name.to_string();
+    let name_str = match naming::parse_rename(&input.attrs)? {
+        Some(lit) => lit.value(),
+        None => name.to_string(),
+    };
+    let rename_all = naming::parse_rename_all(&input.attrs)?;
     let generics = &input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let crate_path = utils::parse_crate_path(&input.attrs)?;
@@ -29,7 +36,8 @@ fn derive_custom_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
     let custom_type = match &input.data {
         Data::Struct(data_struct) => {
             let fields = &data_struct.fields;
-            let (field_statics, field_refs) = generate_field_definitions(fields, &crate_path)?;
+            let (field_statics, field_refs) =
+                generate_field_definitions(fields, &crate_path, rename_all)?;
 
             quote!({
                 #(#field_statics)*
@@ -44,7 +52,8 @@ fn derive_custom_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
             })
         }
         Data::Enum(data_enum) => {
-            let variant_refs = generate_enum_variant_definitions(data_enum, &crate_path)?;
+            let variant_refs =
+                generate_enum_variant_definitions(data_enum, &crate_path, rename_all)?;
 
             quote!({
                 static VARIANT_REFS: &[&#crate_path::idl::EnumVariant<'static>] = &[
@@ -78,13 +87,15 @@ fn derive_custom_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
 fn generate_field_definitions(
     fields: &Fields,
     crate_path: &TokenStream2,
+    rename_all: Option<RenameAll>,
 ) -> Result<(Vec<TokenStream2>, Vec<TokenStream2>), Error> {
-    shared::generate_field_definitions(fields, crate_path, None)
+    shared::generate_field_definitions(fields, crate_path, None, rename_all)
 }
 
 fn generate_enum_variant_definitions(
     data_enum: &DataEnum,
     crate_path: &TokenStream2,
+    rename_all: Option<RenameAll>,
 ) -> Result<Vec<TokenStream2>, Error> {
-    shared::generate_enum_variant_definitions(data_enum, crate_path)
+    shared::generate_enum_variant_definitions(data_enum, crate_path, rename_all)
 }

--- a/zlink-macros/src/introspect/reply_error.rs
+++ b/zlink-macros/src/introspect/reply_error.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Data, DataEnum, DeriveInput, Error, Fields};
 
-use crate::utils;
+use crate::{naming, utils};
 
 use super::shared;
 
@@ -22,9 +22,16 @@ fn derive_reply_error_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let crate_path = utils::parse_crate_path(&input.attrs)?;
 
+    naming::reject_container_rename(
+        &input.attrs,
+        "`#[zlink(rename)]` has no effect on the `ReplyError` derive: error names are qualified \
+         by `#[zlink(interface)]`. Rename individual variants instead.",
+    )?;
+    let rename_all = naming::parse_rename_all(&input.attrs)?;
+
     let expanded = match &input.data {
         Data::Enum(data_enum) => {
-            let error_variants = generate_error_definitions(data_enum, &crate_path)?;
+            let error_variants = generate_error_definitions(data_enum, &crate_path, rename_all)?;
 
             quote! {
                 impl #impl_generics #crate_path::introspect::ReplyError for #name #ty_generics #where_clause {
@@ -54,11 +61,17 @@ fn derive_reply_error_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
 fn generate_error_definitions(
     data_enum: &DataEnum,
     crate_path: &TokenStream2,
+    rename_all: Option<naming::RenameAll>,
 ) -> Result<Vec<TokenStream2>, Error> {
     let mut error_variants = Vec::new();
 
     for variant in &data_enum.variants {
-        let variant_name = variant.ident.to_string();
+        let variant_name = naming::variant_name(&variant.attrs, &variant.ident, rename_all)?;
+        // The variant's own `rename_all` governs its fields, kept separate from the enum-level
+        // rule above, which governs variant names instead. Parsed unconditionally (even for unit
+        // variants, which have no fields to apply it to) so a bogus value is always rejected,
+        // matching the wire derive's `generate_serialize_variant_arm`.
+        let field_rename_all = naming::parse_rename_all(&variant.attrs)?;
 
         match &variant.fields {
             Fields::Unit => {
@@ -70,16 +83,11 @@ fn generate_error_definitions(
                 error_variants.push(error_variant);
             }
             Fields::Named(fields) => {
-                // `rename_all` is deliberately not honored here yet: the wire `ReplyError`
-                // derive doesn't understand it either, so the two must start honoring it
-                // together, or the IDL would describe field names the wire doesn't actually
-                // send. Field-level `#[zlink(rename)]` is unaffected, since the wire derive
-                // already honors that.
                 let (field_statics, field_refs) = shared::generate_field_definitions(
                     &Fields::Named(fields.clone()),
                     crate_path,
                     Some(&variant.ident),
-                    None,
+                    field_rename_all,
                 )?;
 
                 let comments = utils::extract_doc_comments(&variant.attrs);

--- a/zlink-macros/src/introspect/reply_error.rs
+++ b/zlink-macros/src/introspect/reply_error.rs
@@ -70,10 +70,16 @@ fn generate_error_definitions(
                 error_variants.push(error_variant);
             }
             Fields::Named(fields) => {
+                // `rename_all` is deliberately not honored here yet: the wire `ReplyError`
+                // derive doesn't understand it either, so the two must start honoring it
+                // together, or the IDL would describe field names the wire doesn't actually
+                // send. Field-level `#[zlink(rename)]` is unaffected, since the wire derive
+                // already honors that.
                 let (field_statics, field_refs) = shared::generate_field_definitions(
                     &Fields::Named(fields.clone()),
                     crate_path,
                     Some(&variant.ident),
+                    None,
                 )?;
 
                 let comments = utils::extract_doc_comments(&variant.attrs);

--- a/zlink-macros/src/introspect/shared.rs
+++ b/zlink-macros/src/introspect/shared.rs
@@ -2,7 +2,10 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{DataEnum, Error, Fields, FieldsNamed, FieldsUnnamed};
 
-use crate::utils;
+use crate::{
+    naming::{self, RenameAll},
+    utils,
+};
 
 /// Generate comment objects from a list of comments.
 pub(crate) fn generate_comment_objects(
@@ -22,6 +25,7 @@ pub(super) fn generate_field_definitions(
     fields: &Fields,
     crate_path: &TokenStream2,
     variant_prefix: Option<&syn::Ident>,
+    rename_all: Option<RenameAll>,
 ) -> Result<(Vec<TokenStream2>, Vec<TokenStream2>), Error> {
     match fields {
         Fields::Named(FieldsNamed { named, .. }) => {
@@ -35,7 +39,7 @@ pub(super) fn generate_field_definitions(
                     .ok_or_else(|| Error::new_spanned(field, "Field must have a name"))?;
 
                 let field_type = utils::remove_lifetimes_from_type(&field.ty);
-                let field_name_str = field_name.to_string();
+                let field_name_str = naming::field_name(&field.attrs, field_name, rename_all)?;
 
                 let static_name = if let Some(variant_ident) = variant_prefix {
                     quote::format_ident!(
@@ -82,6 +86,7 @@ pub(super) fn generate_field_definitions(
 pub(super) fn generate_enum_variant_definitions(
     data_enum: &DataEnum,
     crate_path: &TokenStream2,
+    rename_all: Option<RenameAll>,
 ) -> Result<Vec<TokenStream2>, Error> {
     let mut variant_refs = Vec::new();
 
@@ -89,7 +94,8 @@ pub(super) fn generate_enum_variant_definitions(
         // Only support unit variants (no associated data).
         match &variant.fields {
             Fields::Unit => {
-                let variant_name = variant.ident.to_string();
+                let variant_name =
+                    naming::variant_name(&variant.attrs, &variant.ident, rename_all)?;
                 let comments = utils::extract_doc_comments(&variant.attrs);
                 let comment_objects = generate_comment_objects(&comments, crate_path);
                 let variant_ref = quote! {

--- a/zlink-macros/src/introspect/type.rs
+++ b/zlink-macros/src/introspect/type.rs
@@ -2,7 +2,10 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Data, DataEnum, DeriveInput, Error, Fields};
 
-use crate::utils;
+use crate::{
+    naming::{self, RenameAll},
+    utils,
+};
 
 use super::shared;
 
@@ -21,11 +24,18 @@ fn derive_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
     let generics = &input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let crate_path = utils::parse_crate_path(&input.attrs)?;
+    naming::reject_container_rename(
+        &input.attrs,
+        "`#[zlink(rename)]` has no effect on the `Type` derive, which generates an anonymous \
+         object type. Derive `CustomType` instead if the type needs a name in the IDL.",
+    )?;
+    let rename_all = naming::parse_rename_all(&input.attrs)?;
 
     let expanded = match &input.data {
         Data::Struct(data_struct) => {
             let fields = &data_struct.fields;
-            let (field_statics, field_refs) = generate_field_definitions(fields, &crate_path)?;
+            let (field_statics, field_refs) =
+                generate_field_definitions(fields, &crate_path, rename_all)?;
 
             quote! {
                 impl #impl_generics #crate_path::introspect::Type for #name #ty_generics #where_clause {
@@ -42,7 +52,8 @@ fn derive_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
             }
         }
         Data::Enum(data_enum) => {
-            let variant_refs = generate_enum_variant_definitions(data_enum, &crate_path)?;
+            let variant_refs =
+                generate_enum_variant_definitions(data_enum, &crate_path, rename_all)?;
 
             quote! {
                 impl #impl_generics #crate_path::introspect::Type for #name #ty_generics #where_clause {
@@ -70,13 +81,15 @@ fn derive_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
 fn generate_field_definitions(
     fields: &Fields,
     crate_path: &TokenStream2,
+    rename_all: Option<RenameAll>,
 ) -> Result<(Vec<TokenStream2>, Vec<TokenStream2>), Error> {
-    shared::generate_field_definitions(fields, crate_path, None)
+    shared::generate_field_definitions(fields, crate_path, None, rename_all)
 }
 
 fn generate_enum_variant_definitions(
     data_enum: &DataEnum,
     crate_path: &TokenStream2,
+    rename_all: Option<RenameAll>,
 ) -> Result<Vec<TokenStream2>, Error> {
-    shared::generate_enum_variant_definitions(data_enum, crate_path)
+    shared::generate_enum_variant_definitions(data_enum, crate_path, rename_all)
 }

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -72,6 +72,32 @@ mod service;
 /// }
 /// ```
 ///
+/// # Renaming
+///
+/// - `#[zlink(rename = "...")]` on a field or variant sets its name in the IDL.
+/// - `#[zlink(rename_all = "...")]` on a struct applies a case convention to its fields, and on an
+///   enum to its variant names. An explicit `rename` on an item overrides it.
+///
+/// Valid `rename_all` values are `lowercase`, `UPPERCASE`, `PascalCase`, `camelCase`,
+/// `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case` and `SCREAMING-KEBAB-CASE`. They mean the
+/// same as they do in serde.
+///
+/// These attributes do not affect serialization. On a type that also derives serde traits, state
+/// the same renaming to serde, or the IDL will not describe what is actually sent:
+///
+/// ```rust
+/// use serde::Serialize;
+/// use zlink::introspect::Type;
+///
+/// #[derive(Serialize, Type)]
+/// #[serde(rename_all = "camelCase")]
+/// #[zlink(rename_all = "camelCase")]
+/// struct Membership {
+///     user_name: String,
+///     group_name: String,
+/// }
+/// ```
+///
 /// # Examples
 ///
 /// ## Named Structs
@@ -211,6 +237,33 @@ pub fn derive_introspect_type(input: proc_macro::TokenStream) -> proc_macro::Tok
 /// * `#[zlink(crate = "path")]` - Specifies the crate path to use for zlink types. Defaults to
 ///   `::zlink`.
 ///
+/// # Renaming
+///
+/// - `#[zlink(rename = "...")]` on a field or variant sets its name in the IDL.
+/// - `#[zlink(rename_all = "...")]` on a struct applies a case convention to its fields, and on an
+///   enum to its variant names. An explicit `rename` on an item overrides it.
+/// - `#[zlink(rename = "...")]` on the type itself sets the name of the custom type in the IDL.
+///
+/// Valid `rename_all` values are `lowercase`, `UPPERCASE`, `PascalCase`, `camelCase`,
+/// `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case` and `SCREAMING-KEBAB-CASE`. They mean the
+/// same as they do in serde.
+///
+/// These attributes do not affect serialization. On a type that also derives serde traits, state
+/// the same renaming to serde, or the IDL will not describe what is actually sent:
+///
+/// ```rust
+/// use serde::Serialize;
+/// use zlink::introspect::CustomType;
+///
+/// #[derive(Serialize, CustomType)]
+/// #[serde(rename_all = "camelCase")]
+/// #[zlink(rename_all = "camelCase")]
+/// struct Membership {
+///     user_name: String,
+///     group_name: String,
+/// }
+/// ```
+///
 /// # Examples
 ///
 /// ## Named Structs
@@ -298,6 +351,33 @@ pub fn derive_introspect_custom_type(input: proc_macro::TokenStream) -> proc_mac
 ///
 /// * `#[zlink(crate = "path")]` - Specifies the crate path to use for zlink types. Defaults to
 ///   `::zlink`.
+///
+/// # Renaming
+///
+/// - `#[zlink(rename = "...")]` on a field or variant sets its name in the IDL.
+/// - `#[zlink(rename_all = "...")]` on the enum applies to error names, and on a variant to that
+///   variant's fields. An explicit `rename` on an item overrides it. Error names in the IDL are
+///   unqualified; the interface comes from `#[zlink(interface)]`.
+///
+/// Valid `rename_all` values are `lowercase`, `UPPERCASE`, `PascalCase`, `camelCase`,
+/// `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case` and `SCREAMING-KEBAB-CASE`. They mean the
+/// same as they do in serde.
+///
+/// These attributes do not affect serialization on their own. [`macro@ReplyError`] reads the same
+/// `#[zlink(rename)]` and `#[zlink(rename_all)]` attributes, so deriving both on the same enum
+/// (the usual pairing) keeps the wire format and the IDL in sync automatically. Any other type
+/// that separately derives serde traits still needs the same renaming stated to serde, or the IDL
+/// will not describe what is actually sent:
+///
+/// ```rust
+/// use zlink::{ReplyError, introspect};
+///
+/// #[derive(ReplyError, introspect::ReplyError)]
+/// #[zlink(interface = "org.example.Test", rename_all = "SCREAMING_SNAKE_CASE")]
+/// enum ServiceError {
+///     NotFound,
+/// }
+/// ```
 ///
 /// # Example
 ///
@@ -923,6 +1003,12 @@ pub fn proxy(
 ///
 /// - `interface` - This mandatory attribute specifies the Varlink interface name (e.g.,
 ///   "org.varlink.service")
+/// - `rename_all = "..."` - Applies a case convention to every variant name
+///
+/// ## Variant-level attributes
+///
+/// - `rename = "..."` - Specifies a custom name for the variant in the serialized error name
+/// - `rename_all = "..."` - Applies a case convention to this variant's fields
 ///
 /// ## Field-level attributes
 ///
@@ -954,7 +1040,9 @@ pub fn proxy(
 ///         message: Cow<'a, str>,
 ///     },
 ///
-///     // Variant with renamed field
+///     // Variant with a renamed error name: serialized as
+///     // "com.example.MyService.TimedOut".
+///     #[zlink(rename = "TimedOut")]
 ///     Timeout {
 ///         #[zlink(rename = "timeoutSeconds")]
 ///         seconds: u32,

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -12,6 +12,8 @@
 
 mod utils;
 
+mod naming;
+
 #[cfg(feature = "introspection")]
 mod introspect;
 

--- a/zlink-macros/src/naming.rs
+++ b/zlink-macros/src/naming.rs
@@ -1,0 +1,318 @@
+use syn::{Attribute, Error, Ident, LitStr};
+
+use crate::utils::skip_unknown_meta;
+
+/// The case convention requested by `#[zlink(rename_all = "...")]`.
+///
+/// The variants mirror serde's rename rules so the semantics are familiar. Note that the field and
+/// variant rules differ, because the source convention differs: fields are `snake_case`, variants
+/// are `PascalCase`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RenameAll {
+    Lower,
+    Upper,
+    Pascal,
+    Camel,
+    Snake,
+    ScreamingSnake,
+    Kebab,
+    ScreamingKebab,
+}
+
+impl RenameAll {
+    /// Apply the convention to a struct field name, whose source convention is `snake_case`.
+    pub(crate) fn apply_to_field(self, field: &str) -> String {
+        match self {
+            Self::Lower | Self::Snake => field.to_owned(),
+            Self::Upper | Self::ScreamingSnake => field.to_ascii_uppercase(),
+            Self::Pascal => {
+                let mut pascal = String::new();
+                let mut capitalize = true;
+                for ch in field.chars() {
+                    if ch == '_' {
+                        capitalize = true;
+                    } else if capitalize {
+                        pascal.push(ch.to_ascii_uppercase());
+                        capitalize = false;
+                    } else {
+                        pascal.push(ch);
+                    }
+                }
+                pascal
+            }
+            Self::Camel => {
+                let pascal = Self::Pascal.apply_to_field(field);
+                match pascal.get(..1) {
+                    Some(first) => first.to_ascii_lowercase() + &pascal[1..],
+                    None => pascal,
+                }
+            }
+            Self::Kebab => field.replace('_', "-"),
+            Self::ScreamingKebab => Self::ScreamingSnake.apply_to_field(field).replace('_', "-"),
+        }
+    }
+
+    /// Apply the convention to an enum variant name, whose source convention is `PascalCase`.
+    pub(crate) fn apply_to_variant(self, variant: &str) -> String {
+        match self {
+            Self::Pascal => variant.to_owned(),
+            Self::Lower => variant.to_ascii_lowercase(),
+            Self::Upper => variant.to_ascii_uppercase(),
+            Self::Camel => match variant.get(..1) {
+                Some(first) => first.to_ascii_lowercase() + &variant[1..],
+                None => variant.to_owned(),
+            },
+            Self::Snake => {
+                let mut snake = String::new();
+                for (i, ch) in variant.char_indices() {
+                    if i > 0 && ch.is_uppercase() {
+                        snake.push('_');
+                    }
+                    snake.push(ch.to_ascii_lowercase());
+                }
+                snake
+            }
+            Self::ScreamingSnake => Self::Snake.apply_to_variant(variant).to_ascii_uppercase(),
+            Self::Kebab => Self::Snake.apply_to_variant(variant).replace('_', "-"),
+            Self::ScreamingKebab => Self::ScreamingSnake
+                .apply_to_variant(variant)
+                .replace('_', "-"),
+        }
+    }
+
+    fn parse(lit: &LitStr) -> Result<Self, Error> {
+        let rule = match lit.value().as_str() {
+            "lowercase" => Self::Lower,
+            "UPPERCASE" => Self::Upper,
+            "PascalCase" => Self::Pascal,
+            "camelCase" => Self::Camel,
+            "snake_case" => Self::Snake,
+            "SCREAMING_SNAKE_CASE" => Self::ScreamingSnake,
+            "kebab-case" => Self::Kebab,
+            "SCREAMING-KEBAB-CASE" => Self::ScreamingKebab,
+            unknown => {
+                return Err(Error::new_spanned(
+                    lit,
+                    format!(
+                        "unknown `rename_all` value `{unknown}`, expected one of: {}",
+                        VALID_RENAME_ALL.join(", "),
+                    ),
+                ));
+            }
+        };
+
+        Ok(rule)
+    }
+}
+
+/// The name a struct field should carry in the IDL and on the wire.
+///
+/// `#[zlink(rename)]` wins over an inherited `rename_all`, which wins over the Rust ident.
+pub(crate) fn field_name(
+    attrs: &[Attribute],
+    ident: &Ident,
+    rename_all: Option<RenameAll>,
+) -> Result<String, Error> {
+    resolve(attrs, ident, rename_all, RenameAll::apply_to_field)
+}
+
+/// The name an enum variant should carry in the IDL and on the wire.
+///
+/// `#[zlink(rename)]` wins over an inherited `rename_all`, which wins over the Rust ident.
+pub(crate) fn variant_name(
+    attrs: &[Attribute],
+    ident: &Ident,
+    rename_all: Option<RenameAll>,
+) -> Result<String, Error> {
+    resolve(attrs, ident, rename_all, RenameAll::apply_to_variant)
+}
+
+/// Reject a container-level `#[zlink(rename)]` with `msg`, for derives where it means nothing.
+///
+/// Silently ignoring it would let users ship IDL that does not say what they wrote.
+pub(crate) fn reject_container_rename(attrs: &[Attribute], msg: &str) -> Result<(), Error> {
+    match parse_rename(attrs)? {
+        Some(lit) => Err(Error::new_spanned(lit, msg)),
+        None => Ok(()),
+    }
+}
+
+/// The container's `#[zlink(rename_all = "...")]`, if any.
+pub(crate) fn parse_rename_all(attrs: &[Attribute]) -> Result<Option<RenameAll>, Error> {
+    match parse_zlink_lit_str(attrs, "rename_all")? {
+        Some(lit) => RenameAll::parse(&lit).map(Some),
+        None => Ok(None),
+    }
+}
+
+/// The item's `#[zlink(rename = "...")]`, if any.
+pub(crate) fn parse_rename(attrs: &[Attribute]) -> Result<Option<LitStr>, Error> {
+    parse_zlink_lit_str(attrs, "rename")
+}
+
+fn resolve<F>(
+    attrs: &[Attribute],
+    ident: &Ident,
+    rename_all: Option<RenameAll>,
+    apply: F,
+) -> Result<String, Error>
+where
+    F: FnOnce(RenameAll, &str) -> String,
+{
+    if let Some(lit) = parse_rename(attrs)? {
+        return Ok(lit.value());
+    }
+
+    let ident = ident.to_string();
+
+    Ok(match rename_all {
+        Some(rule) => apply(rule, &ident),
+        None => ident,
+    })
+}
+
+/// The string value of `#[zlink(<key> = "...")]`, if present.
+///
+/// Unlike `utils::parse_zlink_string_attr` this reports parse errors rather than swallowing them,
+/// which is what the rename attributes need in order to reject bad input.
+fn parse_zlink_lit_str(attrs: &[Attribute], key: &str) -> Result<Option<LitStr>, Error> {
+    let mut result = None;
+
+    for attr in attrs {
+        if !attr.path().is_ident("zlink") {
+            continue;
+        }
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident(key) {
+                let lit: LitStr = meta.value()?.parse()?;
+                if result.is_some() {
+                    return Err(meta.error(format!("duplicate `{key}` attribute")));
+                }
+                result = Some(lit);
+            } else {
+                skip_unknown_meta(&meta)?;
+            }
+
+            Ok(())
+        })?;
+    }
+
+    Ok(result)
+}
+
+const VALID_RENAME_ALL: &[&str] = &[
+    "lowercase",
+    "UPPERCASE",
+    "PascalCase",
+    "camelCase",
+    "snake_case",
+    "SCREAMING_SNAKE_CASE",
+    "kebab-case",
+    "SCREAMING-KEBAB-CASE",
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn field_conventions() {
+        let cases = [
+            (RenameAll::Lower, "user_name"),
+            (RenameAll::Upper, "USER_NAME"),
+            (RenameAll::Pascal, "UserName"),
+            (RenameAll::Camel, "userName"),
+            (RenameAll::Snake, "user_name"),
+            (RenameAll::ScreamingSnake, "USER_NAME"),
+            (RenameAll::Kebab, "user-name"),
+            (RenameAll::ScreamingKebab, "USER-NAME"),
+        ];
+
+        for (rule, expected) in cases {
+            assert_eq!(rule.apply_to_field("user_name"), expected, "rule: {rule:?}");
+        }
+    }
+
+    #[test]
+    fn variant_conventions() {
+        let cases = [
+            (RenameAll::Lower, "username"),
+            (RenameAll::Upper, "USERNAME"),
+            (RenameAll::Pascal, "UserName"),
+            (RenameAll::Camel, "userName"),
+            (RenameAll::Snake, "user_name"),
+            (RenameAll::ScreamingSnake, "USER_NAME"),
+            (RenameAll::Kebab, "user-name"),
+            (RenameAll::ScreamingKebab, "USER-NAME"),
+        ];
+
+        for (rule, expected) in cases {
+            assert_eq!(
+                rule.apply_to_variant("UserName"),
+                expected,
+                "rule: {rule:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rename_beats_rename_all() {
+        let attrs: Vec<Attribute> = vec![parse_quote!(#[zlink(rename = "ID")])];
+        let ident: Ident = parse_quote!(user_id);
+        let name = field_name(&attrs, &ident, Some(RenameAll::Camel)).unwrap();
+
+        assert_eq!(name, "ID");
+    }
+
+    #[test]
+    fn rename_all_applies_without_rename() {
+        let attrs: Vec<Attribute> = vec![];
+        let ident: Ident = parse_quote!(user_id);
+        let name = field_name(&attrs, &ident, Some(RenameAll::Camel)).unwrap();
+
+        assert_eq!(name, "userId");
+    }
+
+    #[test]
+    fn ident_used_without_any_attr() {
+        let attrs: Vec<Attribute> = vec![];
+        let ident: Ident = parse_quote!(user_id);
+
+        assert_eq!(field_name(&attrs, &ident, None).unwrap(), "user_id");
+    }
+
+    #[test]
+    fn rename_all_parsed_alongside_other_keys() {
+        let attrs: Vec<Attribute> =
+            vec![parse_quote!(#[zlink(crate = "crate", rename_all = "camelCase")])];
+
+        assert_eq!(parse_rename_all(&attrs).unwrap(), Some(RenameAll::Camel));
+    }
+
+    #[test]
+    fn unknown_rename_all_value_rejected() {
+        let attrs: Vec<Attribute> = vec![parse_quote!(#[zlink(rename_all = "bogus")])];
+        let err = parse_rename_all(&attrs).unwrap_err().to_string();
+
+        assert!(
+            err.contains("bogus"),
+            "message should name the bad value: {err}"
+        );
+        assert!(
+            err.contains("camelCase"),
+            "message should list valid values: {err}"
+        );
+    }
+
+    #[test]
+    fn container_rename_rejected_with_message() {
+        let attrs: Vec<Attribute> = vec![parse_quote!(#[zlink(rename = "Foo")])];
+        let err = reject_container_rename(&attrs, "nope")
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(err, "nope");
+    }
+}

--- a/zlink-macros/src/naming.rs
+++ b/zlink-macros/src/naming.rs
@@ -173,8 +173,8 @@ where
 
 /// The string value of `#[zlink(<key> = "...")]`, if present.
 ///
-/// Unlike `utils::parse_zlink_string_attr` this reports parse errors rather than swallowing them,
-/// which is what the rename attributes need in order to reject bad input.
+/// Parse errors are reported rather than swallowed, which is what the rename attributes need in
+/// order to reject bad input.
 fn parse_zlink_lit_str(attrs: &[Attribute], key: &str) -> Result<Option<LitStr>, Error> {
     let mut result = None;
 

--- a/zlink-macros/src/reply_error.rs
+++ b/zlink-macros/src/reply_error.rs
@@ -2,7 +2,10 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Data, DataEnum, DeriveInput, Error, Fields, FieldsNamed, parse_quote};
 
-use crate::utils::{convert_type_lifetimes, has_zlink_bool_attr, parse_zlink_string_attr};
+use crate::{
+    naming::{self, RenameAll},
+    utils::{convert_type_lifetimes, has_zlink_bool_attr},
+};
 
 /// Main entry point for the `ReplyError` derive macro that generates serde implementations.
 ///
@@ -29,13 +32,20 @@ fn derive_reply_error_impl(input: &DeriveInput) -> Result<TokenStream2, Error> {
     // Parse the interface from zlink attributes (mandatory).
     let interface = parse_interface_from_attrs(&input.attrs)?;
 
+    naming::reject_container_rename(
+        &input.attrs,
+        "`#[zlink(rename)]` has no effect on the `ReplyError` derive: error names are qualified \
+         by `#[zlink(interface)]`. Rename individual variants instead.",
+    )?;
+
     let data_enum = extract_enum_data(&input.data)?;
 
     // Validate that enum variants are supported.
     validate_enum_variants(data_enum)?;
 
     // Generate manual Serialize implementation (still custom for variant naming).
-    let serialize_impl = generate_serialize_impl(name, data_enum, generics, &interface)?;
+    let serialize_impl =
+        generate_serialize_impl(name, data_enum, generics, &interface, &input.attrs)?;
 
     // For Deserialize, generate a helper enum with serde derives and convert to original.
     let deserialize_impl = generate_deserialize_with_derive(input, data_enum, &interface)?;
@@ -115,15 +125,19 @@ fn generate_serialize_impl(
     data_enum: &DataEnum,
     generics: &syn::Generics,
     interface: &str,
+    input_attrs: &[syn::Attribute],
 ) -> Result<TokenStream2, Error> {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let has_lifetimes = !generics.lifetimes().collect::<Vec<_>>().is_empty();
 
+    let rename_all = naming::parse_rename_all(input_attrs)?;
     // Generate match arms for each variant (empty for empty enums).
     let variant_arms = data_enum
         .variants
         .iter()
-        .map(|variant| generate_serialize_variant_arm(variant, interface, has_lifetimes))
+        .map(|variant| {
+            generate_serialize_variant_arm(variant, interface, has_lifetimes, rename_all)
+        })
         .collect::<Result<Vec<_>, _>>()?;
 
     // For empty enums, we need to dereference self to match the uninhabited type.
@@ -151,9 +165,12 @@ fn generate_serialize_variant_arm(
     variant: &syn::Variant,
     interface: &str,
     has_lifetimes: bool,
+    rename_all: Option<RenameAll>,
 ) -> Result<TokenStream2, Error> {
     let variant_name = &variant.ident;
-    let qualified_name = format!("{interface}.{variant_name}");
+    let resolved = naming::variant_name(&variant.attrs, variant_name, rename_all)?;
+    let qualified_name = format!("{interface}.{resolved}");
+    let field_rename_all = naming::parse_rename_all(&variant.attrs)?;
 
     match &variant.fields {
         // Unit variant - serialize as tagged enum with just error field.
@@ -167,7 +184,7 @@ fn generate_serialize_variant_arm(
         }),
         Fields::Named(fields) => {
             // Named fields - serialize as tagged enum with parameters.
-            let field_info = FieldInfo::extract(fields);
+            let field_info = FieldInfo::extract(fields, field_rename_all)?;
             let field_count = field_info.names.len();
             let field_names = &field_info.names;
             let field_types = &field_info.types;
@@ -237,28 +254,32 @@ fn generate_deserialize_with_derive(
     let generics = &input.generics;
 
     // First extract field info for all variants from the original enum.
-    let variant_field_info: Vec<_> = data_enum
+    let variant_field_info: Vec<Option<FieldInfo<'_>>> = data_enum
         .variants
         .iter()
-        .map(|variant| {
-            if let Fields::Named(fields) = &variant.fields {
-                Some(FieldInfo::extract(fields))
-            } else {
-                None
+        .map(|variant| match &variant.fields {
+            Fields::Named(fields) => {
+                let rename_all = naming::parse_rename_all(&variant.attrs)?;
+                FieldInfo::extract(fields, rename_all).map(Some)
             }
+            _ => Ok(None),
         })
-        .collect();
+        .collect::<Result<Vec<_>, Error>>()?;
 
     // Clone and modify the enum to add serde attributes.
     let mut modified_enum = data_enum.clone();
 
+    let rename_all = naming::parse_rename_all(&input.attrs)?;
+
     // Now modify the variants.
     for (i, variant) in modified_enum.variants.iter_mut().enumerate() {
         let field_info = &variant_field_info[i];
-        let variant_name = &variant.ident;
-        let qualified_name = format!("{interface}.{variant_name}");
+        let resolved = naming::variant_name(&variant.attrs, &variant.ident, rename_all)?;
+        let qualified_name = format!("{interface}.{resolved}");
 
-        // Add rename attribute for the variant.
+        // Strip our helper attributes before they reach the generated helper enum, which only
+        // derives `Deserialize` and so has nothing to declare `zlink`.
+        variant.attrs.retain(|attr| !attr.path().is_ident("zlink"));
         variant
             .attrs
             .push(parse_quote!(#[serde(rename = #qualified_name)]));
@@ -367,37 +388,28 @@ struct FieldInfo<'a> {
 
 impl<'a> FieldInfo<'a> {
     /// Extract field information from named fields to avoid duplication.
-    fn extract(fields: &'a FieldsNamed) -> Self {
-        let field_data: Vec<_> = fields
-            .named
-            .iter()
-            .filter_map(|f| {
-                f.ident.as_ref().map(|name| {
-                    let serialized_name = Self::get_serialized_name(f, name);
-                    let borrow = has_zlink_bool_attr(&f.attrs, "borrow");
-                    (name, &f.ty, serialized_name, borrow)
-                })
-            })
-            .collect();
+    fn extract(fields: &'a FieldsNamed, rename_all: Option<RenameAll>) -> Result<Self, Error> {
+        let mut names = Vec::new();
+        let mut types = Vec::new();
+        let mut name_strings = Vec::new();
+        let mut borrow_flags = Vec::new();
 
-        let names: Vec<_> = field_data.iter().map(|(name, _, _, _)| *name).collect();
-        let types: Vec<_> = field_data.iter().map(|(_, ty, _, _)| *ty).collect();
-        let name_strings: Vec<String> = field_data
-            .iter()
-            .map(|(_, _, sname, _)| sname.clone())
-            .collect();
-        let borrow_flags: Vec<bool> = field_data.iter().map(|(_, _, _, borrow)| *borrow).collect();
+        for field in &fields.named {
+            let Some(name) = field.ident.as_ref() else {
+                continue;
+            };
 
-        Self {
+            names.push(name);
+            types.push(&field.ty);
+            name_strings.push(naming::field_name(&field.attrs, name, rename_all)?);
+            borrow_flags.push(has_zlink_bool_attr(&field.attrs, "borrow"));
+        }
+
+        Ok(Self {
             names,
             types,
             name_strings,
             borrow_flags,
-        }
-    }
-
-    /// Extract the serialized name from field attributes or use the field name.
-    fn get_serialized_name(field: &syn::Field, default_name: &syn::Ident) -> String {
-        parse_zlink_string_attr(&field.attrs, "rename").unwrap_or_else(|| default_name.to_string())
+        })
     }
 }

--- a/zlink-macros/src/utils.rs
+++ b/zlink-macros/src/utils.rs
@@ -30,9 +30,7 @@ pub(crate) fn parse_crate_path(attrs: &[Attribute]) -> Result<TokenStream2, Erro
                     let crate_path = lit_str.value();
                     result = Some(syn::parse_str(&crate_path)?);
                 } else {
-                    // Skip unknown attributes by consuming their values
-                    let _ = meta.value()?;
-                    let _: syn::Expr = meta.input.parse()?;
+                    skip_unknown_meta(&meta)?;
                 }
                 Ok(())
             })?;
@@ -44,6 +42,23 @@ pub(crate) fn parse_crate_path(attrs: &[Attribute]) -> Result<TokenStream2, Erro
     }
     // Default to ::zlink
     Ok(quote! { ::zlink })
+}
+
+/// Consume an unknown `#[zlink(..)]` key's payload so the surrounding walk can continue.
+///
+/// Keys come in three shapes: bare (`borrow`), name-value (`crate = "x"`) and list (`foo(..)`).
+/// Bare keys have no payload to consume, so peeking first avoids failing the whole walk.
+pub(crate) fn skip_unknown_meta(meta: &syn::meta::ParseNestedMeta<'_>) -> syn::Result<()> {
+    if meta.input.peek(syn::Token![=]) {
+        let value = meta.value()?;
+        let _: syn::Expr = value.parse()?;
+    } else if meta.input.peek(syn::token::Paren) {
+        let content;
+        syn::parenthesized!(content in meta.input);
+        let _: proc_macro2::TokenStream = content.parse()?;
+    }
+
+    Ok(())
 }
 
 /// Extract doc comments from attributes.
@@ -284,6 +299,8 @@ pub(crate) fn has_zlink_bool_attr(attrs: &[Attribute], key: &str) -> bool {
         let _ = attr.parse_nested_meta(|meta| {
             if meta.path.is_ident(key) {
                 found = true;
+            } else {
+                skip_unknown_meta(&meta)?;
             }
             Ok(())
         });
@@ -314,9 +331,7 @@ pub(crate) fn parse_zlink_string_attr(attrs: &[Attribute], key: &str) -> Option<
                 let lit_str: syn::LitStr = value.parse()?;
                 result = Some(lit_str.value());
             } else {
-                // Skip unknown attributes by consuming their values
-                let _ = meta.value()?;
-                let _: syn::Expr = meta.input.parse()?;
+                skip_unknown_meta(&meta)?;
             }
             Ok(())
         });
@@ -326,4 +341,36 @@ pub(crate) fn parse_zlink_string_attr(attrs: &[Attribute], key: &str) -> Option<
         }
     }
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::parse_quote;
+
+    #[test]
+    fn string_attr_after_valueless_key() {
+        let attr: Attribute = parse_quote!(#[zlink(borrow, rename = "actualName")]);
+        assert_eq!(
+            parse_zlink_string_attr(&[attr], "rename").as_deref(),
+            Some("actualName"),
+        );
+    }
+
+    #[test]
+    fn string_attr_before_valueless_key() {
+        let attr: Attribute = parse_quote!(#[zlink(rename = "actualName", borrow)]);
+        assert_eq!(
+            parse_zlink_string_attr(&[attr], "rename").as_deref(),
+            Some("actualName"),
+        );
+    }
+
+    #[cfg(feature = "introspection")]
+    #[test]
+    fn crate_path_after_valueless_key() {
+        let attr: Attribute = parse_quote!(#[zlink(borrow, crate = "crate")]);
+        let path = parse_crate_path(&[attr]).unwrap();
+        assert_eq!(path.to_string(), "crate");
+    }
 }

--- a/zlink-macros/src/utils.rs
+++ b/zlink-macros/src/utils.rs
@@ -312,59 +312,10 @@ pub(crate) fn has_zlink_bool_attr(attrs: &[Attribute], key: &str) -> bool {
     false
 }
 
-/// Parse a string value from a zlink attribute with a specific key.
-///
-/// For example, parse `#[zlink(rename = "new_name")]` by calling with key "rename".
-/// Returns None if the attribute or key is not found.
-///
-/// This is used by both `reply_error` and `proxy` modules for parsing rename attributes.
-pub(crate) fn parse_zlink_string_attr(attrs: &[Attribute], key: &str) -> Option<String> {
-    for attr in attrs {
-        if !attr.path().is_ident("zlink") {
-            continue;
-        }
-
-        let mut result = None;
-        let _ = attr.parse_nested_meta(|meta| {
-            if meta.path.is_ident(key) {
-                let value = meta.value()?;
-                let lit_str: syn::LitStr = value.parse()?;
-                result = Some(lit_str.value());
-            } else {
-                skip_unknown_meta(&meta)?;
-            }
-            Ok(())
-        });
-
-        if result.is_some() {
-            return result;
-        }
-    }
-    None
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use syn::parse_quote;
-
-    #[test]
-    fn string_attr_after_valueless_key() {
-        let attr: Attribute = parse_quote!(#[zlink(borrow, rename = "actualName")]);
-        assert_eq!(
-            parse_zlink_string_attr(&[attr], "rename").as_deref(),
-            Some("actualName"),
-        );
-    }
-
-    #[test]
-    fn string_attr_before_valueless_key() {
-        let attr: Attribute = parse_quote!(#[zlink(rename = "actualName", borrow)]);
-        assert_eq!(
-            parse_zlink_string_attr(&[attr], "rename").as_deref(),
-            Some("actualName"),
-        );
-    }
 
     #[cfg(feature = "introspection")]
     #[test]

--- a/zlink-macros/tests/introspect-rename.rs
+++ b/zlink-macros/tests/introspect-rename.rs
@@ -1,0 +1,133 @@
+#![cfg(feature = "introspection")]
+
+use zlink::{
+    idl,
+    introspect::{CustomType, Type},
+};
+
+#[test]
+fn struct_field_rename_all() {
+    let idl::Type::Object(fields) = Membership::TYPE else {
+        panic!("expected an object type");
+    };
+    let fields: Vec<_> = fields.iter().collect();
+
+    assert_eq!(fields[0].name(), "userName");
+    assert_eq!(fields[1].name(), "groupName");
+}
+
+#[test]
+fn explicit_rename_overrides_rename_all() {
+    let idl::Type::Object(fields) = Overridden::TYPE else {
+        panic!("expected an object type");
+    };
+    let fields: Vec<_> = fields.iter().collect();
+
+    assert_eq!(fields[0].name(), "ID", "explicit rename must win");
+    assert_eq!(fields[1].name(), "groupName", "rename_all still applies");
+}
+
+#[test]
+fn kebab_case_field_names_do_not_break_statics() {
+    let idl::Type::Object(fields) = Kebabed::TYPE else {
+        panic!("expected an object type");
+    };
+    let fields: Vec<_> = fields.iter().collect();
+
+    assert_eq!(fields[0].name(), "user-name");
+}
+
+#[test]
+fn enum_variant_rename_all() {
+    let idl::Type::Enum(variants) = Status::TYPE else {
+        panic!("expected an enum type");
+    };
+    let variants: Vec<_> = variants.iter().collect();
+
+    assert_eq!(variants[0].name(), "active");
+    assert_eq!(variants[1].name(), "notReady");
+    assert_eq!(variants[2].name(), "GONE", "explicit rename must win");
+}
+
+#[test]
+fn custom_type_container_rename() {
+    let idl::CustomType::Object(obj) = Record::CUSTOM_TYPE else {
+        panic!("expected an object custom type");
+    };
+
+    assert_eq!(obj.name(), "Membership");
+
+    let fields: Vec<_> = obj.fields().collect();
+    assert_eq!(fields[0].name(), "userName");
+}
+
+#[test]
+fn custom_type_rename_keeps_type_reference_in_sync() {
+    // The `Type` impl must point at the same name the `CustomType` impl declares, or the IDL
+    // reference dangles.
+    assert_eq!(Record::TYPE, &idl::Type::Custom("Membership"));
+}
+
+#[test]
+fn custom_enum_container_rename() {
+    let idl::CustomType::Enum(e) = Level::CUSTOM_TYPE else {
+        panic!("expected an enum custom type");
+    };
+
+    assert_eq!(e.name(), "Severity");
+
+    let variants: Vec<_> = e.variants().collect();
+    assert_eq!(variants[0].name(), "low");
+}
+
+// `#[allow(unused)]` on test types matches the convention already used throughout
+// `tests/introspect-type.rs`: the fields exist only to be described, never read.
+
+#[derive(Type)]
+#[allow(unused)]
+#[zlink(rename_all = "camelCase")]
+struct Membership {
+    user_name: String,
+    group_name: String,
+}
+
+#[derive(Type)]
+#[allow(unused)]
+#[zlink(rename_all = "camelCase")]
+struct Overridden {
+    #[zlink(rename = "ID")]
+    user_id: String,
+    group_name: String,
+}
+
+#[derive(Type)]
+#[allow(unused)]
+#[zlink(rename_all = "kebab-case")]
+struct Kebabed {
+    user_name: String,
+}
+
+#[derive(Type)]
+#[allow(unused)]
+#[zlink(rename_all = "camelCase")]
+enum Status {
+    Active,
+    NotReady,
+    #[zlink(rename = "GONE")]
+    Gone,
+}
+
+#[derive(CustomType)]
+#[allow(unused)]
+#[zlink(rename = "Membership", rename_all = "camelCase")]
+struct Record {
+    user_name: String,
+}
+
+#[derive(CustomType)]
+#[allow(unused)]
+#[zlink(rename = "Severity", rename_all = "lowercase")]
+enum Level {
+    Low,
+    High,
+}

--- a/zlink-macros/tests/reply-error-derive.rs
+++ b/zlink-macros/tests/reply-error-derive.rs
@@ -21,6 +21,16 @@ enum TestError<'a> {
         #[zlink(rename = "optionalData")]
         _optional: Option<&'a str>,
     },
+    // `borrow` before `rename` on one attribute must not drop the rename.
+    BorrowThenRename {
+        #[zlink(borrow, rename = "borrowedMessage")]
+        _message: std::borrow::Cow<'a, str>,
+    },
+    // `rename` before `borrow` on one attribute must not drop the borrow.
+    RenameThenBorrow {
+        #[zlink(rename = "renamedMessage", borrow)]
+        _message: std::borrow::Cow<'a, str>,
+    },
 }
 
 #[cfg(test)]
@@ -116,6 +126,33 @@ mod tests {
         let json_with_original_names = r#"{"error":"com.example.Test.RenamedFields","parameters":{"_internal_name":"test_value","_code":42}}"#;
         let result: Result<TestError, _> = serde_json::from_str(json_with_original_names);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn borrow_before_rename_is_honored() {
+        let error = TestError::BorrowThenRename {
+            _message: std::borrow::Cow::Borrowed("hi"),
+        };
+        let json = serde_json::to_string(&error).unwrap();
+
+        assert!(json.contains("borrowedMessage"), "rename dropped: {json}");
+        assert!(!json.contains("_message"), "field not renamed: {json}");
+    }
+
+    #[test]
+    fn rename_before_borrow_is_honored() {
+        // No escapes in the value, so a zero-copy borrow is possible.
+        let json =
+            r#"{"error":"com.example.Test.RenameThenBorrow","parameters":{"renamedMessage":"hi"}}"#;
+
+        let TestError::RenameThenBorrow { _message } = serde_json::from_str(json).unwrap() else {
+            panic!("wrong variant deserialized");
+        };
+
+        assert!(
+            matches!(_message, std::borrow::Cow::Borrowed(_)),
+            "borrow dropped: field was owned instead of borrowed",
+        );
     }
 
     #[test]

--- a/zlink-macros/tests/reply-error-rename.rs
+++ b/zlink-macros/tests/reply-error-rename.rs
@@ -1,0 +1,99 @@
+#![cfg(feature = "introspection")]
+
+use serde_json::json;
+use zlink::{ReplyError, introspect};
+
+// `zlink::ReplyError` (serde) and `zlink::introspect::ReplyError` (IDL) share a name, so import the
+// containing module for the latter rather than aliasing, and reach the trait's associated const
+// through a qualified path below.
+#[derive(Debug, PartialEq, ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.Test")]
+#[zlink(rename_all = "SCREAMING_SNAKE_CASE")]
+enum RenamedError {
+    NotFound,
+    #[zlink(rename = "TimedOut")]
+    Timeout {
+        #[zlink(rename = "timeoutSeconds")]
+        seconds: u32,
+    },
+    #[zlink(rename_all = "camelCase")]
+    BadRequest {
+        request_id: u32,
+    },
+}
+
+#[test]
+fn variant_rename_all_reaches_the_wire() {
+    let json = serde_json::to_value(RenamedError::NotFound).unwrap();
+
+    assert_eq!(json, json!({"error": "org.example.Test.NOT_FOUND"}));
+}
+
+#[test]
+fn explicit_variant_rename_beats_rename_all() {
+    let error = RenamedError::Timeout { seconds: 30 };
+    let json = serde_json::to_value(&error).unwrap();
+
+    assert_eq!(
+        json,
+        json!({
+            "error": "org.example.Test.TimedOut",
+            "parameters": {"timeoutSeconds": 30},
+        }),
+    );
+}
+
+#[test]
+fn variant_rename_all_applies_to_that_variants_fields() {
+    let error = RenamedError::BadRequest { request_id: 7 };
+    let json = serde_json::to_value(&error).unwrap();
+
+    assert_eq!(
+        json,
+        json!({
+            "error": "org.example.Test.BAD_REQUEST",
+            "parameters": {"requestId": 7},
+        }),
+    );
+}
+
+#[test]
+fn renamed_variants_round_trip() {
+    // `Timeout` covers the explicit-rename path (variant and field renamed via
+    // `#[zlink(rename)]`).
+    let error = RenamedError::Timeout { seconds: 30 };
+    let json = serde_json::to_string(&error).unwrap();
+    let back: RenamedError = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(back, error);
+
+    // `BadRequest` covers the `rename_all`-derived path (variant name from the enum-level
+    // `SCREAMING_SNAKE_CASE` rule, field name from the variant-level `camelCase` rule).
+    let error = RenamedError::BadRequest { request_id: 7 };
+    let json = serde_json::to_string(&error).unwrap();
+    let back: RenamedError = serde_json::from_str(&json).unwrap();
+
+    assert_eq!(back, error);
+}
+
+#[test]
+fn idl_error_names_match_the_wire() {
+    // The whole point of sharing `naming`: these must not drift. The IDL name is unqualified; the
+    // wire name is the same string qualified by the interface.
+    let variants = <RenamedError as introspect::ReplyError>::VARIANTS;
+
+    assert_eq!(variants[0].name(), "NOT_FOUND");
+    assert_eq!(variants[1].name(), "TimedOut");
+    assert_eq!(variants[2].name(), "BAD_REQUEST");
+}
+
+#[test]
+fn idl_field_names_match_the_wire() {
+    let variants = <RenamedError as introspect::ReplyError>::VARIANTS;
+
+    let timeout: Vec<_> = variants[1].fields().collect();
+    assert_eq!(timeout[0].name(), "timeoutSeconds");
+
+    let bad_request: Vec<_> = variants[2].fields().collect();
+    assert_eq!(bad_request[0].name(), "requestId");
+}


### PR DESCRIPTION
Fixes #81.

Renaming is now supported in the derives, driven by zlink's own attributes:

- `#[zlink(rename = "...")]` on a field or variant sets its name.
- `#[zlink(rename_all = "...")]` on a struct applies a case convention to its fields, on an enum to
  its variant names, and on a variant to that variant's fields. An explicit `rename` overrides it.
- On `CustomType`, a container `rename` names the IDL type itself.
- `ReplyError` variants can be renamed, changing the serialized error name.

The eight `rename_all` values and their semantics are serde's (`lowercase`, `UPPERCASE`,
`PascalCase`, `camelCase`, `snake_case`, `SCREAMING_SNAKE_CASE`, `kebab-case`,
`SCREAMING-KEBAB-CASE`) — the attributes are ours, but there's no value in inventing different
semantics for something Rust users already know.

So the workaround posted on the issue becomes:

```rust
#[derive(Debug, Serialize, Type)]
#[serde(rename_all = "camelCase")]
#[zlink(rename_all = "camelCase")]
struct Membership {
    user_name: String,
    group_name: String,
}
```

## On serde's attributes

The issue asked to investigate reusing serde's attributes. That was investigated and **rejected**:
it's consistent with the existing `#[zlink(rename)]` API on proxy methods and `ReplyError` fields,
and it works on types that don't derive serde at all — the `ReplyError` derive writes its own serde
impls, so `#[serde(..)]` wouldn't even compile there.

The trade-off is real and accepted: a type deriving both serde's and zlink's traits must state the
renaming twice, and nothing detects a disagreement. The derive docs say so plainly rather than
leave it to be discovered.

## Two design points worth review

`ReplyError` variant renaming changes **both** derives in a single commit. The serde derive puts
the name on the wire, the introspection derive puts it in the IDL; both resolve through one shared
`naming` module, because a disagreement between them would be an interface description that lies
about the protocol.

A container `rename` is a **hard error** on the `Type` derive (its object type is anonymous) and on
both `ReplyError` derives (error names are qualified by `#[zlink(interface)]`). Silently ignoring
it is how people ship wrong IDL. This is technically breaking for anyone who wrote a `rename` that
never did anything.

## Also here

The first commit is a standalone fix for a pre-existing bug: `#[zlink(..)]` parsing was
order-dependent in both directions — `#[zlink(borrow, rename = "x")]` silently dropped the rename,
and `#[zlink(rename = "x", borrow)]` silently dropped the `borrow` (losing zero-copy). The rename
work builds on these helpers and needs them to be order-independent.

## Not included

- `#[serde(skip)]`/`flatten`/`tag` equivalents. These also affect what's on the wire and so can
  produce wrong IDL, but they aren't renaming. #291 
- Raw identifiers remain as they are today: a `r#type` field fails to compile in the introspection
  derives and reaches the wire as the `r#type` key. Pre-existing, and fixing it would change an
  existing derive's wire format. #290 

## Testing

`cargo test --all-features`: 458 passed, 0 failed (429 on `main`). The no_std path
(`cargo test -p zlink-core --no-default-features --features idl-parse,proxy,defmt`): 154 passed.
Clippy `-D warnings` and nightly fmt clean.

New tests cover all eight conventions for both fields and variants, `rename` overriding
`rename_all`, kebab-case names not breaking generated statics, the `CustomType` name and its
`Type::Custom` reference staying in sync, and — the important one — that the IDL error/field names
match what actually goes on the wire.

Generated by Claude Opus 4.8 (1M context).
