### PR TITLE
Unraw raw identifiers in the derives

### DIFF
--- a/zlink-macros/src/introspect/custom_type.rs
+++ b/zlink-macros/src/introspect/custom_type.rs
@@ -23,7 +23,7 @@ fn derive_custom_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
     let name = &input.ident;
     let name_str = match naming::parse_rename(&input.attrs)? {
         Some(lit) => lit.value(),
-        None => name.to_string(),
+        None => naming::unraw(name),
     };
     let rename_all = naming::parse_rename_all(&input.attrs)?;
     let generics = &input.generics;

--- a/zlink-macros/src/introspect/shared.rs
+++ b/zlink-macros/src/introspect/shared.rs
@@ -44,11 +44,11 @@ pub(super) fn generate_field_definitions(
                 let static_name = if let Some(variant_ident) = variant_prefix {
                     quote::format_ident!(
                         "FIELD_{}_{}",
-                        variant_ident.to_string().to_uppercase(),
-                        field_name.to_string().to_uppercase()
+                        naming::unraw(variant_ident).to_uppercase(),
+                        naming::unraw(field_name).to_uppercase()
                     )
                 } else {
-                    quote::format_ident!("FIELD_{}", field_name.to_string().to_uppercase())
+                    quote::format_ident!("FIELD_{}", naming::unraw(field_name).to_uppercase())
                 };
 
                 let comments = utils::extract_doc_comments(&field.attrs);

--- a/zlink-macros/src/naming.rs
+++ b/zlink-macros/src/naming.rs
@@ -150,6 +150,19 @@ pub(crate) fn parse_rename(attrs: &[Attribute]) -> Result<Option<LitStr>, Error>
     parse_zlink_lit_str(attrs, "rename")
 }
 
+/// The unraw'd name of an ident: its leading `r#`, if any, stripped off.
+///
+/// `r#` (e.g. `r#type`) is Rust syntax that lets a keyword be used as an identifier; it is never
+/// part of the name itself, so it must not leak into the IDL or onto the wire.
+pub(crate) fn unraw(ident: &Ident) -> String {
+    let name = ident.to_string();
+
+    match name.strip_prefix("r#") {
+        Some(stripped) => stripped.to_owned(),
+        None => name,
+    }
+}
+
 fn resolve<F>(
     attrs: &[Attribute],
     ident: &Ident,
@@ -163,7 +176,7 @@ where
         return Ok(lit.value());
     }
 
