### PR TITLE
🏗️ zlink: Make the runtime features additive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,6 +2216,7 @@ dependencies = [
  "test-log",
  "tokio",
  "tracing-subscriber",
+ "zlink-core",
  "zlink-smol",
  "zlink-tokio",
 ]

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ macros:
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tokio::{select, sync::oneshot};
-use zlink::{introspect, proxy, service, unix, ReplyError, Server};
+use zlink::{introspect, proxy, service, tokio::unix, ReplyError, Server};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -286,7 +286,7 @@ responses.
 ```rust,no_run
 use futures_util::{StreamExt, pin_mut};
 use serde::{Deserialize, Serialize};
-use zlink::{proxy, unix, ReplyError};
+use zlink::{proxy, tokio::unix, ReplyError};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -388,14 +388,18 @@ enum ProcessError {
 
 ### Main Features
 
-- `tokio` (default): Enable tokio runtime integration.
-- `smol`: Enable smol runtime integration.
+- `tokio` (default): Enable tokio runtime integration, under the `tokio` module.
+- `smol`: Enable smol runtime integration, under the `smol` module.
 - `server` (default): Enable server-related functionality (Server, Listener, Service).
 - `service` (default): Enable the `#[service]` macro. Implies `server` and `introspection`.
 - `proxy` (default): Enable the `#[proxy]` macro for type-safe client code.
 - `tracing` (default): Enable `tracing`-based logging.
 - `defmt`:  Enable `defmt`-based logging. If both `tracing` and `defmt` is enabled, `tracing` is
   used.
+
+The runtime features are additive: both can be enabled at the same time, with the
+runtime-specific API (currently the `unix` and `notified` modules) of each residing in its own
+module. The rest of the API is runtime-agnostic and available at the crate root.
 
 ### IDL and Introspection
 

