### PR TITLE
Unraw raw identifiers in the service and proxy macros

### DIFF
--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -18,7 +18,9 @@ pub(super) fn generate_chain_extension_method(
     crate_path: &TokenStream,
     param_attrs_map: &std::collections::HashMap<String, ParamAttrs>,
 ) -> Result<(TokenStream, TokenStream), Error> {
-    let method_name_str = method.sig.ident.to_string();
+    // Only the wire name is unraw'd; `method_ident` stays raw so the generated fn still matches
+    // the trait it implements.
+    let method_name_str = crate::naming::unraw(&method.sig.ident);
     let method_ident = method.sig.ident.clone();
 
     // Check for explicit lifetimes early
@@ -309,14 +311,14 @@ fn generate_with_params_method(
     let params_struct_name = syn::Ident::new(
         &format!(
             "{}Params",
-            snake_case_to_pascal_case(&method_name.to_string())
+            snake_case_to_pascal_case(&crate::naming::unraw(method_name))
         ),
         method_name.span(),
     );
     let wrapper_enum_name = syn::Ident::new(
         &format!(
             "{}Wrapper",
-            snake_case_to_pascal_case(&method_name.to_string())
+            snake_case_to_pascal_case(&crate::naming::unraw(method_name))
         ),
         method_name.span(),
     );

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -23,7 +23,9 @@ pub(super) fn generate_chain_method(
     crate_path: &TokenStream,
     param_attrs_map: &std::collections::HashMap<String, ParamAttrs>,
 ) -> Result<(TokenStream, TokenStream), Error> {
-    let method_name_str = method.sig.ident.to_string();
+    // Only the wire name and the `chain_` ident are unraw'd; `method_ident` stays raw so the
+    // generated fn still matches the trait it implements.
+    let method_name_str = crate::naming::unraw(&method.sig.ident);
     let method_ident = method.sig.ident.clone();
     let method_span = method.sig.ident.span();
 
@@ -271,14 +273,14 @@ fn generate_method_call_creation(
         let params_struct_name = syn::Ident::new(
             &format!(
                 "{}Params",
-                snake_case_to_pascal_case(&method_name.to_string())
+                snake_case_to_pascal_case(&crate::naming::unraw(method_name))
             ),
             method_name.span(),
         );
         let wrapper_enum_name = syn::Ident::new(
             &format!(
                 "{}Wrapper",
-                snake_case_to_pascal_case(&method_name.to_string())
+                snake_case_to_pascal_case(&crate::naming::unraw(method_name))
             ),
             method_name.span(),
         );
@@ -325,7 +327,7 @@ fn generate_method_call_creation(
         let wrapper_enum_name = syn::Ident::new(
             &format!(
                 "{}Wrapper",
-                snake_case_to_pascal_case(&method_name.to_string())
+                snake_case_to_pascal_case(&crate::naming::unraw(method_name))
             ),
             method_name.span(),
         );

--- a/zlink-macros/src/proxy/method_impl.rs
+++ b/zlink-macros/src/proxy/method_impl.rs
@@ -21,7 +21,9 @@ pub(super) fn generate_method_impl(
     param_attrs_map: &std::collections::HashMap<String, ParamAttrs>,
 ) -> Result<TokenStream, Error> {
     let method_name = &method.sig.ident;
-    let method_name_str = method_name.to_string();
+    // Only the wire name is unraw'd; the generated fn keeps the raw ident so it still matches the
+    // trait it implements.
+    let method_name_str = crate::naming::unraw(method_name);
 
     let converted_name = snake_case_to_pascal_case(&method_name_str);
     let actual_method_name = method_attrs.rename.as_deref().unwrap_or(&converted_name);

--- a/zlink-macros/src/reply_error.rs
+++ b/zlink-macros/src/reply_error.rs
@@ -360,6 +360,9 @@ fn generate_deserialize_with_derive(
             where
                 D: serde::Deserializer<'de>,
             {
+                // Nested in a function body, so the user's own `#[allow]` on their enum cannot
+                // reach the variants cloned in here, and they cannot annotate this item.
+                #[allow(non_camel_case_types)]
                 #[derive(serde::Deserialize)]
                 #[serde(tag = "error", content = "parameters")]
                 enum __ZlinkDeserHelper #orig_impl_generics #orig_where_clause {

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -65,10 +65,11 @@ impl MethodInfo {
             *current_interface = Some(iface.clone());
         }
 
-        // Determine the Varlink method name.
+        // Determine the Varlink method name. The ident is unraw'd first: `r#` is Rust syntax, not
+        // part of the name, and it would otherwise reach `format_ident!` as `R#type`.
         let varlink_name = method_attrs
             .rename
-            .unwrap_or_else(|| snake_case_to_pascal_case(&name.to_string()));
+            .unwrap_or_else(|| snake_case_to_pascal_case(&crate::naming::unraw(&name)));
 
         // Check if this is a streaming method.
         let is_streaming = method_attrs.is_streaming;
@@ -119,7 +120,8 @@ impl MethodInfo {
             .iter()
             .filter(|p| !p.is_connection && !p.is_more && !p.is_fds)
         {
-            if param.serialized_name.is_none() && param.name.to_string().starts_with('_') {
+            if param.serialized_name.is_none() && crate::naming::unraw(&param.name).starts_with('_')
+            {
                 return Err(Error::new_spanned(
                     &param.name,
                     "parameter names starting with `_` are not valid Varlink field names; \
@@ -671,4 +673,32 @@ pub(super) fn extract_first_tuple_element(ty: &Type) -> Option<Type> {
         return None;
     };
     tuple.elems.first().cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use syn::{FnArg, parse_quote};
+
+    /// The `_` check must judge the same string `ParamInfo::wire_name` does, or a raw ident slips
+    /// past it and reaches the IDL unraw'd as `_foo`.
+    #[test]
+    fn underscore_prefixed_params_rejected_raw_or_not() {
+        for src in ["_foo: String", "r#_foo: String"] {
+            let param: FnArg = syn::parse_str(src).unwrap();
+            let mut method: ImplItemFn = parse_quote! {
+                async fn probe(&self, #param) -> Result<Reply, Error> { todo!() }
+            };
+            let mut interface = Some("org.example.probe".to_owned());
+
+            let Err(err) = MethodInfo::extract(&mut method, &mut interface) else {
+                panic!("`{src}` must be rejected: it reaches the IDL as `_foo`");
+            };
+
+            assert!(
+                err.to_string().contains("not valid Varlink field names"),
+                "unexpected error for `{src}`: {err}"
+            );
+        }
+    }
 }

--- a/zlink-macros/src/service/types.rs
+++ b/zlink-macros/src/service/types.rs
@@ -24,13 +24,14 @@ pub(super) struct ParamInfo {
 impl ParamInfo {
     /// The parameter name used on the wire (and in the IDL).
     ///
-    /// This is the explicit `#[zlink(rename = "...")]` name if provided, the Rust parameter
-    /// name otherwise. Parameter names starting with `_` are rejected at extraction time, so
-    /// this is always a valid Varlink field name.
+    /// This is the explicit `#[zlink(rename = "...")]` name if provided, the unraw'd Rust
+    /// parameter name otherwise. Unrawing is what keeps the IDL and the wire in agreement: serde
+    /// unraws the name it deserializes, so an `r#`-prefixed IDL name would advertise a parameter
+    /// the method could never accept.
     pub(super) fn wire_name(&self) -> Cow<'_, str> {
         match &self.serialized_name {
             Some(name) => Cow::Borrowed(name),
-            None => Cow::Owned(self.name.to_string()),
+            None => Cow::Owned(crate::naming::unraw(&self.name)),
         }
     }
 

--- a/zlink-macros/tests/proxy/rename.rs
+++ b/zlink-macros/tests/proxy/rename.rs
@@ -126,3 +126,86 @@ async fn param_rename_chain_test() {
     assert_eq!(written2["parameters"]["dryRun"], false);
     assert_eq!(written2["parameters"]["configValue"], "another_value");
 }
+
+#[tokio::test]
+async fn raw_ident_method_name() {
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
+
+    #[proxy("org.example.Raw")]
+    trait RawProxy {
+        // The generated fn has to keep the raw ident to match this declaration, while the name it
+        // carries on the wire must not: `r#` is Rust syntax, never part of the name.
+        async fn r#type(&mut self, r#move: i32) -> zlink::Result<Result<(), Error>>;
+    }
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Error;
+
+    let responses = json!({}).to_string();
+    let socket = MockSocket::with_responses(&[&responses]);
+    let mut conn = Connection::new(socket);
+
+    conn.r#type(42).await.unwrap().unwrap();
+
+    let bytes_written = conn.write().write_half().written_data();
+    let written: serde_json::Value =
+        serde_json::from_slice(&bytes_written[..bytes_written.len() - 1]).unwrap();
+    assert_eq!(written["method"], "org.example.Raw.Type");
+    assert_eq!(written["parameters"]["move"], 42);
+}
+
+#[tokio::test]
+async fn raw_ident_chain_method() {
+    use futures_util::{pin_mut, stream::StreamExt};
+    use serde::{Deserialize, Serialize};
+    use serde_json::json;
+    use zlink::{Connection, proxy, test_utils::mock_socket::MockSocket};
+
+    #[derive(Debug, Serialize, Deserialize)]
+    struct Error;
+
+    #[proxy("org.example.RawChain")]
+    trait RawChainProxy {
+        #[allow(unused)]
+        async fn r#type(&mut self, r#move: i32) -> zlink::Result<Result<(), Error>>;
+    }
+
+    let reply1 = json!({}).to_string();
+    let reply2 = json!({}).to_string();
+    let socket = MockSocket::new(&[&reply1, &reply2], vec![vec![]]);
+    let mut conn = Connection::new(socket);
+
+    {
+        // `chain_type`, not `chain_r#type`; the chain extension method stays raw-named.
+        let replies = conn
+            .chain_type(1)
+            .unwrap()
+            .r#type(2)
+            .unwrap()
+            .send::<(), Error>()
+            .await
+            .unwrap();
+
+        pin_mut!(replies);
+
+        let (reply1, _fds) = replies.next().await.unwrap().unwrap();
+        reply1.unwrap();
+        let (reply2, _fds) = replies.next().await.unwrap().unwrap();
+        reply2.unwrap();
+    }
+
+    let bytes_written = conn.write().write_half().written_data();
+    let messages: Vec<&[u8]> = bytes_written
+        .split(|&b| b == 0)
+        .filter(|s| !s.is_empty())
+        .collect();
+    assert_eq!(messages.len(), 2);
+
+    for (message, expected) in messages.iter().zip([1, 2]) {
+        let written: serde_json::Value = serde_json::from_slice(message).unwrap();
+        assert_eq!(written["method"], "org.example.RawChain.Type");
+        assert_eq!(written["parameters"]["move"], expected);
+    }
+}

--- a/zlink-macros/tests/reply-error-rename.rs
+++ b/zlink-macros/tests/reply-error-rename.rs
@@ -1,4 +1,7 @@
 #![cfg(feature = "introspection")]
+// Denied here rather than left to the test runner's flags, so that the `ProbeError` fixture below
+// keeps proving the generated `Deserialize` helper carries its own `#[allow]`.
+#![deny(non_camel_case_types)]
 
 use serde_json::json;
 use zlink::{ReplyError, introspect};
@@ -137,12 +140,12 @@ fn idl_and_wire_agree_on_raw_ident_field_name() {
 // `FIELD_{VARIANT}_{FIELD}` static-name path in `introspect/shared.rs`, which only runs when the
 // *variant* ident is also raw. Cover that combination here.
 //
-// The variant is named `r#Fn` rather than the keyword-driven `r#fn`: the wire `ReplyError` derive
-// clones variants into an internal helper enum for `Deserialize` that does not inherit this
-// enum's `#[allow(non_camel_case_types)]`, so a lowercase raw ident would fail
-// `clippy -D warnings` independently of the fix under test. `r#Fn` is a redundant (but legal) raw
-// ident on an already-PascalCase word: `Ident::to_string()` still yields it with the `r#` prefix,
-// so it exercises the same `naming::unraw` call without tripping that unrelated lint.
+// The variant is named `r#Fn` rather than the keyword-driven `r#fn` because a Varlink error name
+// must be PascalCase: `error_def` parses it with `type_name`, which requires an uppercase first
+// letter. `r#fn` would unraw to `fn` and describe an error our own IDL parser rejects. `r#Fn` is a
+// redundant (but legal) raw ident on an already-PascalCase word: `Ident::to_string()` still yields
+// it with the `r#` prefix, so it exercises the same `naming::unraw` call while staying valid
+// Varlink.
 #[derive(Debug, PartialEq, ReplyError, introspect::ReplyError)]
 #[zlink(interface = "org.example.RawVariant")]
 enum RawIdentVariantError {
@@ -180,4 +183,36 @@ fn idl_and_wire_agree_on_raw_ident_variant_and_field_names() {
 
     let fields: Vec<_> = variants[0].fields().collect();
     assert_eq!(fields[0].name(), "type");
+}
+
+// A lowercase variant needs an `#[allow]` on both this enum and the helper the wire derive nests
+// inside `Deserialize::deserialize`, which cannot inherit this one. Dropping the derive's own
+// `#[allow(non_camel_case_types)]` fails this file to compile, pointing here.
+//
+// Only the wire derive is applied: `lowercase` is not a valid Varlink error name (those are
+// PascalCase, as `RawIdentVariantError` above notes), so there is no IDL worth asserting on.
+#[derive(Debug, PartialEq, ReplyError)]
+#[zlink(interface = "org.example.Probe")]
+#[allow(non_camel_case_types)]
+enum ProbeError {
+    lowercase { value: String },
+}
+
+#[test]
+fn lowercase_variant_name_is_allowed_by_the_users_own_allow() {
+    let error = ProbeError::lowercase {
+        value: "x".to_owned(),
+    };
+    let json = serde_json::to_value(&error).unwrap();
+
+    assert_eq!(
+        json,
+        json!({
+            "error": "org.example.Probe.lowercase",
+            "parameters": {"value": "x"},
+        }),
+    );
+
+    let back: ProbeError = serde_json::from_value(json).unwrap();
+    assert_eq!(back, error);
 }

--- a/zlink-macros/tests/service.rs
+++ b/zlink-macros/tests/service.rs
@@ -21,6 +21,8 @@ mod metadata;
 mod multiple_interfaces;
 #[path = "service/per_interface_types.rs"]
 mod per_interface_types;
+#[path = "service/raw_idents.rs"]
+mod raw_idents;
 #[path = "service/streaming.rs"]
 mod streaming;
 #[path = "service/streaming_errors.rs"]

--- a/zlink-macros/tests/service/raw_idents.rs
+++ b/zlink-macros/tests/service/raw_idents.rs
@@ -1,0 +1,89 @@
+//! Tests for raw identifiers (`r#type`) as method and parameter names.
+//!
+//! `r#` is Rust syntax for using a keyword as an identifier; it is never part of the name, and
+//! Varlink cannot express it at all (`#` starts a comment there). serde strips it when
+//! (de)serializing, so the IDL must strip it too — otherwise the interface description advertises
+//! names the method can never accept.
+
+use serde::{Deserialize, Serialize};
+use zlink::{
+    Server,
+    introspect::{self, CustomType},
+    unix::{bind, connect},
+};
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn raw_ident_method_and_param() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let socket_path = dir.path().join("test.sock");
+
+    // Set up the server and run it concurrently with the client.
+    let listener = bind(&socket_path).unwrap();
+    let service = Probe;
+    let server = Server::new(listener, service);
+    tokio::select! {
+        res = server.run() => res?,
+        res = run_client(&socket_path) => res?,
+    }
+
+    Ok(())
+}
+
+async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+    let mut conn = connect(socket_path).await?;
+
+    // A successful call proves the wire side: the proxy sends `Type` with a `type` parameter, and
+    // dispatch accepts both.
+    let reply = conn.probe_type("frobnicate").await?.unwrap();
+    assert_eq!(reply.echoed, "frobnicate");
+
+    // The introspection data must advertise exactly those names, or a client trusting our own IDL
+    // would send `r#type` and get `missing field type`.
+    {
+        use zlink::varlink_service::Proxy as VarlinkProxy;
+
+        let desc = conn
+            .get_interface_description("org.example.probe")
+            .await?
+            .unwrap();
+        let interface = desc.parse()?;
+        let method = interface
+            .methods()
+            .find(|m| m.name() == "Type")
+            .expect("raw method ident must be advertised unraw'd");
+        let input_names: Vec<_> = method.inputs().map(|f| f.name()).collect();
+        assert_eq!(input_names.as_slice(), &["type"]);
+    }
+
+    Ok(())
+}
+
+// Response type echoing back the raw-named parameter.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, CustomType)]
+struct Probed {
+    echoed: String,
+}
+
+#[derive(Debug, Clone, PartialEq, zlink::ReplyError, introspect::ReplyError)]
+#[zlink(interface = "org.example.probe")]
+enum ProbeError {
+    Failed,
+}
+
+struct Probe;
+
+#[zlink::service(interface = "org.example.probe", types = [Probed])]
+impl Probe {
+    /// Echo back the raw-named parameter.
+    async fn r#type(&mut self, r#type: String) -> Result<Probed, ProbeError> {
+        Ok(Probed { echoed: r#type })
+    }
+}
+
+// The proxy method is deliberately not itself raw-named: a raw ident on the proxy side is a
+// separate concern, so this reaches the service's `Type` method by an explicit rename.
+#[zlink::proxy("org.example.probe")]
+trait ProbeProxy {
+    #[zlink(rename = "Type")]
+    async fn probe_type(&mut self, r#type: &str) -> zlink::Result<Result<Probed, ProbeError>>;
+}


### PR DESCRIPTION
Raw identifiers, continued from #294 — plus one lint fix found alongside them.

`r#` is Rust syntax for using a keyword as an identifier; it is never part of the name. #294 taught
the `Type` / `CustomType` / `introspect::ReplyError` derives that. These three commits finish the
job for the two macros #294 didn't touch, and fix an unrelated-but-adjacent lint bug found while
writing its tests.

- **`zlink-macros: Allow non-camel-case variants in ReplyError's helper`** (#293) — the wire
  `ReplyError` derive nests a helper enum inside `Deserialize::deserialize` to clone the variants
  across for serde. Nested items don't inherit attributes, so the user's own
  `#[allow(non_camel_case_types)]` could never reach it: a lowercase variant failed `-D warnings`
  with the diagnostic telling the user to add the attribute they already had. Nothing to do with
  raw idents.
- **`zlink-macros: Unraw idents in the service macro`** (#292) — the macro built the IDL parameter
  name by hand while leaving the wire name to serde, and serde unraws. The two disagreed, and the
  IDL was the wrong half: Varlink can't express `r#type` at all (`#` starts a comment), so what we
  emitted wasn't parseable by our own parser. A raw method name additionally panicked in
  `format_ident!` as `R#type`.
- **`zlink-macros: Unraw idents in the proxy macro`** — no issue of its own; found while verifying
  #292, whose text wrongly claimed proxy was unaffected. Parameters were indeed fine (serde unraws
  them), but a raw *method* name panicked with `"R#typeParams" is not a valid identifier` across 8
  sites, one of which would have built the ident `chain_r#type`.

Both halves of #292 had to land together: unrawing only the static's ident would have made
`r#type` compile while the IDL still described the field as `r#type`.

An explicit `#[zlink(rename = "...")]` is still used verbatim throughout — that's a user-supplied
string, not an ident.

Each commit passes standalone (469 → 471 → 473), so the branch bisects. Every fix is
mutation-verified: reverting it fails a test with the error the issue reports.

Fixes #292.
Fixes #293.
