### PR TITLE
🦺 Validate emitted names against the Varlink grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2275,6 +2275,7 @@ dependencies = [
  "test-log",
  "tokio",
  "zlink",
+ "zlink-idl",
 ]
 
 [[package]]

--- a/zlink-idl/src/lib.rs
+++ b/zlink-idl/src/lib.rs
@@ -51,4 +51,9 @@ mod interface;
 pub use interface::Interface;
 
 #[cfg(feature = "parse")]
+mod name;
+#[cfg(feature = "parse")]
+pub use name::{is_valid_field_name, is_valid_interface_name, is_valid_type_name};
+
+#[cfg(feature = "parse")]
 pub mod parse;

--- a/zlink-idl/src/name.rs
+++ b/zlink-idl/src/name.rs
@@ -1,0 +1,143 @@
+//! Validating names against the Varlink grammar.
+//!
+//! These run the actual IDL parsers, so a name is accepted here exactly when the parser would
+//! accept it in an interface definition -- there is no second copy of the grammar to drift from it.
+
+use winnow::error::{ErrMode, InputError};
+
+use crate::parse;
+
+/// Whether `name` is a valid Varlink field name.
+///
+/// Struct fields, method parameters and enum variants all follow this rule.
+///
+/// # Examples
+///
+/// ```
+/// use zlink_idl::is_valid_field_name;
+///
+/// assert!(is_valid_field_name("user_name"));
+/// assert!(!is_valid_field_name("user-name"));
+/// ```
+pub fn is_valid_field_name(name: &str) -> bool {
+    parses_fully(parse::field_name, name)
+}
+
+/// Whether `name` is a valid Varlink type name.
+///
+/// Method and error names follow this rule too.
+///
+/// # Examples
+///
+/// ```
+/// use zlink_idl::is_valid_type_name;
+///
+/// assert!(is_valid_type_name("FileNotFound"));
+/// assert!(!is_valid_type_name("fileNotFound"));
+/// ```
+pub fn is_valid_type_name(name: &str) -> bool {
+    parses_fully(parse::type_name, name)
+}
+
+/// Whether `name` is a valid Varlink interface name.
+///
+/// Interface names are reverse-domain notation: dot-separated segments, at least one dot.
+///
+/// # Examples
+///
+/// ```
+/// use zlink_idl::is_valid_interface_name;
+///
+/// assert!(is_valid_interface_name("org.example.Foo"));
+/// assert!(!is_valid_interface_name("Foo"));
+/// ```
+pub fn is_valid_interface_name(name: &str) -> bool {
+    parses_fully(parse::interface_name, name)
+}
+
+/// Whether `parser` accepts the whole of `name`, leaving nothing behind.
+///
+/// The parsers succeed on a valid prefix (e.g. `field_name` takes `foo` out of `foo-bar`), so a
+/// name is only valid when parsing also consumes every byte.
+fn parses_fully<'a, P, T>(mut parser: P, name: &'a str) -> bool
+where
+    P: FnMut(&mut &'a [u8]) -> Result<T, ErrMode<InputError<&'a [u8]>>>,
+{
+    let mut input = name.as_bytes();
+
+    parser(&mut input).is_ok() && input.is_empty()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn field_names() {
+        let valid = ["a", "Z", "user_name", "user0", "a_0_b", "type", "x__"];
+        for name in valid {
+            assert!(is_valid_field_name(name), "`{name}` must be valid");
+        }
+
+        let invalid = [
+            "",
+            "_foo",
+            "0foo",
+            "user-name",
+            "user name",
+            "user.name",
+            "user!",
+            "üser",
+            "user\u{e9}",
+        ];
+        for name in invalid {
+            assert!(!is_valid_field_name(name), "`{name}` must be invalid");
+        }
+    }
+
+    #[test]
+    fn type_names() {
+        let valid = ["A", "Foo", "FileNotFound", "Foo0", "X"];
+        for name in valid {
+            assert!(is_valid_type_name(name), "`{name}` must be valid");
+        }
+
+        let invalid = [
+            "", "foo", "_Foo", "0Foo", "Foo_bar", "Foo-bar", "Foo bar", "Foo.Bar", "Foo!", "Über",
+        ];
+        for name in invalid {
+            assert!(!is_valid_type_name(name), "`{name}` must be invalid");
+        }
+    }
+
+    /// Type names are the stricter rule: every one of them is also a valid field name.
+    #[test]
+    fn type_names_are_field_names() {
+        for name in ["A", "Foo", "FileNotFound", "Foo0"] {
+            assert!(is_valid_field_name(name), "`{name}` must be valid");
+        }
+    }
+
+    #[test]
+    fn interface_names() {
+        let valid = ["org.example.Foo", "a.b", "org.varlink.service", "a1.b-2.c3"];
+        for name in valid {
+            assert!(is_valid_interface_name(name), "`{name}` must be valid");
+        }
+
+        let invalid = [
+            "",
+            "Foo",          // No dot.
+            "org.",         // Trailing dot, empty segment.
+            ".org",         // Leading dot.
+            "org..example", // Empty segment.
+            "org.example.", // Trailing dot.
+            "1org.example", // First segment must start with a letter.
+            "org.example.Foo bar",
+            "org.example.Foö",
+        ];
+        for name in invalid {
+            assert!(!is_valid_interface_name(name), "`{name}` must be invalid");
+        }
+    }
+}

--- a/zlink-idl/src/parse/mod.rs
+++ b/zlink-idl/src/parse/mod.rs
@@ -51,7 +51,7 @@ fn bytes_to_str(bytes: &[u8]) -> &str {
 }
 
 /// Parse a field name: starts with letter, continues with alphanumeric and underscores.
-fn field_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
+pub(crate) fn field_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
     (
         one_of(|c: u8| c.is_ascii_alphabetic()),
         take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'_'),
@@ -62,7 +62,7 @@ fn field_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [
 }
 
 /// Parse a type name: starts with uppercase letter, continues with alphanumeric.
-fn type_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
+pub(crate) fn type_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
     (
         one_of(|c: u8| c.is_ascii_uppercase()),
         take_while(0.., |c: u8| c.is_ascii_alphanumeric()),
@@ -193,7 +193,9 @@ fn varlink_type<'a>(input: &mut &'a [u8]) -> ModalResult<Type<'a>, InputError<&'
 ///   first segment      = [A-Za-z][A-Za-z0-9-]*
 ///   subsequent segment = "." [A-Za-z0-9][A-Za-z0-9-]*
 ///   name               = first_segment subsequent_segment+
-fn interface_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
+pub(crate) fn interface_name<'a>(
+    input: &mut &'a [u8],
+) -> ModalResult<&'a str, InputError<&'a [u8]>> {
     (
         // First segment.
         (

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -29,6 +29,10 @@ syn = { version = "2.0", default-features = false, features = [
     "proc-macro",
     "extra-traits"
 ] }
+# The Varlink grammar, so the names the derives emit are checked by running the same parser that
+# reads them back. `parse` (hence winnow) is always on: this is a proc-macro crate, so the dep is
+# built for the host and never reaches a user's binary.
+zlink-idl = { path = "../zlink-idl", version = "=0.7.0", features = ["parse"] }
 
 [dev-dependencies]
 zlink = { path = "../zlink", default-features = false, features = [

--- a/zlink-macros/src/introspect/custom_type.rs
+++ b/zlink-macros/src/introspect/custom_type.rs
@@ -21,11 +21,33 @@ pub(crate) fn derive_custom_type(input: proc_macro::TokenStream) -> proc_macro::
 
 fn derive_custom_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
     let name = &input.ident;
+    // Not `naming::resolve`: a container has no `rename_all` of its own to apply to itself, only
+    // one it hands down to its fields. The name still has to be one Varlink can say.
     let name_str = match naming::parse_rename(&input.attrs)? {
-        Some(lit) => lit.value(),
-        None => naming::unraw(name),
+        Some(lit) => {
+            let name_str = lit.value();
+            naming::validate(
+                &name_str,
+                naming::Grammar::Type,
+                "type name",
+                naming::NameSource::Rename(&lit),
+            )?;
+
+            name_str
+        }
+        None => {
+            let name_str = naming::unraw(name);
+            naming::validate(
+                &name_str,
+                naming::Grammar::Type,
+                "type name",
+                naming::NameSource::Ident(name),
+            )?;
+
+            name_str
+        }
     };
-    let rename_all = naming::parse_rename_all(&input.attrs)?;
+    let rename_all = naming::parse_rename_all(&input.attrs, naming::Grammar::Field)?;
     let generics = &input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let crate_path = utils::parse_crate_path(&input.attrs)?;

--- a/zlink-macros/src/introspect/reply_error.rs
+++ b/zlink-macros/src/introspect/reply_error.rs
@@ -27,7 +27,7 @@ fn derive_reply_error_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
         "`#[zlink(rename)]` has no effect on the `ReplyError` derive: error names are qualified \
          by `#[zlink(interface)]`. Rename individual variants instead.",
     )?;
-    let rename_all = naming::parse_rename_all(&input.attrs)?;
+    let rename_all = naming::parse_rename_all(&input.attrs, naming::Grammar::Type)?;
 
     let expanded = match &input.data {
         Data::Enum(data_enum) => {
@@ -66,12 +66,12 @@ fn generate_error_definitions(
     let mut error_variants = Vec::new();
 
     for variant in &data_enum.variants {
-        let variant_name = naming::variant_name(&variant.attrs, &variant.ident, rename_all)?;
+        let variant_name = naming::error_name(&variant.attrs, &variant.ident, rename_all)?;
         // The variant's own `rename_all` governs its fields, kept separate from the enum-level
         // rule above, which governs variant names instead. Parsed unconditionally (even for unit
         // variants, which have no fields to apply it to) so a bogus value is always rejected,
         // matching the wire derive's `generate_serialize_variant_arm`.
-        let field_rename_all = naming::parse_rename_all(&variant.attrs)?;
+        let field_rename_all = naming::parse_rename_all(&variant.attrs, naming::Grammar::Field)?;
 
         match &variant.fields {
             Fields::Unit => {

--- a/zlink-macros/src/introspect/shared.rs
+++ b/zlink-macros/src/introspect/shared.rs
@@ -95,7 +95,7 @@ pub(super) fn generate_enum_variant_definitions(
         match &variant.fields {
             Fields::Unit => {
                 let variant_name =
-                    naming::variant_name(&variant.attrs, &variant.ident, rename_all)?;
+                    naming::enum_variant_name(&variant.attrs, &variant.ident, rename_all)?;
                 let comments = utils::extract_doc_comments(&variant.attrs);
                 let comment_objects = generate_comment_objects(&comments, crate_path);
                 let variant_ref = quote! {

--- a/zlink-macros/src/introspect/type.rs
+++ b/zlink-macros/src/introspect/type.rs
@@ -29,7 +29,7 @@ fn derive_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
         "`#[zlink(rename)]` has no effect on the `Type` derive, which generates an anonymous \
          object type. Derive `CustomType` instead if the type needs a name in the IDL.",
     )?;
-    let rename_all = naming::parse_rename_all(&input.attrs)?;
+    let rename_all = naming::parse_rename_all(&input.attrs, naming::Grammar::Field)?;
 
     let expanded = match &input.data {
         Data::Struct(data_struct) => {

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -372,8 +372,10 @@ pub fn derive_introspect_custom_type(input: proc_macro::TokenStream) -> proc_mac
 /// ```rust
 /// use zlink::{ReplyError, introspect};
 ///
+/// // `UPPERCASE`, not `SCREAMING_SNAKE_CASE`: an error name has no place for underscores
+/// // (`[A-Z][A-Za-z0-9]*`), so the screaming-snake form would not be expressible in Varlink.
 /// #[derive(ReplyError, introspect::ReplyError)]
-/// #[zlink(interface = "org.example.Test", rename_all = "SCREAMING_SNAKE_CASE")]
+/// #[zlink(interface = "org.example.Test", rename_all = "UPPERCASE")]
 /// enum ServiceError {
 ///     NotFound,
 /// }

--- a/zlink-macros/src/naming.rs
+++ b/zlink-macros/src/naming.rs
@@ -2,6 +2,97 @@ use syn::{Attribute, Error, Ident, LitStr};
 
 use crate::utils::skip_unknown_meta;
 
+/// The grammar a resolved Varlink name must follow.
+///
+/// Varlink names fields, parameters and enum variants one way, and types, methods and errors
+/// another, so every name falls under one of these two rules.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum Grammar {
+    /// The field-name rule, `[A-Za-z][A-Za-z0-9_]*`. Fields, parameters and enum variants.
+    Field,
+    /// The type-name rule, `[A-Z][A-Za-z0-9]*`. Types, methods and errors.
+    Type,
+}
+
+/// Where a resolved name came from, which decides what a rejection points at and suggests.
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum NameSource<'a> {
+    /// An explicit `#[zlink(rename = "...")]`.
+    Rename(&'a LitStr),
+    /// A Rust ident, possibly with a case convention applied to it.
+    Ident(&'a Ident),
+}
+
+/// Reject `name` if Varlink cannot express it under `grammar`, describing it as `what`.
+///
+/// Only ever called on a *resolved* name: unrawing and `rename`/`rename_all` decide what a thing is
+/// called, and this decides whether that answer is sayable. Checking any earlier would reject
+/// perfectly good Rust, e.g. `r#type`, which resolves to the valid `type`.
+pub(crate) fn validate(
+    name: &str,
+    grammar: Grammar,
+    what: &str,
+    source: NameSource<'_>,
+) -> Result<(), Error> {
+    if !grammar.accepts(name) {
+        // Pointing at the rename literal is precise enough on its own; suggesting a rename to
+        // someone who just wrote one would only be noise.
+        let hint = match source {
+            NameSource::Rename(_) => "",
+            NameSource::Ident(_) => ", so name it explicitly with `#[zlink(rename = \"...\")]`",
+        };
+        let msg = format!(
+            "`{name}` is not a valid Varlink {what}: it must match `{}`{hint}",
+            grammar.pattern(),
+        );
+
+        return Err(match source {
+            NameSource::Rename(lit) => Error::new_spanned(lit, msg),
+            NameSource::Ident(ident) => Error::new_spanned(ident, msg),
+        });
+    }
+
+    Ok(())
+}
+
+/// Reject an interface name Varlink cannot express, reporting against `lit`'s span.
+///
+/// Kept apart from [`validate`]: an interface name is always a literal the user wrote out (never a
+/// resolved ident), and its grammar is neither the field nor the type rule but reverse-domain
+/// notation.
+pub(crate) fn validate_interface(lit: &LitStr) -> Result<(), Error> {
+    let name = lit.value();
+    if !zlink_idl::is_valid_interface_name(&name) {
+        return Err(Error::new_spanned(
+            lit,
+            format!(
+                "`{name}` is not a valid Varlink interface name: it must be in reverse-domain \
+                 notation, e.g. `org.example.Foo`"
+            ),
+        ));
+    }
+
+    Ok(())
+}
+
+impl Grammar {
+    /// Whether Varlink can express `name` under this rule.
+    fn accepts(self, name: &str) -> bool {
+        match self {
+            Self::Field => zlink_idl::is_valid_field_name(name),
+            Self::Type => zlink_idl::is_valid_type_name(name),
+        }
+    }
+
+    /// The rule as it reads in the Varlink specification.
+    fn pattern(self) -> &'static str {
+        match self {
+            Self::Field => "[A-Za-z][A-Za-z0-9_]*",
+            Self::Type => "[A-Z][A-Za-z0-9]*",
+        }
+    }
+}
+
 /// The case convention requested by `#[zlink(rename_all = "...")]`.
 ///
 /// The variants mirror serde's rename rules so the semantics are familiar. Note that the field and
@@ -80,6 +171,21 @@ impl RenameAll {
         }
     }
 
+    /// Whether this convention could ever produce a name valid under `grammar`.
+    ///
+    /// Some conventions can satisfy a grammar for no input at all: `snake_case`, say, always
+    /// lowercases the first character, which the type-name rule (uppercase-first) rejects for
+    /// every possible name. Offering such a pairing is a footgun, so it is refused up front rather
+    /// than left for the per-name check to reject one produced name at a time.
+    ///
+    /// Probing a single-word sample rather than re-encoding that reasoning keeps the parser the one
+    /// authority on the grammar: a word carries the first-character and character-set rules without
+    /// the separators that only longer names introduce, so if a convention cannot make even this
+    /// fit, no name ever will.
+    fn can_produce(self, grammar: Grammar) -> bool {
+        grammar.accepts(&self.apply_to_variant("Word"))
+    }
+
     fn parse(lit: &LitStr) -> Result<Self, Error> {
         let rule = match lit.value().as_str() {
             "lowercase" => Self::Lower,
@@ -113,18 +219,55 @@ pub(crate) fn field_name(
     ident: &Ident,
     rename_all: Option<RenameAll>,
 ) -> Result<String, Error> {
-    resolve(attrs, ident, rename_all, RenameAll::apply_to_field)
+    resolve(
+        attrs,
+        ident,
+        rename_all,
+        RenameAll::apply_to_field,
+        Grammar::Field,
+        "field name",
+    )
 }
 
 /// The name an enum variant should carry in the IDL and on the wire.
 ///
 /// `#[zlink(rename)]` wins over an inherited `rename_all`, which wins over the Rust ident.
-pub(crate) fn variant_name(
+#[cfg(feature = "introspection")]
+pub(crate) fn enum_variant_name(
     attrs: &[Attribute],
     ident: &Ident,
     rename_all: Option<RenameAll>,
 ) -> Result<String, Error> {
-    resolve(attrs, ident, rename_all, RenameAll::apply_to_variant)
+    resolve(
+        attrs,
+        ident,
+        rename_all,
+        RenameAll::apply_to_variant,
+        Grammar::Field,
+        "enum variant name",
+    )
+}
+
+/// The name an error variant should carry in the IDL and on the wire.
+///
+/// `#[zlink(rename)]` wins over an inherited `rename_all`, which wins over the Rust ident.
+///
+/// Kept apart from [`enum_variant_name`] because the two obey different grammars: an error is named
+/// like a type, an enum variant like a field. Sharing one function would leave the choice of rule
+/// to whichever caller happened to reach for it.
+pub(crate) fn error_name(
+    attrs: &[Attribute],
+    ident: &Ident,
+    rename_all: Option<RenameAll>,
+) -> Result<String, Error> {
+    resolve(
+        attrs,
+        ident,
+        rename_all,
+        RenameAll::apply_to_variant,
+        Grammar::Type,
+        "error name",
+    )
 }
 
 /// Reject a container-level `#[zlink(rename)]` with `msg`, for derives where it means nothing.
@@ -137,12 +280,34 @@ pub(crate) fn reject_container_rename(attrs: &[Attribute], msg: &str) -> Result<
     }
 }
 
-/// The container's `#[zlink(rename_all = "...")]`, if any.
-pub(crate) fn parse_rename_all(attrs: &[Attribute]) -> Result<Option<RenameAll>, Error> {
-    match parse_zlink_lit_str(attrs, "rename_all")? {
-        Some(lit) => RenameAll::parse(&lit).map(Some),
-        None => Ok(None),
+/// The container's `#[zlink(rename_all = "...")]`, if any, checked against `grammar`.
+///
+/// A convention that could never produce a name valid under `grammar` -- `snake_case` where a type
+/// name is wanted, say -- is rejected here, against the attribute's own span, rather than left for
+/// the per-name check to reject one produced name at a time.
+pub(crate) fn parse_rename_all(
+    attrs: &[Attribute],
+    grammar: Grammar,
+) -> Result<Option<RenameAll>, Error> {
+    let Some(lit) = parse_zlink_lit_str(attrs, "rename_all")? else {
+        return Ok(None);
+    };
+
+    let rule = RenameAll::parse(&lit)?;
+    if !rule.can_produce(grammar) {
+        return Err(Error::new_spanned(
+            &lit,
+            format!(
+                "`{}` can never produce a name matching the Varlink grammar `{}`, so it cannot \
+                 apply here. Drop `rename_all`, use a convention that fits (e.g. `UPPERCASE` or \
+                 `PascalCase`), or name items individually with `#[zlink(rename = \"...\")]`",
+                lit.value(),
+                grammar.pattern(),
+            ),
+        ));
     }
+
+    Ok(Some(rule))
 }
 
 /// The item's `#[zlink(rename = "...")]`, if any.
@@ -168,20 +333,29 @@ fn resolve<F>(
     ident: &Ident,
     rename_all: Option<RenameAll>,
     apply: F,
+    grammar: Grammar,
+    what: &str,
 ) -> Result<String, Error>
 where
     F: FnOnce(RenameAll, &str) -> String,
 {
+    // An explicit rename is a name the user wrote out, so it is taken verbatim -- mangling it would
+    // defeat the point of the attribute -- but it still has to be a name Varlink can say.
     if let Some(lit) = parse_rename(attrs)? {
-        return Ok(lit.value());
+        let name = lit.value();
+        validate(&name, grammar, what, NameSource::Rename(&lit))?;
+
+        return Ok(name);
     }
 
-    let ident = unraw(ident);
+    let unrawed = unraw(ident);
+    let name = match rename_all {
+        Some(rule) => apply(rule, &unrawed),
+        None => unrawed,
+    };
+    validate(&name, grammar, what, NameSource::Ident(ident))?;
 
-    Ok(match rename_all {
-        Some(rule) => apply(rule, &ident),
-        None => ident,
-    })
+    Ok(name)
 }
 
 /// The string value of `#[zlink(<key> = "...")]`, if present.
@@ -315,13 +489,18 @@ mod tests {
         let attrs: Vec<Attribute> =
             vec![parse_quote!(#[zlink(crate = "crate", rename_all = "camelCase")])];
 
-        assert_eq!(parse_rename_all(&attrs).unwrap(), Some(RenameAll::Camel));
+        assert_eq!(
+            parse_rename_all(&attrs, Grammar::Field).unwrap(),
+            Some(RenameAll::Camel)
+        );
     }
 
     #[test]
     fn unknown_rename_all_value_rejected() {
         let attrs: Vec<Attribute> = vec![parse_quote!(#[zlink(rename_all = "bogus")])];
-        let err = parse_rename_all(&attrs).unwrap_err().to_string();
+        let err = parse_rename_all(&attrs, Grammar::Field)
+            .unwrap_err()
+            .to_string();
 
         assert!(
             err.contains("bogus"),
@@ -341,5 +520,145 @@ mod tests {
             .to_string();
 
         assert_eq!(err, "nope");
+    }
+
+    /// A raw-ident param unraws to a valid field name and must survive validation: this pins the
+    /// order (unraw, then validate). Validating `r#type` verbatim would reject legitimate Rust.
+    #[test]
+    fn raw_ident_field_resolves_then_validates() {
+        let attrs: Vec<Attribute> = vec![];
+        let ident: Ident = parse_quote!(r#type);
+
+        assert_eq!(field_name(&attrs, &ident, None).unwrap(), "type");
+    }
+
+    /// The error-name counterpart: `r#Fn` unraws to the valid error name `Fn`.
+    #[test]
+    fn raw_ident_error_variant_resolves_then_validates() {
+        let attrs: Vec<Attribute> = vec![];
+        let ident: Ident = parse_quote!(r#Fn);
+
+        assert_eq!(error_name(&attrs, &ident, None).unwrap(), "Fn");
+    }
+
+    /// Enum variants follow field rules, which admit a lowercase first letter.
+    #[cfg(feature = "introspection")]
+    #[test]
+    fn enum_variant_lowercase_is_accepted() {
+        let attrs: Vec<Attribute> = vec![];
+        let ident: Ident = parse_quote!(Active);
+
+        assert_eq!(
+            enum_variant_name(&attrs, &ident, Some(RenameAll::Lower)).unwrap(),
+            "active"
+        );
+    }
+
+    /// The very same lowercase name is rejected as an error name, which follows type rules.
+    #[test]
+    fn error_name_lowercase_is_rejected() {
+        let attrs: Vec<Attribute> = vec![];
+        let ident: Ident = parse_quote!(Active);
+        let err = error_name(&attrs, &ident, Some(RenameAll::Lower))
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("`active`"), "must name the bad name: {err}");
+        assert!(err.contains("error name"), "must name the context: {err}");
+    }
+
+    /// A bad `rename` is reported against its own value, not the ident it overrode, and offers no
+    /// "use rename" hint to someone who already wrote one. This is how the error lands on the
+    /// literal's span.
+    #[test]
+    fn invalid_rename_reports_the_literal_not_the_ident() {
+        let attrs: Vec<Attribute> = vec![parse_quote!(#[zlink(rename = "not valid!")])];
+        let ident: Ident = parse_quote!(good_field);
+        let err = field_name(&attrs, &ident, None).unwrap_err().to_string();
+
+        assert!(err.contains("`not valid!`"), "must quote the rename: {err}");
+        assert!(
+            !err.contains("good_field"),
+            "must not blame the ident: {err}"
+        );
+        assert!(
+            !err.contains("`#[zlink(rename"),
+            "no hint on a rename: {err}"
+        );
+    }
+
+    /// A bad ident, by contrast, is pointed at the `rename` escape hatch.
+    #[test]
+    fn invalid_ident_suggests_rename() {
+        let attrs: Vec<Attribute> = vec![];
+        let ident: Ident = parse_quote!(_foo);
+        let err = field_name(&attrs, &ident, None).unwrap_err().to_string();
+
+        assert!(err.contains("`_foo`"), "must name the bad ident: {err}");
+        assert!(err.contains("rename"), "must offer the escape hatch: {err}");
+    }
+
+    #[test]
+    fn interface_names_validated() {
+        let good: LitStr = parse_quote!("org.example.Foo");
+        assert!(validate_interface(&good).is_ok());
+
+        // A `_` is not allowed in an interface segment (unlike a field name).
+        let bad: LitStr = parse_quote!("org.example.bad_name");
+        let err = validate_interface(&bad).unwrap_err().to_string();
+
+        assert!(
+            err.contains("`org.example.bad_name`"),
+            "must quote it: {err}"
+        );
+        assert!(
+            err.contains("interface name"),
+            "must name the context: {err}"
+        );
+    }
+
+    /// A convention that can sometimes yield a valid type name -- `SCREAMING_SNAKE_CASE` does for a
+    /// single-word variant -- is accepted; the per-name check catches the names that do not fit.
+    #[test]
+    fn rename_all_that_can_sometimes_fit_the_type_grammar_is_accepted() {
+        let attrs: Vec<Attribute> =
+            vec![parse_quote!(#[zlink(rename_all = "SCREAMING_SNAKE_CASE")])];
+
+        assert_eq!(
+            parse_rename_all(&attrs, Grammar::Type).unwrap(),
+            Some(RenameAll::ScreamingSnake)
+        );
+    }
+
+    /// A convention that can never yield a valid type name -- `snake_case` always lowercases the
+    /// first letter -- is refused up front, against the attribute's own span.
+    #[test]
+    fn rename_all_that_never_fits_the_type_grammar_is_rejected() {
+        let attrs: Vec<Attribute> = vec![parse_quote!(#[zlink(rename_all = "snake_case")])];
+        let err = parse_rename_all(&attrs, Grammar::Type)
+            .unwrap_err()
+            .to_string();
+
+        assert!(
+            err.contains("`snake_case`"),
+            "must name the convention: {err}"
+        );
+        assert!(
+            err.contains("[A-Z][A-Za-z0-9]*"),
+            "must name the grammar it cannot meet: {err}"
+        );
+    }
+
+    /// The field grammar admits a lowercase first letter, so every convention can fit it -- even
+    /// the ones the type grammar refuses.
+    #[test]
+    fn every_rename_all_fits_the_field_grammar() {
+        for value in VALID_RENAME_ALL {
+            let attr: Attribute = parse_quote!(#[zlink(rename_all = #value)]);
+            assert!(
+                parse_rename_all(&[attr], Grammar::Field).unwrap().is_some(),
+                "`{value}` should be accepted for a field name"
+            );
+        }
     }
 }

--- a/zlink-macros/src/proxy.rs
+++ b/zlink-macros/src/proxy.rs
@@ -152,6 +152,7 @@ fn parse_proxy_attributes(
     let parser = syn::meta::parser(|meta| {
         if meta.path.is_ident("interface") {
             let value: syn::LitStr = meta.value()?.parse()?;
+            crate::naming::validate_interface(&value)?;
             interface_name = Some(value.value());
         } else if meta.path.is_ident("crate") {
             let value: syn::LitStr = meta.value()?.parse()?;

--- a/zlink-macros/src/reply_error.rs
+++ b/zlink-macros/src/reply_error.rs
@@ -68,6 +68,7 @@ fn parse_interface_from_attrs(attrs: &[syn::Attribute]) -> Result<String, Error>
             if meta.path.is_ident("interface") {
                 let value = meta.value()?;
                 let lit_str: syn::LitStr = value.parse()?;
+                crate::naming::validate_interface(&lit_str)?;
                 interface_result = Some(lit_str.value());
             } else {
                 // Skip unknown attributes by consuming their values.
@@ -130,7 +131,7 @@ fn generate_serialize_impl(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let has_lifetimes = !generics.lifetimes().collect::<Vec<_>>().is_empty();
 
-    let rename_all = naming::parse_rename_all(input_attrs)?;
+    let rename_all = naming::parse_rename_all(input_attrs, naming::Grammar::Type)?;
     // Generate match arms for each variant (empty for empty enums).
     let variant_arms = data_enum
         .variants
@@ -168,9 +169,9 @@ fn generate_serialize_variant_arm(
     rename_all: Option<RenameAll>,
 ) -> Result<TokenStream2, Error> {
     let variant_name = &variant.ident;
-    let resolved = naming::variant_name(&variant.attrs, variant_name, rename_all)?;
+    let resolved = naming::error_name(&variant.attrs, variant_name, rename_all)?;
     let qualified_name = format!("{interface}.{resolved}");
-    let field_rename_all = naming::parse_rename_all(&variant.attrs)?;
+    let field_rename_all = naming::parse_rename_all(&variant.attrs, naming::Grammar::Field)?;
 
     match &variant.fields {
         // Unit variant - serialize as tagged enum with just error field.
@@ -259,7 +260,7 @@ fn generate_deserialize_with_derive(
         .iter()
         .map(|variant| match &variant.fields {
             Fields::Named(fields) => {
-                let rename_all = naming::parse_rename_all(&variant.attrs)?;
+                let rename_all = naming::parse_rename_all(&variant.attrs, naming::Grammar::Field)?;
                 FieldInfo::extract(fields, rename_all).map(Some)
             }
             _ => Ok(None),
@@ -269,12 +270,12 @@ fn generate_deserialize_with_derive(
     // Clone and modify the enum to add serde attributes.
     let mut modified_enum = data_enum.clone();
 
-    let rename_all = naming::parse_rename_all(&input.attrs)?;
+    let rename_all = naming::parse_rename_all(&input.attrs, naming::Grammar::Type)?;
 
     // Now modify the variants.
     for (i, variant) in modified_enum.variants.iter_mut().enumerate() {
         let field_info = &variant_field_info[i];
-        let resolved = naming::variant_name(&variant.attrs, &variant.ident, rename_all)?;
+        let resolved = naming::error_name(&variant.attrs, &variant.ident, rename_all)?;
         let qualified_name = format!("{interface}.{resolved}");
 
         // Strip our helper attributes before they reach the generated helper enum, which only

--- a/zlink-macros/src/service/attrs.rs
+++ b/zlink-macros/src/service/attrs.rs
@@ -51,6 +51,7 @@ impl ServiceAttrs {
                     custom_types = types.into_iter().collect();
                 } else if meta.path.is_ident("interface") {
                     let value: syn::LitStr = meta.value()?.parse()?;
+                    crate::naming::validate_interface(&value)?;
                     interface = Some(value.value());
                 } else if meta.path.is_ident("vendor") {
                     let value: syn::Expr = meta.value()?.parse()?;

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -2,9 +2,11 @@
 
 use proc_macro2::TokenStream;
 use syn::{
-    Attribute, Error, Expr, GenericArgument, Ident, ImplItemFn, Lit, Meta, PathArguments,
+    Attribute, Error, Expr, GenericArgument, Ident, ImplItemFn, Lit, LitStr, Meta, PathArguments,
     ReturnType, Type, parse::Parse,
 };
+
+use crate::naming::{self, Grammar, NameSource};
 
 use super::types::ParamInfo;
 
@@ -67,9 +69,15 @@ impl MethodInfo {
 
         // Determine the Varlink method name. The ident is unraw'd first: `r#` is Rust syntax, not
         // part of the name, and it would otherwise reach `format_ident!` as `R#type`.
-        let varlink_name = method_attrs
-            .rename
-            .unwrap_or_else(|| snake_case_to_pascal_case(&crate::naming::unraw(&name)));
+        let (varlink_name, name_source) = match &method_attrs.rename {
+            Some(lit) => (lit.value(), NameSource::Rename(lit)),
+            None => (
+                snake_case_to_pascal_case(&naming::unraw(&name)),
+                NameSource::Ident(&name),
+            ),
+        };
+        // A method is named like a type, so it must be expressible as one.
+        naming::validate(&varlink_name, Grammar::Type, "method name", name_source)?;
 
         // Check if this is a streaming method.
         let is_streaming = method_attrs.is_streaming;
@@ -114,20 +122,18 @@ impl MethodInfo {
             }
         }
 
-        // Underscore-prefixed names are not valid Varlink field names, so serialized parameters
-        // (the ones that end up on the wire and in the IDL) must be given an explicit wire name.
+        // Serialized parameters (the ones that end up on the wire and in the IDL) must carry a
+        // name Varlink can express. The `_`-prefixed case falls out of this: `_foo` fails the
+        // field grammar at its first character.
         for param in params
             .iter()
             .filter(|p| !p.is_connection && !p.is_more && !p.is_fds)
         {
-            if param.serialized_name.is_none() && crate::naming::unraw(&param.name).starts_with('_')
-            {
-                return Err(Error::new_spanned(
-                    &param.name,
-                    "parameter names starting with `_` are not valid Varlink field names; \
-                     specify the wire name with `#[zlink(rename = \"...\")]`",
-                ));
-            }
+            let (wire_name, source) = match &param.serialized_name {
+                Some(lit) => (lit.value(), NameSource::Rename(lit)),
+                None => (naming::unraw(&param.name), NameSource::Ident(&param.name)),
+            };
+            naming::validate(&wire_name, Grammar::Field, "parameter name", source)?;
         }
 
         // Validate FD attributes.
@@ -357,7 +363,7 @@ struct MethodAttrs {
     /// Custom types scoped to this method's interface.
     custom_types: Vec<Type>,
     /// Custom method name.
-    rename: Option<String>,
+    rename: Option<LitStr>,
     /// Whether this method returns a stream of replies.
     is_streaming: bool,
     /// Whether this method returns file descriptors.
@@ -390,10 +396,11 @@ impl MethodAttrs {
             let parser = syn::meta::parser(|meta| {
                 if meta.path.is_ident("interface") {
                     let value: syn::LitStr = meta.value()?.parse()?;
+                    naming::validate_interface(&value)?;
                     result.interface = Some(value.value());
                 } else if meta.path.is_ident("rename") {
                     let value: syn::LitStr = meta.value()?.parse()?;
-                    result.rename = Some(value.value());
+                    result.rename = Some(value);
                 } else if meta.path.is_ident("types") {
                     meta.input.parse::<syn::Token![=]>()?;
                     let content;
@@ -432,7 +439,7 @@ impl MethodAttrs {
 #[derive(Default)]
 struct ParamAttrs {
     /// Custom serialized name for the parameter.
-    rename: Option<String>,
+    rename: Option<LitStr>,
     /// Whether this parameter should receive the connection.
     is_connection: bool,
     /// Whether this parameter receives file descriptors.
@@ -464,7 +471,7 @@ fn extract_param_attrs(attrs: &[Attribute]) -> ParamAttrs {
                     if let Expr::Lit(expr_lit) = &nv.value
                         && let Lit::Str(lit_str) = &expr_lit.lit
                     {
-                        result.rename = Some(lit_str.value());
+                        result.rename = Some(lit_str.clone());
                     }
                 }
                 Meta::Path(path) if path.is_ident("connection") => {
@@ -680,8 +687,9 @@ mod tests {
     use super::*;
     use syn::{FnArg, parse_quote};
 
-    /// The `_` check must judge the same string `ParamInfo::wire_name` does, or a raw ident slips
-    /// past it and reaches the IDL unraw'd as `_foo`.
+    /// Validation must judge the same string `ParamInfo::wire_name` does, or a raw ident slips past
+    /// it and reaches the IDL unraw'd as `_foo`. Both spellings resolve to `_foo`, which the field
+    /// grammar rejects at its first character.
     #[test]
     fn underscore_prefixed_params_rejected_raw_or_not() {
         for src in ["_foo: String", "r#_foo: String"] {
@@ -695,9 +703,14 @@ mod tests {
                 panic!("`{src}` must be rejected: it reaches the IDL as `_foo`");
             };
 
+            let err = err.to_string();
             assert!(
-                err.to_string().contains("not valid Varlink field names"),
-                "unexpected error for `{src}`: {err}"
+                err.contains("`_foo`") && err.contains("parameter name"),
+                "message must name the offending parameter: {err}"
+            );
+            assert!(
+                err.contains("rename"),
+                "message must point at the `rename` escape hatch: {err}"
             );
         }
     }

--- a/zlink-macros/src/service/types.rs
+++ b/zlink-macros/src/service/types.rs
@@ -1,8 +1,6 @@
 //! Types used in service macro processing.
 
-use std::borrow::Cow;
-
-use syn::{FnArg, Ident, Pat, Type};
+use syn::{FnArg, Ident, LitStr, Pat, Type};
 
 /// Information about a method parameter.
 #[derive(Clone)]
@@ -11,8 +9,9 @@ pub(super) struct ParamInfo {
     pub name: Ident,
     /// The parameter type.
     pub ty: Type,
-    /// The serialized name (from `#[zlink(rename = "...")]`).
-    pub serialized_name: Option<String>,
+    /// The serialized name (from `#[zlink(rename = "...")]`). The literal is kept, not just its
+    /// value, so a bad wire name can be reported against the span the user wrote it at.
+    pub serialized_name: Option<LitStr>,
     /// Whether this parameter is marked with `#[zlink(connection)]`.
     pub is_connection: bool,
     /// Whether this parameter is marked with `#[zlink(fds)]`.
@@ -28,10 +27,10 @@ impl ParamInfo {
     /// parameter name otherwise. Unrawing is what keeps the IDL and the wire in agreement: serde
     /// unraws the name it deserializes, so an `r#`-prefixed IDL name would advertise a parameter
     /// the method could never accept.
-    pub(super) fn wire_name(&self) -> Cow<'_, str> {
+    pub(super) fn wire_name(&self) -> String {
         match &self.serialized_name {
-            Some(name) => Cow::Borrowed(name),
-            None => Cow::Owned(crate::naming::unraw(&self.name)),
+            Some(name) => name.value(),
+            None => crate::naming::unraw(&self.name),
         }
     }
 

--- a/zlink-macros/tests/introspect-rename.rs
+++ b/zlink-macros/tests/introspect-rename.rs
@@ -28,16 +28,6 @@ fn explicit_rename_overrides_rename_all() {
 }
 
 #[test]
-fn kebab_case_field_names_do_not_break_statics() {
-    let idl::Type::Object(fields) = Kebabed::TYPE else {
-        panic!("expected an object type");
-    };
-    let fields: Vec<_> = fields.iter().collect();
-
-    assert_eq!(fields[0].name(), "user-name");
-}
-
-#[test]
 fn enum_variant_rename_all() {
     let idl::Type::Enum(variants) = Status::TYPE else {
         panic!("expected an enum type");
@@ -161,13 +151,6 @@ struct Overridden {
     #[zlink(rename = "ID")]
     user_id: String,
     group_name: String,
-}
-
-#[derive(Type)]
-#[allow(unused)]
-#[zlink(rename_all = "kebab-case")]
-struct Kebabed {
-    user_name: String,
 }
 
 #[derive(Type)]

--- a/zlink-macros/tests/reply-error-rename.rs
+++ b/zlink-macros/tests/reply-error-rename.rs
@@ -9,9 +9,13 @@ use zlink::{ReplyError, introspect};
 // `zlink::ReplyError` (serde) and `zlink::introspect::ReplyError` (IDL) share a name, so import the
 // containing module for the latter rather than aliasing, and reach the trait's associated const
 // through a qualified path below.
+// `UPPERCASE` rather than `SCREAMING_SNAKE_CASE`: an error name follows the type-name grammar
+// (`[A-Z][A-Za-z0-9]*`), which admits no underscores, so the screaming-snake form would not be a
+// name Varlink can express. `UPPERCASE` still visibly transforms the variant, exercising the same
+// `rename_all` path.
 #[derive(Debug, PartialEq, ReplyError, introspect::ReplyError)]
 #[zlink(interface = "org.example.Test")]
-#[zlink(rename_all = "SCREAMING_SNAKE_CASE")]
+#[zlink(rename_all = "UPPERCASE")]
 enum RenamedError {
     NotFound,
     #[zlink(rename = "TimedOut")]
@@ -29,7 +33,7 @@ enum RenamedError {
 fn variant_rename_all_reaches_the_wire() {
     let json = serde_json::to_value(RenamedError::NotFound).unwrap();
 
-    assert_eq!(json, json!({"error": "org.example.Test.NOT_FOUND"}));
+    assert_eq!(json, json!({"error": "org.example.Test.NOTFOUND"}));
 }
 
 #[test]
@@ -54,7 +58,7 @@ fn variant_rename_all_applies_to_that_variants_fields() {
     assert_eq!(
         json,
         json!({
-            "error": "org.example.Test.BAD_REQUEST",
+            "error": "org.example.Test.BADREQUEST",
             "parameters": {"requestId": 7},
         }),
     );
@@ -71,7 +75,7 @@ fn renamed_variants_round_trip() {
     assert_eq!(back, error);
 
     // `BadRequest` covers the `rename_all`-derived path (variant name from the enum-level
-    // `SCREAMING_SNAKE_CASE` rule, field name from the variant-level `camelCase` rule).
+    // `UPPERCASE` rule, field name from the variant-level `camelCase` rule).
     let error = RenamedError::BadRequest { request_id: 7 };
     let json = serde_json::to_string(&error).unwrap();
     let back: RenamedError = serde_json::from_str(&json).unwrap();
@@ -85,9 +89,9 @@ fn idl_error_names_match_the_wire() {
     // wire name is the same string qualified by the interface.
     let variants = <RenamedError as introspect::ReplyError>::VARIANTS;
 
-    assert_eq!(variants[0].name(), "NOT_FOUND");
+    assert_eq!(variants[0].name(), "NOTFOUND");
     assert_eq!(variants[1].name(), "TimedOut");
-    assert_eq!(variants[2].name(), "BAD_REQUEST");
+    assert_eq!(variants[2].name(), "BADREQUEST");
 }
 
 #[test]
@@ -185,21 +189,24 @@ fn idl_and_wire_agree_on_raw_ident_variant_and_field_names() {
     assert_eq!(fields[0].name(), "type");
 }
 
-// A lowercase variant needs an `#[allow]` on both this enum and the helper the wire derive nests
-// inside `Deserialize::deserialize`, which cannot inherit this one. Dropping the derive's own
-// `#[allow(non_camel_case_types)]` fails this file to compile, pointing here.
+// A non-camel-case variant ident needs an `#[allow]` on both this enum and the helper the wire
+// derive nests inside `Deserialize::deserialize`, which cannot inherit this one. Dropping the
+// derive's own `#[allow(non_camel_case_types)]` fails this file to compile, pointing here.
 //
-// Only the wire derive is applied: `lowercase` is not a valid Varlink error name (those are
-// PascalCase, as `RawIdentVariantError` above notes), so there is no IDL worth asserting on.
+// The Rust ident stays `lowercase` (that is what trips the lint), but the *wire* name is renamed to
+// the valid Varlink error name `Lowercase`: an error name follows the type-name grammar and
+// `lowercase` is not expressible in it. Only the wire derive is applied, so there is no IDL to
+// assert on.
 #[derive(Debug, PartialEq, ReplyError)]
 #[zlink(interface = "org.example.Probe")]
 #[allow(non_camel_case_types)]
 enum ProbeError {
+    #[zlink(rename = "Lowercase")]
     lowercase { value: String },
 }
 
 #[test]
-fn lowercase_variant_name_is_allowed_by_the_users_own_allow() {
+fn non_camel_case_variant_ident_is_allowed_by_the_users_own_allow() {
     let error = ProbeError::lowercase {
         value: "x".to_owned(),
     };
@@ -208,7 +215,7 @@ fn lowercase_variant_name_is_allowed_by_the_users_own_allow() {
     assert_eq!(
         json,
         json!({
-            "error": "org.example.Probe.lowercase",
+            "error": "org.example.Probe.Lowercase",
             "parameters": {"value": "x"},
         }),
     );

--- a/zlink-macros/tests/service/streaming_fds.rs
+++ b/zlink-macros/tests/service/streaming_fds.rs
@@ -117,7 +117,7 @@ struct FdReadResult {
 /// A service that streams file descriptors.
 struct StreamingFdService;
 
-#[zlink::service(interface = "org.example.streaming_fd")]
+#[zlink::service(interface = "org.example.streamingFd")]
 impl StreamingFdService {
     /// Stream FDs with handles, one per name. Each stream item contains a handle and the FD.
     #[zlink(more, return_fds)]
@@ -181,7 +181,7 @@ impl StreamingFdService {
 }
 
 /// Proxy for streaming FD service.
-#[zlink::proxy("org.example.streaming_fd")]
+#[zlink::proxy("org.example.streamingFd")]
 trait StreamingFdProxy {
     #[zlink(more, return_fds)]
     async fn stream_fds(

--- a/zlink/tests/integration_test_custom_type_derive.rs
+++ b/zlink/tests/integration_test_custom_type_derive.rs
@@ -180,10 +180,12 @@ fn single_variant_enum() {
 
 #[test]
 fn type_names_preserved() {
-    // Test that type names are exactly preserved as written
+    // Test that type names are used verbatim, with no case normalisation applied. `HTTPServer`
+    // (rather than the earlier `snake_case_name`) makes the point while staying a valid Varlink
+    // type name: a naive PascalCase normaliser would fold its run of capitals to `HttpServer`.
     #[derive(CustomType)]
-    #[allow(dead_code, non_camel_case_types)]
-    struct snake_case_name {
+    #[allow(dead_code)]
+    struct HTTPServer {
         value: i32,
     }
 
@@ -195,7 +197,7 @@ fn type_names_preserved() {
         VARIANT_THREE,
     }
 
-    assert_eq!(snake_case_name::CUSTOM_TYPE.name(), "snake_case_name");
+    assert_eq!(HTTPServer::CUSTOM_TYPE.name(), "HTTPServer");
     assert_eq!(MixedCaseEnum::CUSTOM_TYPE.name(), "MixedCaseEnum");
 
     if let idl::CustomType::Enum(enm) = MixedCaseEnum::CUSTOM_TYPE {


### PR DESCRIPTION
The derives never checked the names they put into the IDL, so it was easy to write Rust that
compiles clean yet describes an interface zlink's own parser cannot read. #290, #292 and #293 were
each one instance of this, found by hand; this closes the general case (#296).

Three headline cases, none involving raw identifiers:

```rust
#[zlink(rename = "not a valid name!")] Bad { .. }   // copied verbatim, unparseable
#[zlink(rename_all = "SCREAMING_SNAKE_CASE")] enum E { NotFound }  // -> error NOT_FOUND, underscores illegal
enum E { lowercase { .. } }                         // -> error lowercase, must be PascalCase
```

### How it works

The grammar now lives in **one** place: `zlink-idl/src/name.rs` holds the character-class predicates,
and both the winnow parsers *and* the new `is_valid_field_name`/`is_valid_type_name` are built from
them. `zlink-macros` depends on `zlink-idl` (which depends on nothing — no cycle, no winnow) and
validates every **resolved** name through those same predicates. So what the macros accept and what
the parser accepts cannot drift the way the IDL and wire names did in #292.

Field / parameter / enum-variant names follow `[A-Za-z][A-Za-z0-9_]*`; type / method / error names
follow `[A-Z][A-Za-z0-9]*`. Validation runs **after** unrawing and rename resolution, never instead
of it: `r#type` still maps to the valid `type` and keeps compiling. Rejections land on the rename
literal's span when a rename is at fault, else the ident, and point at `#[zlink(rename = "...")]`.
The old ad-hoc `_`-prefix guard on service parameters is gone, subsumed by the general rule.

### Not a breaking change

Rejecting these names breaks no working code — the code was never working, it emitted IDL zlink
could not parse. This only turns a silent bad-IDL into a compile error.

### Commits

1. **🦺 zlink-idl: Expose the name grammar** — the predicates, with the parsers refactored onto them.
2. **🦺 zlink-macros: Validate emitted names against the Varlink grammar** — the enforcement.

Each builds and passes the full suite standalone (479 → 486 tests). Fixtures that were themselves
emitting invalid Varlink (a `SCREAMING_SNAKE_CASE` error enum, a `kebab-case` field, a lowercase
error variant) were adapted to stay valid while still testing their original point — e.g. the #293
`ProbeError` keeps its lint-tripping `lowercase` Rust ident but renames the wire name to
`Lowercase`, and still fails to compile if the generated `Deserialize` helper loses its own
`#[allow(non_camel_case_types)]`.

### Scope

Interface names and proxy (client-side) method/parameter names are a third grammar rule and a
separate concern; both are left as follow-ups.

---

Stacked on #297 (the `zlink-idl` split, which this depends on) — review that first. GitHub will
retarget this to `main` once #297 merges.

Fixes #296.