--- a/book/src/client.md
+++ b/book/src/client.md
@@ -82,7 +82,7 @@ enum ResolveError {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut conn = zlink::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
+    let mut conn = zlink::tokio::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
 
     // The proxy methods are available directly on the connection.
     match conn.resolve_hostname("systemd.io").await? {

--- a/book/src/connection.md
+++ b/book/src/connection.md
@@ -8,7 +8,7 @@ the zlink API.
 ## Picking an async runtime
 
 zlink is async-first and runtime-agnostic at its core, with ready-made integration for the two
-popular runtimes, selected through cargo features:
+popular runtimes, enabled through cargo features:
 
 ```toml
 # tokio (the default):
@@ -18,9 +18,12 @@ zlink = "0.7"
 zlink = { version = "0.7", default-features = false, features = ["smol", "service", "proxy", "tracing"] }
 ```
 
-Exactly the same API is available with either runtime — the examples in this book use tokio, but
-they work identically with smol. If you enable neither feature, the crate fails to compile with an
-explicit error, since the transport implementations live in the runtime-integration crates.
+The features are additive — you can enable both at once. The bulk of the API is runtime-agnostic
+and lives at the crate root; only the transport-specific parts (the `unix` and `notified` modules)
+are per-runtime, under `zlink::tokio` and `zlink::smol` respectively. The examples in this book use
+tokio, but they work identically with smol — just replace `zlink::tokio` with `zlink::smol`. If you
+enable neither feature, the crate fails to compile with an explicit error, since the transport
+implementations live in the runtime-integration crates.
 
 ## Connecting to a service
 
@@ -30,7 +33,7 @@ directly to the service you're interested in, through the socket it listens on:
 ```rust,no_run
 #[tokio::main]
 async fn main() -> zlink::Result<()> {
-    let mut conn = zlink::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
+    let mut conn = zlink::tokio::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
 
     // ... use the connection ...
     Ok(())
@@ -39,8 +42,9 @@ async fn main() -> zlink::Result<()> {
 
 That's it. No handshake, no authentication round-trips, no name registration: after `connect`
 returns, you can immediately send your first method call. The returned type is
-`zlink::unix::Connection`, an alias for `zlink::Connection<zlink::unix::Stream>` — the `Connection`
-type is generic over its transport (more on that in the [embedded chapter](embedded.html)).
+`zlink::tokio::unix::Connection`, an alias for `zlink::Connection<zlink::tokio::unix::Stream>` —
+the `Connection` type is generic over its transport (more on that in the
+[embedded chapter](embedded.html)).
 
 Note that `connect()` gives you the connection *by value* and all its methods take `&mut self`.
 This is a deliberate — and central — design decision in zlink: a connection is exclusively owned by
@@ -96,7 +100,7 @@ enum ResolveError {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut conn = zlink::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
+    let mut conn = zlink::tokio::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
 
     let call = Call::new(ResolveMethods::ResolveHostname { name: "systemd.io" });
     let (reply, _fds): (reply::Result<ResolveHostnameReply, ResolveError>, _) =
@@ -146,7 +150,7 @@ each owning its own buffer. You can split a connection into its halves and use t
 for instance, one task feeding calls while another consumes streaming replies:
 
 ```rust,noplayground
-# fn example(conn: zlink::unix::Connection) {
+# fn example(conn: zlink::tokio::unix::Connection) {
 let (mut read, mut write) = conn.split();
 // `read.receive_reply(...)` and `write.send_call(...)` can now be driven
 // from separate tasks. `Connection::join(read, write)` puts them back together.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -40,7 +40,8 @@ The zlink project is a Cargo workspace consisting of several crates:
 * **[`zlink-codegen`]**: Generates Rust code from Varlink IDL files.
 
 Since `zlink` re-exports everything you need, this book will only use the `zlink` crate in its
-examples. You pick your async runtime through cargo features: `tokio` (the default) or `smol`.
+examples. You enable your async runtime(s) through the additive cargo features `tokio` (the
+default) and `smol`, with the runtime-specific API of each residing in a module of the same name.
 
 ## Getting help
 

--- a/book/src/introspection.md
+++ b/book/src/introspection.md
@@ -25,7 +25,7 @@ use zlink::varlink_service::Proxy as _;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut conn = zlink::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
+    let mut conn = zlink::tokio::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
 
     // Who are you?
     let info = conn.get_info().await?.map_err(|e| e.to_string())?;

--- a/book/src/pipelining.md
+++ b/book/src/pipelining.md
@@ -41,7 +41,7 @@ trait ResolveProxy {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let mut conn = zlink::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
+    let mut conn = zlink::tokio::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
 
     // Three DNS lookups, one write, one batch of replies.
     let replies = conn
@@ -100,7 +100,7 @@ The same machinery is available on `Connection` directly, no macros involved:
 ```rust,noplayground
 # use zlink::Call;
 # async fn example(
-#     conn: &mut zlink::unix::Connection,
+#     conn: &mut zlink::tokio::unix::Connection,
 #     get_user: Call<u32>, get_project: Call<u32>,
 # ) -> zlink::Result<()> {
 # #[derive(Debug, serde::Deserialize)] struct User;
@@ -135,7 +135,7 @@ with `chain_from_iter` (and `chain_from_iter_with_fds` when file descriptors are
 # #[derive(Debug, Deserialize)] struct User;
 # #[derive(Debug, zlink::ReplyError)]
 # #[zlink(interface = "org.example")] enum ApiError { NotFound }
-# async fn example(conn: &mut zlink::unix::Connection) -> zlink::Result<()> {
+# async fn example(conn: &mut zlink::tokio::unix::Connection) -> zlink::Result<()> {
 let user_ids = [1, 2, 3, 4, 5];
 let replies = conn
     .chain_from_iter::<Methods, _, _>(user_ids.iter().map(|&id| Methods::GetUser { id }))?

--- a/book/src/service.md
+++ b/book/src/service.md
@@ -23,7 +23,7 @@ socket it listens on. Setting up shop is exactly two steps — bind a listener a
 #     }
 # }
 # async fn example(greeter: Greeter) -> Result<(), Box<dyn std::error::Error>> {
-let listener = zlink::unix::bind("/run/user/1000/org.zlink.MyGreeter")?;
+let listener = zlink::tokio::unix::bind("/run/user/1000/org.zlink.MyGreeter")?;
 let server = zlink::Server::new(listener, greeter);
 server.run().await?;
 # Ok(())
@@ -40,7 +40,7 @@ The `service` attribute macro turns an ordinary `impl` block into a full Varlink
 generates the message handling, method dispatch, and introspection support:
 
 ```rust,no_run
-use zlink::{service, unix, Server};
+use zlink::{service, tokio::unix, Server};
 use serde::{Deserialize, Serialize};
 use zlink::introspect;
 
@@ -111,8 +111,8 @@ Due to a [compiler bug][rustc-100013], the future returned by `Server::run` cann
 work using `select!`:
 
 ```rust,noplayground
-# async fn example<Svc: zlink::Service<zlink::unix::Stream>>(
-#     server: zlink::Server<zlink::unix::Listener, Svc>,
+# async fn example<Svc: zlink::Service<zlink::tokio::unix::Stream>>(
+#     server: zlink::Server<zlink::tokio::unix::Listener, Svc>,
 # ) -> Result<(), Box<dyn std::error::Error>> {
 # async fn do_other_things() -> Result<(), Box<dyn std::error::Error>> { Ok(()) }
 tokio::select! {
@@ -205,7 +205,7 @@ one-liner. Here's the relevant part of the FTL (faster-than-light drive 🚀) ex
 test suite:
 
 ```rust,noplayground
-use zlink::notified::{self, traits::State as _};
+use zlink::tokio::notified::{self, traits::State as _};
 # use zlink::service;
 # #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize, zlink::introspect::CustomType)]
 # struct DriveCondition { tylium_level: i64 }

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1358,7 +1358,7 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// use zlink::{
 ///     introspect::{self, Type},
 ///     service,
-///     unix::{bind, connect},
+///     tokio::unix::{bind, connect},
 ///     Server,
 /// };
 /// use serde::{Deserialize, Serialize};

--- a/zlink-macros/tests/service/basic.rs
+++ b/zlink-macros/tests/service/basic.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use zlink::{
     Server,
     introspect::{self, CustomType},
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/borrowed-types.rs
+++ b/zlink-macros/tests/service/borrowed-types.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use zlink::{
     Server,
     introspect::{self, CustomType},
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/custom_bounds.rs
+++ b/zlink-macros/tests/service/custom_bounds.rs
@@ -5,7 +5,7 @@ use zlink::{
     Server,
     connection::socket::FetchPeerCredentials,
     introspect::{self},
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/fd_passing.rs
+++ b/zlink-macros/tests/service/fd_passing.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use zlink::{
     Server,
     introspect::{self},
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/introspection.rs
+++ b/zlink-macros/tests/service/introspection.rs
@@ -4,7 +4,7 @@ use super::basic::{BankAccount, BankError};
 use zlink::{
     Server,
     idl::Type,
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/metadata.rs
+++ b/zlink-macros/tests/service/metadata.rs
@@ -2,7 +2,7 @@
 
 use zlink::{
     Server,
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/multiple_interfaces.rs
+++ b/zlink-macros/tests/service/multiple_interfaces.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use zlink::{
     Server,
     introspect::{self, Type},
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/per_interface_types.rs
+++ b/zlink-macros/tests/service/per_interface_types.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use zlink::{
     Server,
     introspect::{self, CustomType},
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/raw_idents.rs
+++ b/zlink-macros/tests/service/raw_idents.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use zlink::{
     Server,
     introspect::{self, CustomType},
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/streaming.rs
+++ b/zlink-macros/tests/service/streaming.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use zlink::{
     Server, introspect,
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/streaming_errors.rs
+++ b/zlink-macros/tests/service/streaming_errors.rs
@@ -8,7 +8,7 @@ use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use zlink::{
     Reply, Server, introspect,
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/streaming_fds.rs
+++ b/zlink-macros/tests/service/streaming_fds.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use zlink::{
     Server,
     introspect::Type,
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-macros/tests/service/underscore_params.rs
+++ b/zlink-macros/tests/service/underscore_params.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use zlink::{
     Server,
     introspect::{self, CustomType},
-    unix::{bind, connect},
+    tokio::unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink-smol/src/lib.rs
+++ b/zlink-smol/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(unreachable_pub)]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
-pub use zlink_core::*;
+pub(crate) use zlink_core::*;
 #[cfg(feature = "server")]
 pub mod notified;
 pub mod unix;

--- a/zlink-smol/src/notified/state.rs
+++ b/zlink-smol/src/notified/state.rs
@@ -81,7 +81,7 @@ where
 }
 
 pin_project! {
-    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
+    /// The stream to use as the [`zlink_core::Service::ReplyStream`] in service implementation when
     /// using [`State`].
     #[derive(Debug)]
     pub struct Stream<ReplyParams> {

--- a/zlink-tokio/src/lib.rs
+++ b/zlink-tokio/src/lib.rs
@@ -10,7 +10,7 @@
 #![warn(unreachable_pub)]
 #![cfg_attr(not(doctest), doc = include_str!("../README.md"))]
 
-pub use zlink_core::*;
+pub(crate) use zlink_core::*;
 #[cfg(feature = "server")]
 pub mod notified;
 pub mod unix;

--- a/zlink-tokio/src/notified/state.rs
+++ b/zlink-tokio/src/notified/state.rs
@@ -62,7 +62,7 @@ where
 }
 
 pin_project! {
-    /// The stream to use as the [`crate::Service::ReplyStream`] in service implementation when
+    /// The stream to use as the [`zlink_core::Service::ReplyStream`] in service implementation when
     /// using [`State`].
     #[derive(Debug)]
     pub struct Stream<ReplyParams> {

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -12,16 +12,27 @@ authors.workspace = true
 default = ["tokio", "service", "proxy", "tracing"]
 tokio = ["dep:zlink-tokio"]
 smol = ["dep:zlink-smol"]
-server = ["zlink-tokio?/server", "zlink-smol?/server"]
-proxy = ["zlink-tokio?/proxy", "zlink-smol?/proxy"]
-service = ["server", "introspection", "zlink-tokio?/service", "zlink-smol?/service"]
-idl = ["zlink-tokio?/idl", "zlink-smol?/idl"]
-idl-parse = ["zlink-tokio?/idl-parse", "zlink-smol?/idl-parse"]
-introspection = ["zlink-tokio?/introspection", "zlink-smol?/introspection"]
-tracing = ["zlink-tokio?/tracing", "zlink-smol?/tracing"]
-defmt = ["zlink-tokio?/defmt", "zlink-smol?/defmt"]
+server = ["zlink-core/server", "zlink-tokio?/server", "zlink-smol?/server"]
+proxy = ["zlink-core/proxy", "zlink-tokio?/proxy", "zlink-smol?/proxy"]
+service = [
+    "server",
+    "introspection",
+    "zlink-core/service",
+    "zlink-tokio?/service",
+    "zlink-smol?/service",
+]
+idl = ["zlink-core/idl", "zlink-tokio?/idl", "zlink-smol?/idl"]
+idl-parse = ["zlink-core/idl-parse", "zlink-tokio?/idl-parse", "zlink-smol?/idl-parse"]
+introspection = [
+    "zlink-core/introspection",
+    "zlink-tokio?/introspection",
+    "zlink-smol?/introspection",
+]
+tracing = ["zlink-core/tracing", "zlink-tokio?/tracing", "zlink-smol?/tracing"]
+defmt = ["zlink-core/defmt", "zlink-tokio?/defmt", "zlink-smol?/defmt"]
 
 [dependencies]
+zlink-core = { path = "../zlink-core", version = "=0.7.0", default-features = false }
 zlink-tokio = { path = "../zlink-tokio", version = "=0.7.0", default-features = false, optional = true }
 zlink-smol = { path = "../zlink-smol", version = "=0.7.0", default-features = false, optional = true }
 

--- a/zlink/examples/resolved.rs
+++ b/zlink/examples/resolved.rs
@@ -11,7 +11,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Setup tracing subscriber
     tracing_subscriber::fmt::init();
 
-    let mut connection = zlink::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
+    let mut connection =
+        zlink::tokio::unix::connect("/run/systemd/resolve/io.systemd.Resolve").await?;
 
     let args: Vec<_> = args().skip(1).collect();
 

--- a/zlink/examples/varlink-inspect.rs
+++ b/zlink/examples/varlink-inspect.rs
@@ -6,7 +6,7 @@
 use clap::Parser;
 use colored::*;
 use std::process;
-use zlink::{unix, varlink_service::Proxy};
+use zlink::{tokio::unix, varlink_service::Proxy};
 
 #[derive(Parser)]
 #[command(name = "varlink-inspect")]

--- a/zlink/src/lib.rs
+++ b/zlink/src/lib.rs
@@ -9,12 +9,19 @@
     missing_docs
 )]
 #![warn(unreachable_pub)]
-#![doc = include_str!("../README.md")]
+// The README examples use the tokio runtime and hence the `tokio`-specific API.
+#![cfg_attr(feature = "tokio", doc = include_str!("../README.md"))]
+#![cfg_attr(
+    not(feature = "tokio"),
+    doc = "An asynchronous [Varlink](https://varlink.org/) API. See the \
+        [project README](https://github.com/z-galaxy/zlink) for an overview and examples."
+)]
 
 #[cfg(not(any(feature = "tokio", feature = "smol")))]
 compile_error!("At least one runtime feature must be enabled: 'tokio' or 'smol'");
 
-#[cfg(doctest)]
+// The book examples use the tokio runtime and hence the `tokio`-specific API.
+#[cfg(all(doctest, feature = "tokio"))]
 mod doctests {
     // Book markdown checks.
     doc_comment::doctest!("../../book/src/introduction.md");
@@ -34,8 +41,20 @@ mod doctests {
     doc_comment::doctest!("../../book/src/faq.md");
 }
 
-#[cfg(feature = "tokio")]
-pub use zlink_tokio::*;
+pub use zlink_core::*;
 
-#[cfg(all(feature = "smol", not(feature = "tokio")))]
-pub use zlink_smol::*;
+/// API specific to the [tokio](https://tokio.rs/) runtime.
+#[cfg(feature = "tokio")]
+pub mod tokio {
+    #[cfg(feature = "server")]
+    pub use zlink_tokio::notified;
+    pub use zlink_tokio::unix;
+}
+
+/// API specific to the [smol](https://github.com/smol-rs/smol) runtime.
+#[cfg(feature = "smol")]
+pub mod smol {
+    #[cfg(feature = "server")]
+    pub use zlink_smol::notified;
+    pub use zlink_smol::unix;
+}

--- a/zlink/tests/ftl.rs
+++ b/zlink/tests/ftl.rs
@@ -11,9 +11,18 @@ use serde::{Deserialize, Serialize};
 use tokio::{select, time::sleep};
 use zlink::{
     introspect::{self, CustomType, ReplyError as _, Type},
+    varlink_service::{self, Proxy as _},
+};
+
+#[cfg(all(feature = "smol", not(feature = "tokio")))]
+use zlink::smol::{
     notified::{self, traits::State as _},
     unix::{bind, connect},
-    varlink_service::{self, Proxy as _},
+};
+#[cfg(feature = "tokio")]
+use zlink::tokio::{
+    notified::{self, traits::State as _},
+    unix::{bind, connect},
 };
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]

--- a/zlink/tests/machined_proxy_e2e.rs
+++ b/zlink/tests/machined_proxy_e2e.rs
@@ -17,9 +17,14 @@ use tempfile::TempDir;
 use tokio::select;
 use tokio::time::{Duration, timeout};
 use zlink::{
-    proxy, unix,
+    proxy,
     varlink_service::{self, Proxy},
 };
+
+#[cfg(all(feature = "smol", not(feature = "tokio")))]
+use zlink::smol::unix;
+#[cfg(feature = "tokio")]
+use zlink::tokio::unix;
 
 use mock_machined_service::{AcquireMetadata, ListReply, MachinedError, OwnedListReply, ProcessId};
 

--- a/zlink/tests/peer_credentials.rs
+++ b/zlink/tests/peer_credentials.rs
@@ -10,6 +10,11 @@ use std::os::fd::AsRawFd;
 use tempfile::TempDir;
 use zlink::Listener;
 
+#[cfg(all(feature = "smol", not(feature = "tokio")))]
+use zlink::smol::unix;
+#[cfg(feature = "tokio")]
+use zlink::tokio::unix;
+
 #[tokio::test]
 async fn peer_credentials_unix_socket() {
     // Create a temporary directory for the socket.
@@ -17,7 +22,7 @@ async fn peer_credentials_unix_socket() {
     let socket_path = temp_dir.path().join("test_creds.sock");
 
     // Create a listener.
-    let mut listener = zlink::unix::bind(&socket_path).unwrap();
+    let mut listener = unix::bind(&socket_path).unwrap();
 
     // Connect from a client.
     let socket_path_clone = socket_path.clone();
@@ -87,11 +92,11 @@ async fn passed_credentials_over_unix_socket() {
     let temp_dir = TempDir::new().unwrap();
     let socket_path = temp_dir.path().join("passed_creds.sock");
 
-    let mut listener = zlink::unix::bind(&socket_path).unwrap();
+    let mut listener = unix::bind(&socket_path).unwrap();
 
     let socket_path_clone = socket_path.clone();
     let client_task = tokio::spawn(async move {
-        let mut client = zlink::unix::connect(&socket_path_clone).await.unwrap();
+        let mut client = unix::connect(&socket_path_clone).await.unwrap();
 
         let creds = PassedCredentials::new(
             rustix::process::getuid(),

--- a/zlink/tests/ready_listener_exit.rs
+++ b/zlink/tests/ready_listener_exit.rs
@@ -10,8 +10,12 @@ use tokio::time::timeout;
 use zlink::{
     Connection, ReadyListener, Server,
     introspect::{self, CustomType},
-    unix::Stream,
 };
+
+#[cfg(all(feature = "smol", not(feature = "tokio")))]
+use zlink::smol::unix::Stream;
+#[cfg(feature = "tokio")]
+use zlink::tokio::unix::Stream;
 
 const TIMEOUT: Duration = Duration::from_secs(5);
 


### PR DESCRIPTION
The `tokio` and `smol` features were mutually exclusive in practice: the crate root re-exported one runtime crate wholesale, with `tokio` taking precedence when both were enabled. Since cargo features are supposed to be additive, this could silently switch a `smol` user over to the `tokio` transport when some other crate in the dependency graph enabled `zlink`'s default features.

Now the runtime-agnostic API (everything from `zlink-core`, on which `zlink` now depends directly) is re-exported at the crate root, and only the runtime-specific parts (the `unix` and `notified` modules) live in per-runtime `tokio` and `smol` modules. Both runtime features can be enabled at the same time, each providing its own transport API:

```rust
// tokio:
let conn = zlink::tokio::unix::connect(path).await?;
// smol (can coexist in the same build):
let conn = zlink::smol::unix::connect(path).await?;
```

Notes:

* **Breaking change**: `zlink::unix` → `zlink::tokio::unix` / `zlink::smol::unix` (same for `notified`). Since 0.7.0 is unreleased (crates.io is at 0.6.0), this lands within the already-major 0.7.0 bump.
* The README and book examples now use the `tokio`-specific paths, so they are only built as doctests when the `tokio` feature is enabled; a short fallback crate doc keeps `deny(missing_docs)` satisfied on non-tokio builds.
* The `zlink` integration tests select the runtime module via `cfg`, so the smol-only CI configuration keeps exercising the smol transport as before. `cargo test --all-features` now builds with both runtimes enabled, exercising the additivity with no CI changes.
* The book's runtime-selection docs were updated accordingly.

Verified: `cargo test --all-features`, the smol-only test configuration, clippy, `cargo doc --all-features` (with `-D warnings`), the `zlink-core` no_std check, and nightly `fmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VRXgTeDd4vcpDdW7ukwhgq

---
_Generated by [Claude Code](https://claude.ai/code/session_01VRXgTeDd4vcpDdW7ukwhgq)_