-    let ident = ident.to_string();
+    let ident = unraw(ident);
 
     Ok(match rename_all {
         Some(rule) => apply(rule, &ident),
@@ -281,6 +294,20 @@ mod tests {
         let ident: Ident = parse_quote!(user_id);
 
         assert_eq!(field_name(&attrs, &ident, None).unwrap(), "user_id");
+    }
+
+    #[test]
+    fn unraw_strips_the_prefix() {
+        let ident: Ident = parse_quote!(r#type);
+
+        assert_eq!(unraw(&ident), "type");
+    }
+
+    #[test]
+    fn unraw_leaves_a_normal_ident_unchanged() {
+        let ident: Ident = parse_quote!(user_id);
+
+        assert_eq!(unraw(&ident), "user_id");
     }
 
     #[test]

--- a/zlink-macros/tests/introspect-rename.rs
+++ b/zlink-macros/tests/introspect-rename.rs
@@ -80,6 +80,69 @@ fn custom_enum_container_rename() {
     assert_eq!(variants[0].name(), "low");
 }
 
+#[test]
+fn custom_type_raw_ident_container_name_is_unraw_d() {
+    let idl::CustomType::Object(obj) = Foo::CUSTOM_TYPE else {
+        panic!("expected an object custom type");
+    };
+
+    assert_eq!(obj.name(), "Foo", "must not be r#Foo");
+}
+
+#[test]
+fn raw_ident_custom_type_keeps_type_reference_in_sync() {
+    // Same sync property as `custom_type_rename_keeps_type_reference_in_sync` above, but for the
+    // no-explicit-rename path: the container name comes straight from the (unraw'd) Rust ident.
+    assert_eq!(Foo::TYPE, &idl::Type::Custom("Foo"));
+}
+
+#[test]
+fn raw_ident_field_name_is_unraw_d() {
+    // `r#type` must not panic (the static ident derived from it must not carry `r#`), and the
+    // IDL name must not carry `r#` either: `r#type` is not valid Varlink.
+    let idl::Type::Object(fields) = RawField::TYPE else {
+        panic!("expected an object type");
+    };
+    let fields: Vec<_> = fields.iter().collect();
+
+    assert_eq!(fields[0].name(), "type");
+}
+
+#[test]
+fn raw_ident_field_rename_all_applies_to_the_unraw_d_name() {
+    let idl::Type::Object(fields) = RawFieldUppercased::TYPE else {
+        panic!("expected an object type");
+    };
+    let fields: Vec<_> = fields.iter().collect();
+
+    assert_eq!(fields[0].name(), "TYPE", "must not be R#TYPE");
+}
+
+#[test]
+fn raw_ident_field_explicit_rename_wins() {
+    // This asserted value ("kind") is produced by `resolve` whether or not the ident is unraw'd
+    // first, so it does not by itself pin the fix. What this test actually guards is that the
+    // `RawFieldRenamed` fixture below compiles at all: the static field ident is derived from the
+    // (unraw'd) Rust ident `r#type`, not from the resolved "kind" name. Reverting the fix makes
+    // this fail to compile with `` `"FIELD_R#TYPE"` is not a valid identifier ``.
+    let idl::Type::Object(fields) = RawFieldRenamed::TYPE else {
+        panic!("expected an object type");
+    };
+    let fields: Vec<_> = fields.iter().collect();
+
+    assert_eq!(fields[0].name(), "kind");
+}
+
+#[test]
+fn raw_ident_variant_name_is_unraw_d() {
+    let idl::Type::Enum(variants) = RawVariant::TYPE else {
+        panic!("expected an enum type");
+    };
+    let variants: Vec<_> = variants.iter().collect();
+
+    assert_eq!(variants[0].name(), "fn");
+}
+
 // `#[allow(unused)]` on test types matches the convention already used throughout
 // `tests/introspect-type.rs`: the fields exist only to be described, never read.
 
@@ -130,4 +193,36 @@ struct Record {
 enum Level {
     Low,
     High,
+}
+
+#[derive(Type)]
+#[allow(unused)]
+struct RawField {
+    r#type: String,
+}
+
+#[derive(Type)]
+#[allow(unused)]
+#[zlink(rename_all = "UPPERCASE")]
+struct RawFieldUppercased {
+    r#type: String,
+}
+
+#[derive(Type)]
+#[allow(unused)]
+struct RawFieldRenamed {
+    #[zlink(rename = "kind")]
+    r#type: String,
+}
+
+#[derive(Type)]
+#[allow(unused, non_camel_case_types)]
+enum RawVariant {
+    r#fn,
+}
+
+#[derive(CustomType)]
+#[allow(unused)]
+struct r#Foo {
+    value: String,
 }

--- a/zlink-macros/tests/reply-error-rename.rs
+++ b/zlink-macros/tests/reply-error-rename.rs
@@ -97,3 +97,87 @@ fn idl_field_names_match_the_wire() {
     let bad_request: Vec<_> = variants[2].fields().collect();
     assert_eq!(bad_request[0].name(), "requestId");
 }
+
+#[derive(Debug, PartialEq, ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.RawIdent")]
+enum RawIdentError {
+    Bad { r#type: String },
+}
+
+#[test]
+fn raw_ident_field_name_reaches_the_wire_unraw_d() {
+    // `r#type` is Rust syntax; `r#` must never leak into the JSON key, and `r#type` is not
+    // expressible in Varlink IDL to begin with.
+    let error = RawIdentError::Bad {
+        r#type: "x".to_owned(),
+    };
+    let json = serde_json::to_value(&error).unwrap();
+
+    assert_eq!(
+        json,
+        json!({
+            "error": "org.example.RawIdent.Bad",
+            "parameters": {"type": "x"},
+        }),
+    );
+
+    let back: RawIdentError = serde_json::from_value(json).unwrap();
+    assert_eq!(back, error);
+}
+
+#[test]
+fn idl_and_wire_agree_on_raw_ident_field_name() {
+    let variants = <RawIdentError as introspect::ReplyError>::VARIANTS;
+    let fields: Vec<_> = variants[0].fields().collect();
+
+    assert_eq!(fields[0].name(), "type");
+}
+
+// `RawIdentError` above covers a raw-ident *field* on a non-raw variant. It does not reach the
+// `FIELD_{VARIANT}_{FIELD}` static-name path in `introspect/shared.rs`, which only runs when the
+// *variant* ident is also raw. Cover that combination here.
+//
+// The variant is named `r#Fn` rather than the keyword-driven `r#fn`: the wire `ReplyError` derive
+// clones variants into an internal helper enum for `Deserialize` that does not inherit this
+// enum's `#[allow(non_camel_case_types)]`, so a lowercase raw ident would fail
+// `clippy -D warnings` independently of the fix under test. `r#Fn` is a redundant (but legal) raw
+// ident on an already-PascalCase word: `Ident::to_string()` still yields it with the `r#` prefix,
+// so it exercises the same `naming::unraw` call without tripping that unrelated lint.
+#[derive(Debug, PartialEq, ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.RawVariant")]
+enum RawIdentVariantError {
+    r#Fn { r#type: String },
+}
+
+#[test]
+fn raw_ident_variant_with_raw_field_reaches_the_wire_unraw_d() {
+    // Both the variant ident (`r#Fn`) and its field (`r#type`) are raw. This is the only fixture
+    // that exercises `naming::unraw(variant_ident)` in the `FIELD_{VARIANT}_{FIELD}` static-name
+    // path (`introspect/shared.rs`): reverting that one call to `variant_ident.to_string()` fails
+    // to compile here with `` `"FIELD_R#FN_TYPE"` is not a valid identifier ``.
+    let error = RawIdentVariantError::r#Fn {
+        r#type: "x".to_owned(),
+    };
+    let json = serde_json::to_value(&error).unwrap();
+
+    assert_eq!(
+        json,
+        json!({
+            "error": "org.example.RawVariant.Fn",
+            "parameters": {"type": "x"},
+        }),
+    );
+
+    let back: RawIdentVariantError = serde_json::from_value(json).unwrap();
+    assert_eq!(back, error);
+}
+
+#[test]
+fn idl_and_wire_agree_on_raw_ident_variant_and_field_names() {
+    let variants = <RawIdentVariantError as introspect::ReplyError>::VARIANTS;
+
+    assert_eq!(variants[0].name(), "Fn");
+
+    let fields: Vec<_> = variants[0].fields().collect();
+    assert_eq!(fields[0].name(), "type");
+}


### PR DESCRIPTION
Fixes #290.

Rust's `r#` prefix is syntax for using a keyword as an identifier — it is never part of the name
the user means. The derives treated it as part of the name, in two coupled ways:

- The introspection derives built their per-field statics from the raw ident, so `r#type` yielded
  the invalid ident `FIELD_R#TYPE` and the derive **panicked** — no span, no hint, just
  `` `"FIELD_R#TYPE"` is not a valid identifier ``.
- `ReplyError` put `r#type` straight into the JSON key.

Both now resolve through `naming::unraw`. A third site turned up in review and is fixed too: the
`CustomType` container name (`#[derive(CustomType)] struct r#Foo` leaked `r#Foo` into the IDL,
silently). That is in scope under the issue's own suggested fix, "strip the `r#` prefix when
resolving a name".

An explicit `#[zlink(rename = "...")]` still passes through verbatim — it is a user-supplied
string, not an ident, so `r#` in it is not syntax and unrawing it would silently rewrite a
deliberate choice.

## The wire change is a fix, not a break

The issue left this open ("worth deciding explicitly whether that's a fix or a break"). It
resolves cleanly in favour of *fix*:

- `r#type` was never expressible in Varlink to begin with. Our own parser defines a field name as
  `[A-Za-z][A-Za-z0-9_]*` (`zlink-core/src/idl/parse/mod.rs:51-59`) and treats `#` as the start of
  a comment (`mod.rs:23-31`). Anyone relying on an `r#`-prefixed key was already emitting
  something no conformant peer could describe.
- The issue's stated alternative — rejecting raw idents with a proper error — is **not viable**:
  `zlink-codegen` itself emits `r#` fields (`codegen.rs:436-442`) for Varlink fields legally named
  after Rust keywords. Rejecting them would break its own output.
- `zlink-codegen` is unaffected either way: it already pairs those `r#` fields with an explicit
  `#[zlink(rename = "...")]`, which wins over the ident.

Both halves have to land together — unrawing only the static's ident would make `r#type` compile
in the introspection derives while the IDL still described the field as `r#type`.

## Testing

`cargo test --all-features`: 468 passed, 0 failed (456 on `main`). no_std
(`cargo test -p zlink-core --no-default-features --features idl-parse,proxy,defmt`): 154 passed.
Clippy `-D warnings`, nightly fmt, and the no_std check are clean.

New tests cover the raw-ident field in the IDL and on the wire (exact JSON, not a substring),
`rename_all` applying to the unraw'd name, an explicit `rename` still winning, the `CustomType`
container name, and — the important one — that the IDL and the wire agree on a raw-ident name.

Worth noting on coverage: review established by mutation that `unraw(variant_ident)` (the
`FIELD_{VARIANT}_{FIELD}` path) was **load-bearing but untested** — reverting it left all tests
green, yet `enum X { r#Fn { r#type: String } }` fails to compile without it. There is now a
fixture that fails under that mutation.

## Found while here, filed separately

- #292 — `#[zlink::service]` has the same bug class with a worse consequence: it builds the IDL
  parameter name by hand while delegating the wire name to serde, and serde unraws. So the IDL
  advertises `r#type` while the method only accepts `type` — the IDL misdescribing the wire, which
  is the exact failure the shared `naming` module exists to prevent. A raw method name panics too.
- #293 — `derive(ReplyError)`'s generated `__ZlinkDeserHelper` lacks
  `#[allow(non_camel_case_types)]`, so any lowercase variant fails `-D warnings` and the user's own
  `#[allow]` cannot silence it. This is why the new fixture uses `r#Fn` rather than the realistic
  `r#fn`: raw *variants* remain unusable under `-D warnings` until #293 is fixed. Raw *fields*,
  the case in #290, work.

Generated by Claude Opus 4.8 (1M context).