### PR TITLE
🏗️ Strong type varlink names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -529,7 +529,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -585,7 +585,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -736,7 +736,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.12.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717a8d2a5a929a1a2eb43a12812498ed141a0bcfb7e8f7844fbdbe4303bba9f"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1248,7 +1248,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1397,27 +1397,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301e07b2f92a4c78e05cade02eddc42f3088ec1059cdfdb701909754de5d4d1d"
 dependencies = [
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1441,7 +1441,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1541,6 +1541,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,7 +1559,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1594,7 +1605,7 @@ checksum = "451b374529930d7601b1eef8d32bc79ae870b6079b069401709c2a8bf9e75f36"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1614,7 +1625,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1688,7 +1699,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -1859,7 +1870,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "wasm-bindgen-shared",
 ]
 
@@ -1881,7 +1892,7 @@ checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2120,7 +2131,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -2147,7 +2158,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2167,7 +2178,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
  "synstructure",
 ]
 
@@ -2201,7 +2212,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.108",
 ]
 
 [[package]]
@@ -2290,7 +2301,7 @@ dependencies = [
  "serde-json-core",
  "serde-prefix-all",
  "serde_json",
- "syn",
+ "syn 2.0.108",
  "tempfile",
  "test-log",
  "tokio",
@@ -2303,7 +2314,7 @@ dependencies = [
 name = "zlink-names"
 version = "0.7.0"
 dependencies = [
- "regex",
+ "serde",
  "winnow",
  "zcheapstr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1320,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1331,9 +1331,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rustix"
@@ -2078,9 +2078,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.13"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 
 [[package]]
 name = "wit-bindgen"
@@ -2123,6 +2123,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
 
 [[package]]
 name = "zerocopy"
@@ -2217,6 +2223,7 @@ dependencies = [
  "tokio",
  "tracing-subscriber",
  "zlink-core",
+ "zlink-names",
  "zlink-smol",
  "zlink-tokio",
 ]
@@ -2261,6 +2268,7 @@ dependencies = [
  "uuid",
  "zlink-idl",
  "zlink-macros",
+ "zlink-names",
 ]
 
 [[package]]
@@ -2268,6 +2276,7 @@ name = "zlink-idl"
 version = "0.7.0"
 dependencies = [
  "winnow",
+ "zlink-names",
 ]
 
 [[package]]
@@ -2287,6 +2296,16 @@ dependencies = [
  "tokio",
  "zlink",
  "zlink-idl",
+ "zlink-names",
+]
+
+[[package]]
+name = "zlink-names"
+version = "0.7.0"
+dependencies = [
+ "regex",
+ "winnow",
+ "zcheapstr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "zlink-codegen",
     "zlink-codegen/test-integration",
     "zlink-idl",
+    "zlink-names",
     "zlink-tokio",
     "zlink-smol",
     "zlink-macros",

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The zlink project consists of several subcrates:
 - **[`zlink`]**: The main unified API crate that re-exports functionality based on enabled features.
   This is the only crate you will want to use directly in your application and services.
 - **[`zlink-core`]**: Core no-std foundation providing essential Varlink types and traits.
+- **[`zlink-names`]**: Varlink name types and validation (field, type and interface names).
 - **[`zlink-macros`]**: Contains the attribute and derive macros.
 - **[`zlink-tokio`]**: `Tokio`-based transport implementations and runtime integration.
 - **[`zlink-smol`]**: `smol`-based transport implementations and runtime integration.
@@ -425,6 +426,7 @@ This project is licensed under the [MIT License][license].
 [license]: ./LICENSE
 [`zlink`]: https://docs.rs/zlink
 [`zlink-core`]: https://docs.rs/zlink-core
+[`zlink-names`]: https://docs.rs/zlink-names
 [`zlink-tokio`]: https://docs.rs/zlink-tokio
 [`zlink-smol`]: https://docs.rs/zlink-smol
 [`zlink-codegen`]: https://docs.rs/zlink-codegen

--- a/zlink-codegen/src/lib.rs
+++ b/zlink-codegen/src/lib.rs
@@ -4,7 +4,7 @@
 //! Code generation for Varlink interfaces.
 
 use std::{fs, path::PathBuf};
-use zlink::idl::Interface;
+use zlink::{idl::Interface, names::InterfaceName};
 
 #[cfg(doctest)]
 mod doctests {
@@ -228,7 +228,7 @@ pub fn generate_files(config: &CodegenOptions) -> Result<(), Error> {
 /// The filename is converted to lowercase to comply with Rust's naming conventions.
 ///
 /// For example: `"org.example.Interface"` → `"org_example_interface.rs"`
-fn interface_to_filename(interface_name: &str) -> String {
+fn interface_to_filename(interface_name: &InterfaceName) -> String {
     format!("{}.rs", interface_name.replace('.', "_").to_lowercase())
 }
 
@@ -239,19 +239,19 @@ mod tests {
     #[test]
     fn test_interface_to_filename() {
         assert_eq!(
-            interface_to_filename("org.example.Interface"),
+            interface_to_filename(&InterfaceName::try_from("org.example.Interface").unwrap()),
             "org_example_interface.rs"
         );
         assert_eq!(
-            interface_to_filename("com.example.MyService"),
+            interface_to_filename(&InterfaceName::try_from("com.example.MyService").unwrap()),
             "com_example_myservice.rs"
         );
         assert_eq!(
-            interface_to_filename("SimpleInterface"),
-            "simpleinterface.rs"
+            interface_to_filename(&InterfaceName::try_from("org.varlink-rs.service").unwrap()),
+            "org_varlink-rs_service.rs"
         );
         assert_eq!(
-            interface_to_filename("org.varlink.service"),
+            interface_to_filename(&InterfaceName::try_from("org.varlink.service").unwrap()),
             "org_varlink_service.rs"
         );
     }

--- a/zlink-core/Cargo.toml
+++ b/zlink-core/Cargo.toml
@@ -22,6 +22,7 @@ introspection = ["idl", "zlink-macros/introspection"]
 [dependencies]
 serde = { version = "1.0.218", default-features = false, features = ["derive", "alloc"] }
 zlink-macros = { path = "../zlink-macros", version = "=0.7.0" }
+zlink-names = { path = "../zlink-names", version = "=0.7.0", default-features = false }
 zlink-idl = { path = "../zlink-idl", version = "=0.7.0", optional = true }
 serde_json = { version = "1.0.139", default-features = false, features = ["alloc"] }
 itoa = { version = "1.0", default-features = false }

--- a/zlink-core/src/introspect/type/special.rs
+++ b/zlink-core/src/introspect/type/special.rs
@@ -98,3 +98,11 @@ impl Type for core::net::SocketAddrV4 {
 impl Type for core::net::SocketAddrV6 {
     const TYPE: &'static idl::Type<'static> = &idl::Type::String;
 }
+
+// ============================================================================
+// Varlink name types
+// ============================================================================
+
+impl Type for zlink_names::InterfaceName<'_> {
+    const TYPE: &'static idl::Type<'static> = &idl::Type::String;
+}

--- a/zlink-core/src/lib.rs
+++ b/zlink-core/src/lib.rs
@@ -62,6 +62,15 @@ pub mod idl {
 #[cfg(feature = "introspection")]
 pub mod introspect;
 pub mod varlink_service;
+pub mod names {
+    //! Varlink name validation and parsing.
+    //!
+    //! This is a re-export of the [`zlink_names`] crate, for those who only need the name API and
+    //! not the rest of zlink.
+
+    #[doc(inline)]
+    pub use zlink_names::*;
+}
 
 #[cfg(feature = "proxy")]
 pub use zlink_macros::proxy;

--- a/zlink-core/src/varlink_service/api.rs
+++ b/zlink-core/src/varlink_service/api.rs
@@ -1,5 +1,6 @@
 use alloc::borrow::Cow;
 use serde::{Deserialize, Serialize};
+use zlink_names::InterfaceName;
 
 #[cfg(feature = "introspection")]
 use crate::introspect;
@@ -21,7 +22,8 @@ pub enum Method<'a> {
     #[serde(rename = "org.varlink.service.GetInterfaceDescription")]
     GetInterfaceDescription {
         /// The interface to get the description for.
-        interface: &'a str,
+        #[serde(borrow)]
+        interface: InterfaceName<'a>,
     },
 }
 

--- a/zlink-core/src/varlink_service/info.rs
+++ b/zlink-core/src/varlink_service/info.rs
@@ -2,6 +2,7 @@
 use crate::introspect::Type;
 use alloc::{borrow::Cow, vec::Vec};
 use serde::{Deserialize, Serialize};
+use zlink_names::InterfaceName;
 
 /// Information about a Varlink service implementation.
 ///
@@ -24,7 +25,7 @@ pub struct Info<'a> {
     pub url: Cow<'a, str>,
     /// List of interfaces provided by the service.
     #[serde(borrow)]
-    pub interfaces: Vec<Cow<'a, str>>,
+    pub interfaces: Vec<InterfaceName<'a>>,
 }
 
 impl<'a> Info<'a> {
@@ -34,7 +35,7 @@ impl<'a> Info<'a> {
         product: impl Into<Cow<'a, str>>,
         version: impl Into<Cow<'a, str>>,
         url: impl Into<Cow<'a, str>>,
-        interfaces: impl IntoIterator<Item = impl Into<Cow<'a, str>>>,
+        interfaces: impl IntoIterator<Item = impl Into<InterfaceName<'static>>>,
     ) -> Self {
         Self {
             vendor: vendor.into(),
@@ -43,6 +44,20 @@ impl<'a> Info<'a> {
             url: url.into(),
             interfaces: interfaces.into_iter().map(Into::into).collect(),
         }
+    }
+
+    /// Internal function only. Do not call this directly in your own code!
+    pub fn from_static_str_unchecked(
+        vendor: impl Into<Cow<'a, str>>,
+        product: impl Into<Cow<'a, str>>,
+        version: impl Into<Cow<'a, str>>,
+        url: impl Into<Cow<'a, str>>,
+        interfaces: impl IntoIterator<Item = &'static str>,
+    ) -> Self {
+        let interfaces = interfaces
+            .into_iter()
+            .map(InterfaceName::from_static_str_unchecked);
+        Self::new(vendor, product, version, url, interfaces)
     }
 
     /// Convert this info into an owned version with `'static` lifetime.
@@ -55,7 +70,7 @@ impl<'a> Info<'a> {
             interfaces: self
                 .interfaces
                 .into_iter()
-                .map(|s| Cow::Owned(s.into_owned()))
+                .map(InterfaceName::into_owned)
                 .collect(),
         }
     }
@@ -86,9 +101,23 @@ impl OwnedInfo {
         product: impl Into<Cow<'static, str>>,
         version: impl Into<Cow<'static, str>>,
         url: impl Into<Cow<'static, str>>,
-        interfaces: impl IntoIterator<Item = impl Into<Cow<'static, str>>>,
+        interfaces: impl IntoIterator<Item = impl Into<InterfaceName<'static>>>,
     ) -> Self {
         Self(Info::new(vendor, product, version, url, interfaces))
+    }
+
+    /// Internal function only. Do not call this directly in your own code!
+    pub fn from_static_str_unchecked(
+        vendor: impl Into<Cow<'static, str>>,
+        product: impl Into<Cow<'static, str>>,
+        version: impl Into<Cow<'static, str>>,
+        url: impl Into<Cow<'static, str>>,
+        interfaces: impl IntoIterator<Item = &'static str>,
+    ) -> Self {
+        let interfaces = interfaces
+            .into_iter()
+            .map(InterfaceName::from_static_str_unchecked);
+        Self::new(vendor, product, version, url, interfaces)
     }
 
     /// Returns a reference to the inner `Info`.
@@ -128,15 +157,16 @@ impl<'de> Deserialize<'de> for OwnedInfo {
         D: serde::Deserializer<'de>,
     {
         use alloc::string::String;
+        use zlink_names::OwnedInterfaceName;
 
-        // Deserialize into owned strings directly.
+        // Deserialize into owned names directly.
         #[derive(Deserialize)]
         struct InfoOwned {
             vendor: String,
             product: String,
             version: String,
             url: String,
-            interfaces: Vec<String>,
+            interfaces: Vec<OwnedInterfaceName>,
         }
 
         let info = InfoOwned::deserialize(deserializer)?;
@@ -145,7 +175,11 @@ impl<'de> Deserialize<'de> for OwnedInfo {
             product: Cow::Owned(info.product),
             version: Cow::Owned(info.version),
             url: Cow::Owned(info.url),
-            interfaces: info.interfaces.into_iter().map(Cow::Owned).collect(),
+            interfaces: info
+                .interfaces
+                .into_iter()
+                .map(InterfaceName::from)
+                .collect(),
         }))
     }
 }
@@ -158,7 +192,7 @@ mod tests {
     fn serialization() {
         let interfaces = alloc::vec!["com.example.test"];
 
-        let info = Info::new(
+        let info = Info::from_static_str_unchecked(
             "Test Vendor",
             "Test Product",
             "1.0.0",
@@ -189,15 +223,15 @@ mod tests {
         assert_eq!(info.version, "1.0.0");
         assert_eq!(info.url, "https://example.com");
         assert_eq!(info.interfaces.len(), 2);
-        assert_eq!(info.interfaces[0], "com.example.test");
-        assert_eq!(info.interfaces[1], "com.example.other");
+        assert_eq!(info.interfaces[0].as_str(), "com.example.test");
+        assert_eq!(info.interfaces[1].as_str(), "com.example.other");
     }
 
     #[test]
     fn round_trip_serialization() {
         let interfaces = alloc::vec!["com.example.test", "com.example.other"];
 
-        let original = Info::new(
+        let original = Info::from_static_str_unchecked(
             "Test Vendor",
             "Test Product",
             "1.0.0",

--- a/zlink-core/src/varlink_service/mod.rs
+++ b/zlink-core/src/varlink_service/mod.rs
@@ -24,6 +24,8 @@ pub const INTERFACE_NAME: &str = "org.varlink.service";
 /// The description of the `org.varlink.service` interface.
 #[cfg(feature = "introspection")]
 pub const DESCRIPTION: &crate::idl::Interface<'static> = &{
+    use crate::names::InterfaceName;
+
     use crate::{
         idl::{Comment, Interface, Method, Parameter},
         introspect::{ReplyError, Type},
@@ -52,7 +54,7 @@ pub const DESCRIPTION: &crate::idl::Interface<'static> = &{
     ];
 
     Interface::new(
-        INTERFACE_NAME,
+        InterfaceName::from_static_str_unchecked(INTERFACE_NAME),
         METHODS,
         &[],
         Error::VARIANTS,

--- a/zlink-idl/src/interface.rs
+++ b/zlink-idl/src/interface.rs
@@ -3,6 +3,7 @@
 use core::fmt;
 
 use alloc::vec::Vec;
+use zlink_names::InterfaceName;
 
 use super::List;
 
@@ -10,7 +11,7 @@ use super::List;
 #[derive(Debug, Clone, Eq)]
 pub struct Interface<'a> {
     /// The name of the interface in reverse-domain notation.
-    name: &'a str,
+    name: InterfaceName<'a>,
     /// The methods of the interface.
     methods: List<'a, super::Method<'a>>,
     /// The custom types of the interface.
@@ -24,7 +25,7 @@ pub struct Interface<'a> {
 impl<'a> Interface<'a> {
     /// Creates a new interface with the given name, borrowed collections, and comments.
     pub const fn new(
-        name: &'a str,
+        name: InterfaceName<'a>,
         methods: &'a [&'a super::Method<'a>],
         custom_types: &'a [&'a super::CustomType<'a>],
         errors: &'a [&'a super::Error<'a>],
@@ -41,7 +42,7 @@ impl<'a> Interface<'a> {
 
     /// Creates a new interface with the given name, owned collections, and comments.
     pub fn new_owned(
-        name: &'a str,
+        name: InterfaceName<'a>,
         methods: Vec<super::Method<'a>>,
         custom_types: Vec<super::CustomType<'a>>,
         errors: Vec<super::Error<'a>>,
@@ -57,8 +58,8 @@ impl<'a> Interface<'a> {
     }
 
     /// Returns the name of the interface.
-    pub fn name(&self) -> &'a str {
-        self.name
+    pub fn name(&self) -> &InterfaceName<'a> {
+        &self.name
     }
 
     /// Returns an iterator over the methods of the interface.
@@ -180,9 +181,10 @@ mod tests {
             &expected_more,
         ];
 
-        let interface = Interface::new("org.varlink.service", methods, &[], errors, &[]);
+        let interface_name = InterfaceName::try_from("org.varlink.service").unwrap();
+        let interface = Interface::new(interface_name.clone(), methods, &[], errors, &[]);
 
-        assert_eq!(interface.name(), "org.varlink.service");
+        assert_eq!(interface.name(), &interface_name);
         assert_eq!(interface.methods().count(), 2);
         assert_eq!(interface.errors().count(), 6);
         assert!(!interface.is_empty());
@@ -249,7 +251,13 @@ error ExpectedMore ()
 
     #[test]
     fn empty_interface() {
-        let interface = Interface::new("com.example.empty", &[], &[], &[], &[]);
+        let interface = Interface::new(
+            InterfaceName::try_from("com.example.empty").unwrap(),
+            &[],
+            &[],
+            &[],
+            &[],
+        );
         assert!(interface.is_empty());
         assert_eq!(interface.methods().count(), 0);
         assert_eq!(interface.errors().count(), 0);
@@ -396,7 +404,13 @@ error ExpectedMore ()
             &dns_error,
         ];
 
-        let interface = Interface::new("io.systemd.Resolve", methods, custom_types, errors, &[]);
+        let interface = Interface::new(
+            InterfaceName::try_from("io.systemd.Resolve").unwrap(),
+            methods,
+            custom_types,
+            errors,
+            &[],
+        );
 
         // Test parsing the IDL and compare with manually constructed interface.
         const SYSTEMD_RESOLVED_IDL: &str = r#"interface io.systemd.Resolve
@@ -604,7 +618,13 @@ error DNSError(
         let method = Method::new("Test", &[], &[], &method_comments);
         let methods = [&method];
 
-        let interface = Interface::new("org.example.test", &methods, &[], &[], &interface_comments);
+        let interface = Interface::new(
+            InterfaceName::try_from("org.example.test").unwrap(),
+            &methods,
+            &[],
+            &[],
+            &interface_comments,
+        );
 
         let mut output = String::new();
         write!(&mut output, "{}", interface).unwrap();
@@ -655,7 +675,7 @@ error DNSError(
         let errors = [&error];
 
         let interface = Interface::new(
-            "org.example.comprehensive",
+            InterfaceName::try_from("org.example.comprehensive").unwrap(),
             &methods,
             &custom_types,
             &errors,

--- a/zlink-idl/src/lib.rs
+++ b/zlink-idl/src/lib.rs
@@ -56,7 +56,10 @@ pub use interface::Interface;
 #[cfg(feature = "parse")]
 mod name;
 #[cfg(feature = "parse")]
-pub use name::{is_valid_field_name, is_valid_interface_name, is_valid_type_name};
+#[deprecated(
+    note = "Use is_valid_field_name, is_valid_interface_name, is_valid_type_name in zlink-names instead"
+)]
+pub use zlink_names::{is_valid_field_name, is_valid_interface_name, is_valid_type_name};
 
 #[cfg(feature = "parse")]
 pub mod parse;

--- a/zlink-idl/src/name.rs
+++ b/zlink-idl/src/name.rs
@@ -3,74 +3,9 @@
 //! These run the actual IDL parsers, so a name is accepted here exactly when the parser would
 //! accept it in an interface definition -- there is no second copy of the grammar to drift from it.
 
-use winnow::error::{ErrMode, InputError};
-
-use crate::parse;
-
-/// Whether `name` is a valid Varlink field name.
-///
-/// Struct fields, method parameters and enum variants all follow this rule.
-///
-/// # Examples
-///
-/// ```
-/// use zlink_idl::is_valid_field_name;
-///
-/// assert!(is_valid_field_name("user_name"));
-/// assert!(!is_valid_field_name("user-name"));
-/// ```
-pub fn is_valid_field_name(name: &str) -> bool {
-    parses_fully(parse::field_name, name)
-}
-
-/// Whether `name` is a valid Varlink type name.
-///
-/// Method and error names follow this rule too.
-///
-/// # Examples
-///
-/// ```
-/// use zlink_idl::is_valid_type_name;
-///
-/// assert!(is_valid_type_name("FileNotFound"));
-/// assert!(!is_valid_type_name("fileNotFound"));
-/// ```
-pub fn is_valid_type_name(name: &str) -> bool {
-    parses_fully(parse::type_name, name)
-}
-
-/// Whether `name` is a valid Varlink interface name.
-///
-/// Interface names are reverse-domain notation: dot-separated segments, at least one dot.
-///
-/// # Examples
-///
-/// ```
-/// use zlink_idl::is_valid_interface_name;
-///
-/// assert!(is_valid_interface_name("org.example.Foo"));
-/// assert!(!is_valid_interface_name("Foo"));
-/// ```
-pub fn is_valid_interface_name(name: &str) -> bool {
-    parses_fully(parse::interface_name, name)
-}
-
-/// Whether `parser` accepts the whole of `name`, leaving nothing behind.
-///
-/// The parsers succeed on a valid prefix (e.g. `field_name` takes `foo` out of `foo-bar`), so a
-/// name is only valid when parsing also consumes every byte.
-fn parses_fully<'a, P, T>(mut parser: P, name: &'a str) -> bool
-where
-    P: FnMut(&mut &'a [u8]) -> Result<T, ErrMode<InputError<&'a [u8]>>>,
-{
-    let mut input = name.as_bytes();
-
-    parser(&mut input).is_ok() && input.is_empty()
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::{is_valid_field_name, is_valid_interface_name, is_valid_type_name};
 
     #[test]
     fn field_names() {

--- a/zlink-idl/src/name.rs
+++ b/zlink-idl/src/name.rs
@@ -9,7 +9,7 @@ mod tests {
 
     #[test]
     fn field_names() {
-        let valid = ["a", "Z", "user_name", "user0", "a_0_b", "type", "x__"];
+        let valid = ["a", "Z", "user_name", "user0", "a_0_b", "type"];
         for name in valid {
             assert!(is_valid_field_name(name), "`{name}` must be valid");
         }
@@ -24,6 +24,9 @@ mod tests {
             "user!",
             "üser",
             "user\u{e9}",
+            "a_",
+            "x__",
+            "a__b",
         ];
         for name in invalid {
             assert!(!is_valid_field_name(name), "`{name}` must be invalid");

--- a/zlink-idl/src/parse/mod.rs
+++ b/zlink-idl/src/parse/mod.rs
@@ -8,11 +8,12 @@ use winnow::{
     ascii::{multispace0, multispace1},
     combinator::{alt, delimited, opt, preceded, repeat, separated},
     error::{ErrMode, InputError, ParserError},
-    token::{literal, one_of, take_while},
+    token::{literal, take_while},
 };
 
 mod error;
 pub use error::Error;
+use zlink_names::{parse_field_name, parse_interface_name, parse_type_name};
 
 use super::{
     Comment, CustomEnum, CustomObject, CustomType, EnumVariant, Field, Interface, List, Method,
@@ -50,28 +51,6 @@ fn bytes_to_str(bytes: &[u8]) -> &str {
     core::str::from_utf8(bytes).unwrap()
 }
 
-/// Parse a field name: starts with letter, continues with alphanumeric and underscores.
-pub(crate) fn field_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
-    (
-        one_of(|c: u8| c.is_ascii_alphabetic()),
-        take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'_'),
-    )
-        .take()
-        .map(bytes_to_str)
-        .parse_next(input)
-}
-
-/// Parse a type name: starts with uppercase letter, continues with alphanumeric.
-pub(crate) fn type_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
-    (
-        one_of(|c: u8| c.is_ascii_uppercase()),
-        take_while(0.., |c: u8| c.is_ascii_alphanumeric()),
-    )
-        .take()
-        .map(bytes_to_str)
-        .parse_next(input)
-}
-
 /// Parse a primitive type.
 fn primitive_type<'a>(input: &mut &'a [u8]) -> ModalResult<Type<'a>, InputError<&'a [u8]>> {
     alt((
@@ -89,7 +68,7 @@ fn primitive_type<'a>(input: &mut &'a [u8]) -> ModalResult<Type<'a>, InputError<
 fn field<'a>(input: &mut &'a [u8]) -> ModalResult<Field<'a>, InputError<&'a [u8]>> {
     let comments = parse_preceding_comments(input)?;
 
-    let name = field_name(input)?;
+    let name = parse_field_name(input)?;
     ws(input)?;
     literal(":").parse_next(input)?;
     ws(input)?;
@@ -125,7 +104,7 @@ fn struct_type<'a>(input: &mut &'a [u8]) -> ModalResult<Type<'a>, InputError<&'a
 /// Parse an enum variant: any preceding comments followed by the variant name.
 fn enum_variant<'a>(input: &mut &'a [u8]) -> ModalResult<EnumVariant<'a>, InputError<&'a [u8]>> {
     let comments = parse_preceding_comments(input)?;
-    let name = field_name(input)?;
+    let name = parse_field_name(input)?;
     Ok(EnumVariant::new_owned(name, comments))
 }
 
@@ -153,7 +132,12 @@ fn inline_type<'a>(input: &mut &'a [u8]) -> ModalResult<Type<'a>, InputError<&'a
 
 /// Parse an element type (primitive, custom, or inline).
 fn element_type<'a>(input: &mut &'a [u8]) -> ModalResult<Type<'a>, InputError<&'a [u8]>> {
-    alt((primitive_type, type_name.map(Type::Custom), inline_type)).parse_next(input)
+    alt((
+        primitive_type,
+        parse_type_name.map(Type::Custom),
+        inline_type,
+    ))
+    .parse_next(input)
 }
 
 /// Parse an optional type: ?type.
@@ -187,37 +171,6 @@ fn varlink_type<'a>(input: &mut &'a [u8]) -> ModalResult<Type<'a>, InputError<&'
     alt((optional_type, array_type, map_type, element_type)).parse_next(input)
 }
 
-/// Parse an interface name: reverse domain notation like `org.example.test`.
-///
-/// Grammar:
-///   first segment      = [A-Za-z][A-Za-z0-9-]*
-///   subsequent segment = "." [A-Za-z0-9][A-Za-z0-9-]*
-///   name               = first_segment subsequent_segment+
-pub(crate) fn interface_name<'a>(
-    input: &mut &'a [u8],
-) -> ModalResult<&'a str, InputError<&'a [u8]>> {
-    (
-        // First segment.
-        (
-            one_of(|c: u8| c.is_ascii_alphabetic()),
-            take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'-'),
-        ),
-        // One or more dotted segments (so the name has at least one `.`).
-        repeat::<_, _, (), _, _>(
-            1..,
-            (
-                literal("."),
-                one_of(|c: u8| c.is_ascii_alphanumeric()),
-                take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'-'),
-            )
-                .void(),
-        ),
-    )
-        .take()
-        .map(bytes_to_str)
-        .parse_next(input)
-}
-
 /// Parse a parameter list: (param1: type1, param2: type2).
 fn parameter_list<'a>(
     input: &mut &'a [u8],
@@ -236,7 +189,7 @@ fn method_def<'a>(input: &mut &'a [u8]) -> ModalResult<Method<'a>, InputError<&'
 
     literal("method").parse_next(input)?;
     take_while(1.., |c: u8| c.is_ascii_whitespace()).parse_next(input)?;
-    let name = type_name(input)?;
+    let name = parse_type_name(input)?;
     ws(input)?;
     let input_params = parameter_list(input)?;
     ws(input)?;
@@ -258,7 +211,7 @@ fn error_def<'a>(input: &mut &'a [u8]) -> ModalResult<super::Error<'a>, InputErr
 
     literal("error").parse_next(input)?;
     take_while(1.., |c: u8| c.is_ascii_whitespace()).parse_next(input)?;
-    let name = type_name(input)?;
+    let name = parse_type_name(input)?;
     ws(input)?;
     let params = parameter_list(input)?;
 
@@ -279,7 +232,7 @@ fn field_or_variant<'a>(
     input: &mut &'a [u8],
 ) -> ModalResult<FieldOrVariant<'a>, InputError<&'a [u8]>> {
     let comments = parse_preceding_comments(input)?;
-    let name = field_name(input)?;
+    let name = parse_field_name(input)?;
     let ty = opt(preceded((ws, literal(":"), ws), varlink_type)).parse_next(input)?;
     Ok(match ty {
         Some(ty) => FieldOrVariant::Field(Field::new_owned(name, ty, comments)),
@@ -293,7 +246,7 @@ fn type_def<'a>(input: &mut &'a [u8]) -> ModalResult<CustomType<'a>, InputError<
 
     literal("type").parse_next(input)?;
     take_while(1.., |c: u8| c.is_ascii_whitespace()).parse_next(input)?;
-    let name = type_name(input)?;
+    let name = parse_type_name(input)?;
     ws(input)?;
 
     let items: Vec<FieldOrVariant<'a>> = delimited(
@@ -371,7 +324,7 @@ fn interface_def<'a>(input: &mut &'a [u8]) -> ModalResult<Interface<'a>, InputEr
 
     literal("interface").parse_next(input)?;
     take_while(1.., |c: u8| c.is_ascii_whitespace()).parse_next(input)?;
-    let name = interface_name(input)?;
+    let name = parse_interface_name(input)?;
 
     let members: Vec<InterfaceMember<'a>> = repeat(
         0..,

--- a/zlink-idl/src/parse/mod.rs
+++ b/zlink-idl/src/parse/mod.rs
@@ -13,7 +13,7 @@ use winnow::{
 
 mod error;
 pub use error::Error;
-use zlink_names::{parse_field_name, parse_interface_name, parse_type_name};
+use zlink_names::{InterfaceName, parse_field_name, parse_interface_name, parse_type_name};
 
 use super::{
     Comment, CustomEnum, CustomObject, CustomType, EnumVariant, Field, Interface, List, Method,
@@ -319,12 +319,17 @@ enum InterfaceMember<'a> {
 }
 
 /// Parse an interface definition.
-fn interface_def<'a>(input: &mut &'a [u8]) -> ModalResult<Interface<'a>, InputError<&'a [u8]>> {
-    let comments = parse_preceding_comments(input)?;
+fn interface_def<'a>(input: &mut &'a [u8]) -> Result<Interface<'a>, Error> {
+    let comments = parse_preceding_comments(input).map_err(to_parse_error)?;
 
-    literal("interface").parse_next(input)?;
-    take_while(1.., |c: u8| c.is_ascii_whitespace()).parse_next(input)?;
-    let name = parse_interface_name(input)?;
+    literal("interface")
+        .parse_next(input)
+        .map_err(to_parse_error)?;
+    take_while(1.., |c: u8| c.is_ascii_whitespace())
+        .parse_next(input)
+        .map_err(to_parse_error)?;
+    let name_str = parse_interface_name(input).map_err(to_parse_error)?;
+    let name = InterfaceName::try_from(name_str).map_err(|err| Error::Parse(err.to_string()))?;
 
     let members: Vec<InterfaceMember<'a>> = repeat(
         0..,
@@ -337,7 +342,8 @@ fn interface_def<'a>(input: &mut &'a [u8]) -> ModalResult<Interface<'a>, InputEr
             )),
         ),
     )
-    .parse_next(input)?;
+    .parse_next(input)
+    .map_err(to_parse_error)?;
 
     let mut methods = Vec::new();
     let mut custom_types = Vec::new();
@@ -359,15 +365,19 @@ fn interface_def<'a>(input: &mut &'a [u8]) -> ModalResult<Interface<'a>, InputEr
     ))
 }
 
+fn to_parse_error(err: ErrMode<InputError<&[u8]>>) -> Error {
+    Error::Parse(err.to_string())
+}
+
 /// Parse an interface from a string.
 pub(super) fn parse_interface(input: &str) -> Result<Interface<'_>, Error> {
     parse_from_str(input, interface_def)
 }
 
 /// Helper function to parse from string using byte-based parsers.
-fn parse_from_str<'a, T>(
+fn parse_from_str<'a, T, E: core::fmt::Display>(
     input: &'a str,
-    parser: impl Fn(&mut &'a [u8]) -> ModalResult<T, InputError<&'a [u8]>>,
+    parser: impl Fn(&mut &'a [u8]) -> Result<T, E>,
 ) -> Result<T, Error> {
     let input_bytes = input.trim().as_bytes();
     if input_bytes.is_empty() {

--- a/zlink-idl/src/parse/tests.rs
+++ b/zlink-idl/src/parse/tests.rs
@@ -319,7 +319,7 @@ error NotFound(id: int)
         "#;
 
     let interface = parse_interface(input).unwrap();
-    assert_eq!(interface.name(), "org.example.test");
+    assert_eq!(interface.name().as_str(), "org.example.test");
     assert_eq!(interface.custom_types().count(), 1);
     assert_eq!(interface.methods().count(), 1);
     assert_eq!(interface.errors().count(), 1);
@@ -380,7 +380,7 @@ error NotFound(id: int)
         "#;
 
     let interface = parse_interface(input).unwrap();
-    assert_eq!(interface.name(), "org.example.test");
+    assert_eq!(interface.name().as_str(), "org.example.test");
 
     // Check that we have the expected number of each type of member
     assert_eq!(interface.custom_types().count(), 1);
@@ -523,7 +523,7 @@ error SimpleError()
         "#;
 
     let interface = parse_interface(input).unwrap();
-    assert_eq!(interface.name(), "org.example.test");
+    assert_eq!(interface.name().as_str(), "org.example.test",);
 
     // Should have: method + error = 2 members (comments attached to them)
     assert_eq!(interface.methods().count(), 1);
@@ -620,7 +620,7 @@ method GetStatus() -> (status: string)
         "#;
 
     let interface = parse_interface(input).unwrap();
-    assert_eq!(interface.name(), "org.example.comprehensive");
+    assert_eq!(interface.name().as_str(), "org.example.comprehensive");
 
     // Check that we have the expected number of each type of member
     assert_eq!(interface.custom_types().count(), 1);
@@ -806,7 +806,7 @@ method GetData() -> (items: []any, map: [string]any)
     "#;
 
     let interface = parse_interface(input).unwrap();
-    assert_eq!(interface.name(), "org.example.anytest");
+    assert_eq!(interface.name().as_str(), "org.example.anytest");
     assert_eq!(interface.custom_types().count(), 1);
     assert_eq!(interface.methods().count(), 2);
 
@@ -1185,7 +1185,7 @@ method SimpleMethod() -> ()
     "#;
 
     let interface = parse_interface(input).unwrap();
-    assert_eq!(interface.name(), "org.example.test");
+    assert_eq!(interface.name().as_str(), "org.example.test");
 
     // Check interface comments
     let comments: Vec<_> = interface.comments().collect();
@@ -1251,7 +1251,7 @@ method GetUser(id: int) -> (user: User)
     "#;
 
     let interface = parse_interface(input).unwrap();
-    assert_eq!(interface.name(), "org.example.core");
+    assert_eq!(interface.name().as_str(), "org.example.core",);
 
     // Check interface comments
     let interface_comments: Vec<_> = interface.comments().collect();

--- a/zlink-idl/src/parse/tests.rs
+++ b/zlink-idl/src/parse/tests.rs
@@ -143,29 +143,6 @@ fn parse_errors() {
 }
 
 #[test]
-fn parse_interface_name() {
-    let input = b"org.example.test";
-    let mut input_mut = input.as_slice();
-    let result = interface_name(&mut input_mut).unwrap();
-    assert_eq!(result, "org.example.test");
-    assert!(input_mut.is_empty());
-
-    let input = b"com.example.foo.bar";
-    let mut input_mut = input.as_slice();
-    let result = interface_name(&mut input_mut).unwrap();
-    assert_eq!(result, "com.example.foo.bar");
-    assert!(input_mut.is_empty());
-
-    // Invalid: no dot
-    let mut input_mut = b"example".as_slice();
-    assert!(interface_name(&mut input_mut).is_err());
-
-    // Invalid: starts with number
-    let mut input_mut = b"1example.test".as_slice();
-    assert!(interface_name(&mut input_mut).is_err());
-}
-
-#[test]
 fn test_parse_method() {
     let input = "method GetInfo() -> (info: string)";
     let method = parse_method(input).unwrap();

--- a/zlink-macros/Cargo.toml
+++ b/zlink-macros/Cargo.toml
@@ -33,6 +33,7 @@ syn = { version = "2.0", default-features = false, features = [
 # reads them back. `parse` (hence winnow) is always on: this is a proc-macro crate, so the dep is
 # built for the host and never reaches a user's binary.
 zlink-idl = { path = "../zlink-idl", version = "=0.7.0", features = ["parse"] }
+zlink-names = { path = "../zlink-names", version = "=0.7.0", default-features = false }
 
 [dev-dependencies]
 zlink = { path = "../zlink", default-features = false, features = [

--- a/zlink-macros/src/introspect/custom_type.rs
+++ b/zlink-macros/src/introspect/custom_type.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Data, DataEnum, DeriveInput, Error, Fields};
+use zlink_names::TypeName;
 
 use crate::{
     naming::{self, RenameAll},
@@ -23,31 +24,18 @@ fn derive_custom_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
     let name = &input.ident;
     // Not `naming::resolve`: a container has no `rename_all` of its own to apply to itself, only
     // one it hands down to its fields. The name still has to be one Varlink can say.
-    let name_str = match naming::parse_rename(&input.attrs)? {
-        Some(lit) => {
-            let name_str = lit.value();
-            naming::validate(
-                &name_str,
-                naming::Grammar::Type,
-                "type name",
-                naming::NameSource::Rename(&lit),
-            )?;
-
-            name_str
-        }
-        None => {
-            let name_str = naming::unraw(name);
-            naming::validate(
-                &name_str,
-                naming::Grammar::Type,
-                "type name",
-                naming::NameSource::Ident(name),
-            )?;
-
-            name_str
-        }
+    let rename_lit = naming::parse_rename(&input.attrs)?;
+    let name_string = match &rename_lit {
+        Some(lit) => lit.value(),
+        None => naming::unraw(name),
     };
-    let rename_all = naming::parse_rename_all(&input.attrs, naming::Grammar::Field)?;
+    let name_source = match &rename_lit {
+        Some(lit) => naming::NameSource::Rename(lit),
+        None => naming::NameSource::Ident(name),
+    };
+    let type_name: TypeName<'_> = naming::validate(&name_string, "type name", name_source)?;
+    let name_str = type_name.as_str();
+    let rename_all = naming::RenameAllParser::new(&input.attrs).try_for_field_name()?;
     let generics = &input.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let crate_path = utils::parse_crate_path(&input.attrs)?;

--- a/zlink-macros/src/introspect/reply_error.rs
+++ b/zlink-macros/src/introspect/reply_error.rs
@@ -27,7 +27,7 @@ fn derive_reply_error_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
         "`#[zlink(rename)]` has no effect on the `ReplyError` derive: error names are qualified \
          by `#[zlink(interface)]`. Rename individual variants instead.",
     )?;
-    let rename_all = naming::parse_rename_all(&input.attrs, naming::Grammar::Type)?;
+    let rename_all = naming::RenameAllParser::new(&input.attrs).try_for_type_name()?;
 
     let expanded = match &input.data {
         Data::Enum(data_enum) => {
@@ -71,14 +71,15 @@ fn generate_error_definitions(
         // rule above, which governs variant names instead. Parsed unconditionally (even for unit
         // variants, which have no fields to apply it to) so a bogus value is always rejected,
         // matching the wire derive's `generate_serialize_variant_arm`.
-        let field_rename_all = naming::parse_rename_all(&variant.attrs, naming::Grammar::Field)?;
+        let field_rename_all = naming::RenameAllParser::new(&variant.attrs).try_for_field_name()?;
 
         match &variant.fields {
             Fields::Unit => {
                 let comments = utils::extract_doc_comments(&variant.attrs);
                 let comment_objects = shared::generate_comment_objects(&comments, crate_path);
+                let variant_name_str = variant_name.as_str();
                 let error_variant = quote! {
-                    &#crate_path::idl::Error::new(#variant_name, &[], &[#(#comment_objects),*])
+                    &#crate_path::idl::Error::new(#variant_name_str, &[], &[#(#comment_objects),*])
                 };
                 error_variants.push(error_variant);
             }
@@ -109,13 +110,14 @@ fn generate_error_definitions(
                 let comments = utils::extract_doc_comments(&variant.attrs);
                 let comment_objects = shared::generate_comment_objects(&comments, crate_path);
 
+                let variant_name_str = variant_name.as_str();
                 let error_variant = quote! {
                     &{
                         #(#field_statics)*
 
                         static FIELD_REFS: &[&#crate_path::idl::Field<'static>] = #field_refs_init;
 
-                        #crate_path::idl::Error::new(#variant_name, FIELD_REFS, &[#(#comment_objects),*])
+                        #crate_path::idl::Error::new(#variant_name_str, FIELD_REFS, &[#(#comment_objects),*])
                     }
                 };
                 error_variants.push(error_variant);
@@ -132,6 +134,7 @@ fn generate_error_definitions(
                     utils::remove_lifetimes_from_type(&fields.unnamed.first().unwrap().ty);
                 let comments = utils::extract_doc_comments(&variant.attrs);
                 let comment_objects = shared::generate_comment_objects(&comments, crate_path);
+                let variant_name_str = variant_name.as_str();
                 let error_variant = quote! {
                     &{
                         match <#field_type as #crate_path::introspect::Type>::TYPE {
@@ -139,7 +142,7 @@ fn generate_error_definitions(
                                 let #crate_path::idl::List::Borrowed(field_slice) = fields else {
                                     panic!("Owned List not supported in const context")
                                 };
-                                #crate_path::idl::Error::new(#variant_name, field_slice, &[#(#comment_objects),*])
+                                #crate_path::idl::Error::new(#variant_name_str, field_slice, &[#(#comment_objects),*])
                             }
                             _ => panic!("Tuple variant field type must have Type::Object"),
                         }

--- a/zlink-macros/src/introspect/shared.rs
+++ b/zlink-macros/src/introspect/shared.rs
@@ -89,7 +89,8 @@ pub(super) fn generate_field_definitions(
             }
             crate::attr_mode::FieldMode::Normal => {
                 let field_type = utils::remove_lifetimes_from_type(&field.ty);
-                let field_name_str = naming::field_name(&field.attrs, field_name, rename_all)?;
+                let field_named = naming::field_name(&field.attrs, field_name, rename_all)?;
+                let field_name_str = field_named.as_str();
 
                 let static_name = if let Some(variant_ident) = variant_prefix {
                     quote::format_ident!(
@@ -160,11 +161,12 @@ pub(super) fn generate_enum_variant_definitions(
             Fields::Unit => {
                 let variant_name =
                     naming::enum_variant_name(&variant.attrs, &variant.ident, rename_all)?;
+                let variant_name_str = variant_name.as_str();
                 let comments = utils::extract_doc_comments(&variant.attrs);
                 let comment_objects = generate_comment_objects(&comments, crate_path);
                 let variant_ref = quote! {
                     &#crate_path::idl::EnumVariant::new(
-                        #variant_name,
+                        #variant_name_str,
                         &[#(#comment_objects),*]
                     )
                 };

--- a/zlink-macros/src/introspect/type.rs
+++ b/zlink-macros/src/introspect/type.rs
@@ -29,7 +29,7 @@ fn derive_type_impl(input: DeriveInput) -> Result<TokenStream2, Error> {
         "`#[zlink(rename)]` has no effect on the `Type` derive, which generates an anonymous \
          object type. Derive `CustomType` instead if the type needs a name in the IDL.",
     )?;
-    let rename_all = naming::parse_rename_all(&input.attrs, naming::Grammar::Field)?;
+    let rename_all = naming::RenameAllParser::new(&input.attrs).try_for_field_name()?;
 
     let expanded = match &input.data {
         Data::Struct(data_struct) => {

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -1687,7 +1687,7 @@ pub fn derive_reply_error(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 /// # let mut conn = zlink::Connection::new(socket);
 /// let desc = conn.get_interface_description("org.example.bank").await?.unwrap();
 /// let interface = desc.parse()?;
-/// assert_eq!(interface.name(), "org.example.bank");
+/// assert_eq!(interface.name().as_str(), "org.example.bank");
 ///
 /// // Verify methods are present.
 /// let method_names: Vec<_> = interface.methods().map(|m| m.name()).collect();

--- a/zlink-macros/src/lib.rs
+++ b/zlink-macros/src/lib.rs
@@ -554,8 +554,9 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 ///   `kebab-case`, `SCREAMING-KEBAB-CASE`. systemd's Varlink APIs, for instance, use `camelCase`
 ///   argument names (with `PascalCase` where a name mirrors a documented option name), so a proxy
 ///   for one typically wants `rename_all_arguments = "camelCase"`. Per-argument `#[zlink(rename =
-///   "...")]` takes precedence over `rename_all_arguments`. Every produced name must still fit the
-///   Varlink field-name grammar (`[A-Za-z][A-Za-z0-9_]*`), so a convention that steps outside it --
+///   "...")]` takes precedence over `rename_all_arguments`. Every argument name must fit the
+///   Varlink field-name grammar (`[A-Za-z][A-Za-z0-9_]*`) -- whether it's produced by a convention,
+///   given explicitly, or just left as the Rust ident -- so a convention that steps outside it --
 ///   `kebab-case` on a multi-word argument, say -- is rejected at compile time:
 ///
 /// ```rust,compile_fail
@@ -564,6 +565,20 @@ pub fn derive_introspect_reply_error(input: proc_macro::TokenStream) -> proc_mac
 /// trait ConfigProxy {
 ///     // `dry_run` would become `dry-run`, which Varlink cannot express.
 ///     async fn set_config(&mut self, dry_run: bool) -> zlink::Result<Result<(), MyError>>;
+/// }
+/// # #[derive(Debug, serde::Serialize, serde::Deserialize)]
+/// # enum MyError {}
+/// ```
+///
+/// and an argument left unrenamed still has to be a name Varlink can express:
+///
+/// ```rust,compile_fail
+/// # use zlink::proxy;
+/// #[proxy(interface = "org.example.Config")]
+/// trait ConfigProxy {
+///     // A leading underscore marks "unused" in Rust, but Varlink field names can't start with
+///     // `_`, and there's no rename here to give it a wire-safe name instead.
+///     async fn set_config(&mut self, _dry_run: bool) -> zlink::Result<Result<(), MyError>>;
 /// }
 /// # #[derive(Debug, serde::Serialize, serde::Deserialize)]
 /// # enum MyError {}

--- a/zlink-macros/src/naming.rs
+++ b/zlink-macros/src/naming.rs
@@ -62,7 +62,7 @@ pub(crate) fn validate(
 /// notation.
 pub(crate) fn validate_interface(lit: &LitStr) -> Result<(), Error> {
     let name = lit.value();
-    if !zlink_idl::is_valid_interface_name(&name) {
+    if !zlink_names::is_valid_interface_name(&name) {
         return Err(Error::new_spanned(
             lit,
             format!(

--- a/zlink-macros/src/naming.rs
+++ b/zlink-macros/src/naming.rs
@@ -1,19 +1,9 @@
-use syn::{Attribute, Error, Ident, LitStr};
-use zlink_names::OwnedInterfaceName;
-
 use crate::utils::skip_unknown_meta;
-
-/// The grammar a resolved Varlink name must follow.
-///
-/// Varlink names fields, parameters and enum variants one way, and types, methods and errors
-/// another, so every name falls under one of these two rules.
-#[derive(Debug, Clone, Copy)]
-pub(crate) enum Grammar {
-    /// The field-name rule, `[A-Za-z][A-Za-z0-9_]*`. Fields, parameters and enum variants.
-    Field,
-    /// The type-name rule, `[A-Z][A-Za-z0-9]*`. Types, methods and errors.
-    Type,
-}
+use std::fmt::Debug;
+use syn::{Attribute, Error, Ident, LitStr};
+use zlink_names::{
+    FieldName, FromPattern, OwnedFieldName, OwnedInterfaceName, OwnedTypeName, TypeName,
+};
 
 /// Where a resolved name came from, which decides what a rejection points at and suggests.
 #[derive(Debug, Clone, Copy)]
@@ -29,13 +19,14 @@ pub(crate) enum NameSource<'a> {
 /// Only ever called on a *resolved* name: unrawing and `rename`/`rename_all` decide what a thing is
 /// called, and this decides whether that answer is sayable. Checking any earlier would reject
 /// perfectly good Rust, e.g. `r#type`, which resolves to the valid `type`.
-pub(crate) fn validate(
-    name: &str,
-    grammar: Grammar,
-    what: &str,
-    source: NameSource<'_>,
-) -> Result<(), Error> {
-    if !grammar.accepts(name) {
+pub(crate) fn validate<'a, T>(name: &'a str, what: &str, source: NameSource<'_>) -> Result<T, Error>
+where
+    T: TryFrom<&'a str>,
+    T: FromPattern,
+    <T as TryFrom<&'a str>>::Error: Debug,
+{
+    let validation_result = T::try_from(name);
+    if validation_result.is_err() {
         // Pointing at the rename literal is precise enough on its own; suggesting a rename to
         // someone who just wrote one would only be noise.
         let hint = match source {
@@ -44,7 +35,7 @@ pub(crate) fn validate(
         };
         let msg = format!(
             "`{name}` is not a valid Varlink {what}: it must match `{}`{hint}",
-            grammar.pattern(),
+            T::from_pattern(),
         );
 
         return Err(match source {
@@ -53,7 +44,7 @@ pub(crate) fn validate(
         });
     }
 
-    Ok(())
+    Ok(validation_result.unwrap())
 }
 
 /// Reject an interface name Varlink cannot express, reporting against `lit`'s span.
@@ -75,24 +66,6 @@ pub(crate) fn validate_interface(lit: &LitStr) -> Result<OwnedInterfaceName, Err
     }
 
     Ok(valid_name.unwrap())
-}
-
-impl Grammar {
-    /// Whether Varlink can express `name` under this rule.
-    fn accepts(self, name: &str) -> bool {
-        match self {
-            Self::Field => zlink_idl::is_valid_field_name(name),
-            Self::Type => zlink_idl::is_valid_type_name(name),
-        }
-    }
-
-    /// The rule as it reads in the Varlink specification.
-    fn pattern(self) -> &'static str {
-        match self {
-            Self::Field => "[A-Za-z][A-Za-z0-9_]*",
-            Self::Type => "[A-Z][A-Za-z0-9]*",
-        }
-    }
 }
 
 /// The case convention requested by `#[zlink(rename_all = "...")]`.
@@ -173,21 +146,6 @@ impl RenameAll {
         }
     }
 
-    /// Whether this convention could ever produce a name valid under `grammar`.
-    ///
-    /// Some conventions can satisfy a grammar for no input at all: `snake_case`, say, always
-    /// lowercases the first character, which the type-name rule (uppercase-first) rejects for
-    /// every possible name. Offering such a pairing is a footgun, so it is refused up front rather
-    /// than left for the per-name check to reject one produced name at a time.
-    ///
-    /// Probing a single-word sample rather than re-encoding that reasoning keeps the parser the one
-    /// authority on the grammar: a word carries the first-character and character-set rules without
-    /// the separators that only longer names introduce, so if a convention cannot make even this
-    /// fit, no name ever will.
-    fn can_produce(self, grammar: Grammar) -> bool {
-        grammar.accepts(&self.apply_to_variant("Word"))
-    }
-
     pub(crate) fn parse(lit: &LitStr) -> Result<Self, Error> {
         let rule = match lit.value().as_str() {
             "lowercase" => Self::Lower,
@@ -220,13 +178,12 @@ pub(crate) fn field_name(
     attrs: &[Attribute],
     ident: &Ident,
     rename_all: Option<RenameAll>,
-) -> Result<String, Error> {
+) -> Result<OwnedFieldName, Error> {
     resolve(
         attrs,
         ident,
         rename_all,
         RenameAll::apply_to_field,
-        Grammar::Field,
         "field name",
     )
 }
@@ -239,13 +196,12 @@ pub(crate) fn enum_variant_name(
     attrs: &[Attribute],
     ident: &Ident,
     rename_all: Option<RenameAll>,
-) -> Result<String, Error> {
+) -> Result<OwnedFieldName, Error> {
     resolve(
         attrs,
         ident,
         rename_all,
         RenameAll::apply_to_variant,
-        Grammar::Field,
         "enum variant name",
     )
 }
@@ -261,13 +217,12 @@ pub(crate) fn error_name(
     attrs: &[Attribute],
     ident: &Ident,
     rename_all: Option<RenameAll>,
-) -> Result<String, Error> {
+) -> Result<OwnedTypeName, Error> {
     resolve(
         attrs,
         ident,
         rename_all,
         RenameAll::apply_to_variant,
-        Grammar::Type,
         "error name",
     )
 }
@@ -282,34 +237,81 @@ pub(crate) fn reject_container_rename(attrs: &[Attribute], msg: &str) -> Result<
     }
 }
 
-/// The container's `#[zlink(rename_all = "...")]`, if any, checked against `grammar`.
+/// The container's `#[zlink(rename_all = "...")]`, if any, checked against a grammar picked by
+/// whichever terminal method is called.
 ///
-/// A convention that could never produce a name valid under `grammar` -- `snake_case` where a type
-/// name is wanted, say -- is rejected here, against the attribute's own span, rather than left for
-/// the per-name check to reject one produced name at a time.
-pub(crate) fn parse_rename_all(
-    attrs: &[Attribute],
-    grammar: Grammar,
-) -> Result<Option<RenameAll>, Error> {
-    let Some(lit) = parse_zlink_lit_str(attrs, "rename_all")? else {
-        return Ok(None);
-    };
+/// Only two grammars ever apply -- field/variant names and type names -- so rather than a generic
+/// parameter callers would have to turbofish (it never appears in the return type, so it can never
+/// be inferred), the grammar is hardcoded by which terminal method is called.
+pub(crate) struct RenameAllParser<'a> {
+    attrs: &'a [Attribute],
+}
 
-    let rule = RenameAll::parse(&lit)?;
-    if !rule.can_produce(grammar) {
-        return Err(Error::new_spanned(
-            &lit,
-            format!(
-                "`{}` can never produce a name matching the Varlink grammar `{}`, so it cannot \
-                 apply here. Drop `rename_all`, use a convention that fits (e.g. `UPPERCASE` or \
-                 `PascalCase`), or name items individually with `#[zlink(rename = \"...\")]`",
-                lit.value(),
-                grammar.pattern(),
-            ),
-        ));
+impl<'a> RenameAllParser<'a> {
+    pub(crate) fn new(attrs: &'a [Attribute]) -> Self {
+        Self { attrs }
     }
 
-    Ok(Some(rule))
+    /// Checked against the field/variant grammar (`snake_case`-sourced, lowercase-first).
+    pub(crate) fn try_for_field_name(self) -> Result<Option<RenameAll>, Error> {
+        self.parse(
+            |rule| FieldName::try_from(rule.apply_to_variant("Word").as_str()).is_ok(),
+            FieldName::from_pattern(),
+        )
+    }
+
+    /// Checked against the type grammar (`PascalCase`-sourced, uppercase-first).
+    pub(crate) fn try_for_type_name(self) -> Result<Option<RenameAll>, Error> {
+        self.parse(
+            |rule| TypeName::try_from(rule.apply_to_variant("Word").as_str()).is_ok(),
+            TypeName::from_pattern(),
+        )
+    }
+
+    /// A convention that could never produce a name valid under `pattern` -- `snake_case` where a
+    /// type name is wanted, say -- is rejected here, against the attribute's own span, rather than
+    /// left for the per-name check to reject one produced name at a time.
+    ///
+    /// Probing a single-word sample rather than re-encoding that reasoning keeps the parser the one
+    /// authority on the grammar: a word carries the first-character and character-set rules without
+    /// the separators that only longer names introduce, so if a convention cannot make even this
+    /// fit, no name ever will.
+    fn parse(
+        self,
+        can_produce: impl Fn(RenameAll) -> bool,
+        pattern: &'static str,
+    ) -> Result<Option<RenameAll>, Error> {
+        let Some(lit) = parse_zlink_lit_str(self.attrs, "rename_all")? else {
+            return Ok(None);
+        };
+
+        let rule = RenameAll::parse(&lit)?;
+        // Whether this convention could ever produce a name valid for the used parser.
+        //
+        // Some conventions can satisfy a grammar for no input at all: `snake_case`, say, always
+        // lowercases the first character, which the type-name rule (uppercase-first) rejects for
+        // every possible name. Offering such a pairing is a footgun, so it is refused up front
+        // rather than left for the per-name check to reject one produced name at a time.
+        //
+        // Probing a single-word sample rather than re-encoding that reasoning keeps the parser the
+        // one authority on the grammar: a word carries the first-character and
+        // character-set rules without the separators that only longer names introduce, so
+        // if a convention cannot make even this fit, no name ever will.
+        if !can_produce(rule) {
+            return Err(Error::new_spanned(
+                &lit,
+                format!(
+                    "`{}` can never produce a name matching the Varlink grammar `{pattern}`, so it \
+                     cannot apply here. Drop `rename_all`, use a convention that fits (e.g. \
+                     `UPPERCASE` or `PascalCase`), or name items individually with \
+                     `#[zlink(rename = \"...\")]`",
+                    lit.value(),
+                ),
+            ));
+        }
+
+        Ok(Some(rule))
+    }
 }
 
 /// The item's `#[zlink(rename = "...")]`, if any.
@@ -330,24 +332,24 @@ pub(crate) fn unraw(ident: &Ident) -> String {
     }
 }
 
-fn resolve<F>(
+fn resolve<'a, T, F>(
     attrs: &[Attribute],
     ident: &Ident,
     rename_all: Option<RenameAll>,
     apply: F,
-    grammar: Grammar,
-    what: &str,
-) -> Result<String, Error>
+    what: &'a str,
+) -> Result<T, Error>
 where
+    T: for<'x> TryFrom<&'x str>,
+    T: FromPattern,
     F: FnOnce(RenameAll, &str) -> String,
+    for<'x> <T as TryFrom<&'x str>>::Error: Debug,
 {
     // An explicit rename is a name the user wrote out, so it is taken verbatim -- mangling it would
     // defeat the point of the attribute -- but it still has to be a name Varlink can say.
     if let Some(lit) = parse_rename(attrs)? {
         let name = lit.value();
-        validate(&name, grammar, what, NameSource::Rename(&lit))?;
-
-        return Ok(name);
+        return validate(&name, what, NameSource::Rename(&lit));
     }
 
     let unrawed = unraw(ident);
@@ -355,9 +357,7 @@ where
         Some(rule) => apply(rule, &unrawed),
         None => unrawed,
     };
-    validate(&name, grammar, what, NameSource::Ident(ident))?;
-
-    Ok(name)
+    validate(&name, what, NameSource::Ident(ident))
 }
 
 /// The string value of `#[zlink(<key> = "...")]`, if present.
@@ -452,7 +452,7 @@ mod tests {
         let ident: Ident = parse_quote!(user_id);
         let name = field_name(&attrs, &ident, Some(RenameAll::Camel)).unwrap();
 
-        assert_eq!(name, "ID");
+        assert_eq!(name.as_ref().as_str(), "ID");
     }
 
     #[test]
@@ -461,7 +461,7 @@ mod tests {
         let ident: Ident = parse_quote!(user_id);
         let name = field_name(&attrs, &ident, Some(RenameAll::Camel)).unwrap();
 
-        assert_eq!(name, "userId");
+        assert_eq!(name.as_ref().as_str(), "userId");
     }
 
     #[test]
@@ -469,7 +469,10 @@ mod tests {
         let attrs: Vec<Attribute> = vec![];
         let ident: Ident = parse_quote!(user_id);
 
-        assert_eq!(field_name(&attrs, &ident, None).unwrap(), "user_id");
+        assert_eq!(
+            field_name(&attrs, &ident, None).unwrap().as_ref().as_str(),
+            "user_id"
+        );
     }
 
     #[test]
@@ -492,7 +495,7 @@ mod tests {
             vec![parse_quote!(#[zlink(crate = "crate", rename_all = "camelCase")])];
 
         assert_eq!(
-            parse_rename_all(&attrs, Grammar::Field).unwrap(),
+            RenameAllParser::new(&attrs).try_for_field_name().unwrap(),
             Some(RenameAll::Camel)
         );
     }
@@ -500,7 +503,8 @@ mod tests {
     #[test]
     fn unknown_rename_all_value_rejected() {
         let attrs: Vec<Attribute> = vec![parse_quote!(#[zlink(rename_all = "bogus")])];
-        let err = parse_rename_all(&attrs, Grammar::Field)
+        let err = RenameAllParser::new(&attrs)
+            .try_for_field_name()
             .unwrap_err()
             .to_string();
 
@@ -531,7 +535,10 @@ mod tests {
         let attrs: Vec<Attribute> = vec![];
         let ident: Ident = parse_quote!(r#type);
 
-        assert_eq!(field_name(&attrs, &ident, None).unwrap(), "type");
+        assert_eq!(
+            field_name(&attrs, &ident, None).unwrap().as_ref().as_str(),
+            "type"
+        );
     }
 
     /// The error-name counterpart: `r#Fn` unraws to the valid error name `Fn`.
@@ -540,7 +547,10 @@ mod tests {
         let attrs: Vec<Attribute> = vec![];
         let ident: Ident = parse_quote!(r#Fn);
 
-        assert_eq!(error_name(&attrs, &ident, None).unwrap(), "Fn");
+        assert_eq!(
+            error_name(&attrs, &ident, None).unwrap().as_ref().as_str(),
+            "Fn"
+        );
     }
 
     /// Enum variants follow field rules, which admit a lowercase first letter.
@@ -551,7 +561,10 @@ mod tests {
         let ident: Ident = parse_quote!(Active);
 
         assert_eq!(
-            enum_variant_name(&attrs, &ident, Some(RenameAll::Lower)).unwrap(),
+            enum_variant_name(&attrs, &ident, Some(RenameAll::Lower))
+                .unwrap()
+                .as_ref()
+                .as_str(),
             "active"
         );
     }
@@ -627,7 +640,7 @@ mod tests {
             vec![parse_quote!(#[zlink(rename_all = "SCREAMING_SNAKE_CASE")])];
 
         assert_eq!(
-            parse_rename_all(&attrs, Grammar::Type).unwrap(),
+            RenameAllParser::new(&attrs).try_for_type_name().unwrap(),
             Some(RenameAll::ScreamingSnake)
         );
     }
@@ -637,7 +650,8 @@ mod tests {
     #[test]
     fn rename_all_that_never_fits_the_type_grammar_is_rejected() {
         let attrs: Vec<Attribute> = vec![parse_quote!(#[zlink(rename_all = "snake_case")])];
-        let err = parse_rename_all(&attrs, Grammar::Type)
+        let err = RenameAllParser::new(&attrs)
+            .try_for_type_name()
             .unwrap_err()
             .to_string();
 
@@ -658,7 +672,10 @@ mod tests {
         for value in VALID_RENAME_ALL {
             let attr: Attribute = parse_quote!(#[zlink(rename_all = #value)]);
             assert!(
-                parse_rename_all(&[attr], Grammar::Field).unwrap().is_some(),
+                RenameAllParser::new(&[attr])
+                    .try_for_field_name()
+                    .unwrap()
+                    .is_some(),
                 "`{value}` should be accepted for a field name"
             );
         }

--- a/zlink-macros/src/naming.rs
+++ b/zlink-macros/src/naming.rs
@@ -1,4 +1,5 @@
 use syn::{Attribute, Error, Ident, LitStr};
+use zlink_names::OwnedInterfaceName;
 
 use crate::utils::skip_unknown_meta;
 
@@ -60,19 +61,20 @@ pub(crate) fn validate(
 /// Kept apart from [`validate`]: an interface name is always a literal the user wrote out (never a
 /// resolved ident), and its grammar is neither the field nor the type rule but reverse-domain
 /// notation.
-pub(crate) fn validate_interface(lit: &LitStr) -> Result<(), Error> {
+pub(crate) fn validate_interface(lit: &LitStr) -> Result<OwnedInterfaceName, Error> {
     let name = lit.value();
-    if !zlink_names::is_valid_interface_name(&name) {
+    let valid_name = OwnedInterfaceName::try_from(name.clone());
+    if let Err(_err) = valid_name {
         return Err(Error::new_spanned(
             lit,
             format!(
                 "`{name}` is not a valid Varlink interface name: it must be in reverse-domain \
-                 notation, e.g. `org.example.Foo`"
+             notation, e.g. `org.example.Foo`"
             ),
         ));
     }
 
-    Ok(())
+    Ok(valid_name.unwrap())
 }
 
 impl Grammar {

--- a/zlink-macros/src/proxy.rs
+++ b/zlink-macros/src/proxy.rs
@@ -2,6 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use std::collections::HashMap;
 use syn::{Error, FnArg, ItemTrait, Lit, Pat, TraitItem, parse::Parser, parse2};
+use zlink_names::OwnedInterfaceName;
 
 mod chain_extension;
 mod chain_method;
@@ -136,7 +137,7 @@ fn parse_proxy_attributes(
     trait_def: &ItemTrait,
 ) -> Result<
     (
-        String,
+        OwnedInterfaceName,
         TokenStream,
         Option<syn::Ident>,
         Option<crate::naming::RenameAll>,
@@ -153,7 +154,13 @@ fn parse_proxy_attributes(
 
     // Try parsing as a simple string literal first (backward compatibility)
     if let Ok(Lit::Str(lit_str)) = parse2::<Lit>(attr.clone()) {
-        return Ok((lit_str.value(), quote! { ::zlink }, None, None));
+        return Ok((
+            OwnedInterfaceName::try_from(lit_str.value())
+                .map_err(|e| Error::new_spanned(&lit_str, e))?,
+            quote! { ::zlink },
+            None,
+            None,
+        ));
     }
 
     // Parse as name-value pairs
@@ -165,8 +172,8 @@ fn parse_proxy_attributes(
     let parser = syn::meta::parser(|meta| {
         if meta.path.is_ident("interface") {
             let value: syn::LitStr = meta.value()?.parse()?;
-            crate::naming::validate_interface(&value)?;
-            interface_name = Some(value.value());
+            let validated_name = crate::naming::validate_interface(&value)?;
+            interface_name = Some(validated_name);
         } else if meta.path.is_ident("crate") {
             let value: syn::LitStr = meta.value()?.parse()?;
             let path_str = value.value();

--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Error, FnArg, Pat};
+use zlink_names::InterfaceName;
 
 use super::{
     types::{ArgInfo, MethodAttrs},
@@ -10,9 +11,9 @@ use super::{
     },
 };
 
-pub(super) fn generate_chain_extension_method(
+pub(super) fn generate_chain_extension_method<'name>(
     method: &mut syn::TraitItemFn,
-    interface_name: &str,
+    interface_name: &InterfaceName<'name>,
     _trait_generics: &syn::Generics,
     method_attrs: &MethodAttrs,
     crate_path: &TokenStream,

--- a/zlink-macros/src/proxy/chain_extension.rs
+++ b/zlink-macros/src/proxy/chain_extension.rs
@@ -105,7 +105,8 @@ pub(super) fn generate_chain_extension_method<'name>(
             let name = info.name;
             let ty = &info.ty_for_params;
             let serde_attrs = if let Some(ref renamed) = info.serialized_name {
-                quote! { #[serde(rename = #renamed)] }
+                let renamed_str = renamed.as_str();
+                quote! { #[serde(rename = #renamed_str)] }
             } else {
                 quote! {}
             };

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Error, FnArg, Pat};
+use zlink_names::InterfaceName;
 
 use super::{
     types::{ArgInfo, MethodAttrs},
@@ -15,9 +16,9 @@ type MethodCallResult = (TokenStream, TokenStream);
 #[cfg(not(feature = "std"))]
 type MethodCallResult = TokenStream;
 
-pub(super) fn generate_chain_method(
+pub(super) fn generate_chain_method<'name>(
     method: &mut syn::TraitItemFn,
-    interface_name: &str,
+    interface_name: &InterfaceName<'name>,
     _trait_generics: &syn::Generics,
     method_attrs: &MethodAttrs,
     crate_path: &TokenStream,

--- a/zlink-macros/src/proxy/chain_method.rs
+++ b/zlink-macros/src/proxy/chain_method.rs
@@ -247,7 +247,8 @@ fn generate_method_call_creation(
                 let name = info.name;
                 let ty = &info.ty_for_params;
                 let serde_attrs = if let Some(ref renamed) = info.serialized_name {
-                    quote! { #[serde(rename = #renamed)] }
+                    let rename_str = renamed.as_str();
+                    quote! { #[serde(rename = #rename_str)] }
                 } else {
                     quote! {}
                 };

--- a/zlink-macros/src/proxy/method_impl.rs
+++ b/zlink-macros/src/proxy/method_impl.rs
@@ -2,6 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use std::collections::HashSet;
 use syn::{Error, FnArg, Pat, Type, punctuated::Punctuated};
+use zlink_names::InterfaceName;
 
 use super::{
     types::{ArgInfo, MethodAttrs},
@@ -12,9 +13,9 @@ use super::{
 };
 use crate::utils::is_option_type;
 
-pub(super) fn generate_method_impl(
+pub(super) fn generate_method_impl<'name>(
     method: &mut syn::TraitItemFn,
-    interface_name: &str,
+    interface_name: &InterfaceName<'name>,
     trait_generics: &syn::Generics,
     method_attrs: &MethodAttrs,
     crate_path: &TokenStream,

--- a/zlink-macros/src/proxy/method_impl.rs
+++ b/zlink-macros/src/proxy/method_impl.rs
@@ -333,13 +333,14 @@ fn generate_method_params(
                 let ty = &info.ty_for_params;
 
                 let serde_attrs = if let Some(ref renamed) = info.serialized_name {
+                    let renamed_str = renamed.as_str();
                     if info.is_optional {
                         quote! {
-                            #[serde(rename = #renamed, skip_serializing_if = "Option::is_none")]
+                            #[serde(rename = #renamed_str, skip_serializing_if = "Option::is_none")]
                         }
                     } else {
                         quote! {
-                            #[serde(rename = #renamed)]
+                            #[serde(rename = #renamed_str)]
                         }
                     }
                 } else if info.is_optional {

--- a/zlink-macros/src/proxy/types.rs
+++ b/zlink-macros/src/proxy/types.rs
@@ -1,4 +1,5 @@
 use syn::{Attribute, Error, Meta};
+use zlink_names::OwnedFieldName;
 
 use super::utils::{extract_zlink_attrs, parse_rename_value};
 
@@ -65,6 +66,6 @@ pub(super) struct ArgInfo<'a> {
     pub ty_for_params: syn::Type,
     pub has_lifetime: bool,
     pub is_optional: bool,
-    pub serialized_name: Option<String>,
+    pub serialized_name: Option<OwnedFieldName>,
     pub is_fds: bool,
 }

--- a/zlink-macros/src/proxy/utils.rs
+++ b/zlink-macros/src/proxy/utils.rs
@@ -1,5 +1,5 @@
 use crate::{
-    naming::{self, Grammar, NameSource, RenameAll},
+    naming::{self, NameSource, RenameAll},
     utils::*,
 };
 use std::collections::HashSet;
@@ -7,6 +7,7 @@ use syn::{
     Attribute, Error, Expr, GenericArgument, Ident, Lit, Meta, PathArguments, ReturnType, Type,
     punctuated::Punctuated,
 };
+use zlink_names::{FieldName, OwnedFieldName};
 
 /// Convert snake_case to PascalCase.
 pub(super) fn snake_case_to_pascal_case(input: &str) -> String {
@@ -177,24 +178,32 @@ pub(super) fn resolve_serialized_name(
     ident: &Ident,
     param_attrs: Option<&ParamAttrs>,
     rename_all: Option<RenameAll>,
-) -> Result<Option<String>, Error> {
+) -> Result<Option<OwnedFieldName>, Error> {
     if let Some(rename) = param_attrs.and_then(|attrs| attrs.rename.clone()) {
-        return Ok(Some(rename));
+        return Ok(Some(naming::validate(
+            &rename,
+            "renamed parameter name",
+            NameSource::Ident(ident),
+        )?));
     }
 
     let Some(rule) = rename_all else {
+        // Not renamed, so nothing to emit `#[serde(rename = ...)]` for -- but the ident's own
+        // name still has to be a name Varlink can express.
+        let _: FieldName<'_> = naming::validate(
+            &naming::unraw(ident),
+            "parameter name",
+            NameSource::Ident(ident),
+        )?;
         return Ok(None);
     };
 
     let name = rule.apply_to_field(&naming::unraw(ident));
-    naming::validate(
+    Ok(Some(naming::validate(
         &name,
-        Grammar::Field,
         "parameter name",
         NameSource::Ident(ident),
-    )?;
-
-    Ok(Some(name))
+    )?))
 }
 
 /// Extract parameter attributes from zlink attributes and remove processed attributes.
@@ -690,7 +699,7 @@ mod tests {
         let ident: Ident = parse_quote!(r#type);
         let name = resolve_serialized_name(&ident, None, Some(RenameAll::Pascal)).unwrap();
 
-        assert_eq!(name.as_deref(), Some("Type"));
+        assert_eq!(name.as_deref().map(|n| n.as_str()), Some("Type"));
     }
 
     #[test]
@@ -702,7 +711,7 @@ mod tests {
         };
         let name = resolve_serialized_name(&ident, Some(&attrs), Some(RenameAll::Pascal)).unwrap();
 
-        assert_eq!(name.as_deref(), Some("customName"));
+        assert_eq!(name.as_deref().map(|n| n.as_str()), Some("customName"));
     }
 
     #[test]
@@ -722,5 +731,19 @@ mod tests {
             .to_string();
 
         assert!(err.contains("`dry-run`"), "must name the bad name: {err}");
+    }
+
+    /// Rust idents that the Varlink field grammar rejects must fail even with no rename rule at
+    /// all -- `None` is not a license to skip validation.
+    #[test]
+    fn unrenamed_ident_still_validated() {
+        for bad in ["_foo", "foo_", "foo__bar"] {
+            let ident: Ident = syn::parse_str(bad).unwrap();
+            let err = resolve_serialized_name(&ident, None, None)
+                .unwrap_err()
+                .to_string();
+
+            assert!(err.contains(&format!("`{bad}`")), "for {bad}: {err}");
+        }
     }
 }

--- a/zlink-macros/src/reply_error.rs
+++ b/zlink-macros/src/reply_error.rs
@@ -1,6 +1,7 @@
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Data, DataEnum, DeriveInput, Error, Fields, FieldsNamed, parse_quote};
+use zlink_names::OwnedFieldName;
 
 use crate::{
     naming::{self, RenameAll},
@@ -131,7 +132,7 @@ fn generate_serialize_impl(
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
     let has_lifetimes = !generics.lifetimes().collect::<Vec<_>>().is_empty();
 
-    let rename_all = naming::parse_rename_all(input_attrs, naming::Grammar::Type)?;
+    let rename_all = naming::RenameAllParser::new(input_attrs).try_for_type_name()?;
     // Generate match arms for each variant (empty for empty enums).
     let variant_arms = data_enum
         .variants
@@ -171,7 +172,7 @@ fn generate_serialize_variant_arm(
     let variant_name = &variant.ident;
     let resolved = naming::error_name(&variant.attrs, variant_name, rename_all)?;
     let qualified_name = format!("{interface}.{resolved}");
-    let field_rename_all = naming::parse_rename_all(&variant.attrs, naming::Grammar::Field)?;
+    let field_rename_all = naming::RenameAllParser::new(&variant.attrs).try_for_field_name()?;
 
     match &variant.fields {
         // Unit variant - serialize as tagged enum with just error field.
@@ -186,10 +187,14 @@ fn generate_serialize_variant_arm(
         Fields::Named(fields) => {
             // Named fields - serialize as tagged enum with parameters.
             let field_info = FieldInfo::extract(fields, field_rename_all)?;
-            let field_count = field_info.names.len();
-            let field_names = &field_info.names;
+            let field_count = field_info.token_names.len();
+            let field_names = &field_info.token_names;
             let field_types = &field_info.types;
-            let field_name_strs = &field_info.name_strings;
+            let field_name_strs = &field_info
+                .field_names
+                .iter()
+                .map(|n| n.as_str())
+                .collect::<Vec<_>>();
 
             // Convert field types to use synthetic lifetime for ParametersSerializer
             // only if enum has lifetimes.
@@ -260,7 +265,8 @@ fn generate_deserialize_with_derive(
         .iter()
         .map(|variant| match &variant.fields {
             Fields::Named(fields) => {
-                let rename_all = naming::parse_rename_all(&variant.attrs, naming::Grammar::Field)?;
+                let rename_all =
+                    naming::RenameAllParser::new(&variant.attrs).try_for_field_name()?;
                 FieldInfo::extract(fields, rename_all).map(Some)
             }
             _ => Ok(None),
@@ -270,7 +276,7 @@ fn generate_deserialize_with_derive(
     // Clone and modify the enum to add serde attributes.
     let mut modified_enum = data_enum.clone();
 
-    let rename_all = naming::parse_rename_all(&input.attrs, naming::Grammar::Type)?;
+    let rename_all = naming::RenameAllParser::new(&input.attrs).try_for_type_name()?;
 
     // Now modify the variants.
     for (i, variant) in modified_enum.variants.iter_mut().enumerate() {
@@ -290,11 +296,12 @@ fn generate_deserialize_with_derive(
             let iter = fields
                 .named
                 .iter_mut()
-                .zip(&field_info.name_strings)
+                .zip(&field_info.field_names)
                 .zip(&field_info.borrow_flags);
-            for ((field, name_str), &borrow) in iter {
+            for ((field, field_name), &borrow) in iter {
                 // Remove zlink attributes and add serde equivalents.
                 field.attrs.retain(|attr| !attr.path().is_ident("zlink"));
+                let name_str = field_name.as_str();
                 field.attrs.push(parse_quote!(#[serde(rename = #name_str)]));
                 if borrow {
                     field.attrs.push(parse_quote!(#[serde(borrow)]));
@@ -384,18 +391,18 @@ fn generate_deserialize_with_derive(
 /// Field information extracted from named fields for reuse across
 /// serialization/deserialization.
 struct FieldInfo<'a> {
-    names: Vec<&'a syn::Ident>,
+    token_names: Vec<&'a syn::Ident>,
     types: Vec<&'a syn::Type>,
-    name_strings: Vec<String>,
+    field_names: Vec<OwnedFieldName>,
     borrow_flags: Vec<bool>,
 }
 
 impl<'a> FieldInfo<'a> {
     /// Extract field information from named fields to avoid duplication.
     fn extract(fields: &'a FieldsNamed, rename_all: Option<RenameAll>) -> Result<Self, Error> {
-        let mut names = Vec::new();
+        let mut token_names = Vec::new();
         let mut types = Vec::new();
-        let mut name_strings = Vec::new();
+        let mut field_names = Vec::new();
         let mut borrow_flags = Vec::new();
 
         for field in &fields.named {
@@ -403,16 +410,16 @@ impl<'a> FieldInfo<'a> {
                 continue;
             };
 
-            names.push(name);
+            token_names.push(name);
             types.push(&field.ty);
-            name_strings.push(naming::field_name(&field.attrs, name, rename_all)?);
+            field_names.push(naming::field_name(&field.attrs, name, rename_all)?);
             borrow_flags.push(has_zlink_bool_attr(&field.attrs, "borrow"));
         }
 
         Ok(Self {
-            names,
+            token_names,
             types,
-            name_strings,
+            field_names,
             borrow_flags,
         })
     }

--- a/zlink-macros/src/service/attrs.rs
+++ b/zlink-macros/src/service/attrs.rs
@@ -6,6 +6,7 @@ use syn::{
     Error, ItemImpl,
     parse::{Parse, Parser},
 };
+use zlink_names::OwnedInterfaceName;
 
 /// Attributes parsed from the `#[service(...)]` macro invocation.
 pub(super) struct ServiceAttrs {
@@ -14,7 +15,7 @@ pub(super) struct ServiceAttrs {
     /// Custom types for introspection.
     pub custom_types: Vec<syn::Type>,
     /// Default interface name for all methods.
-    pub interface: Option<String>,
+    pub interface: Option<OwnedInterfaceName>,
     /// Service vendor name.
     pub vendor: Option<syn::Expr>,
     /// Service product name.
@@ -51,8 +52,8 @@ impl ServiceAttrs {
                     custom_types = types.into_iter().collect();
                 } else if meta.path.is_ident("interface") {
                     let value: syn::LitStr = meta.value()?.parse()?;
-                    crate::naming::validate_interface(&value)?;
-                    interface = Some(value.value());
+                    let validated = crate::naming::validate_interface(&value)?;
+                    interface = Some(validated);
                 } else if meta.path.is_ident("vendor") {
                     let value: syn::Expr = meta.value()?.parse()?;
                     vendor = Some(value);

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -306,7 +306,7 @@ fn generate_method_call_enum(
         .iter()
         .filter_map(|method| {
             let full_path = method.full_method_path()?;
-            let variant_name = format_ident!("{}", method.varlink_name);
+            let variant_name = format_ident!("{}", method.varlink_name.as_str());
 
             // Only include serialized params (exclude connection params).
             let serialized_params: Vec<_> = method.serialized_params().collect();
@@ -781,7 +781,7 @@ fn generate_reply_stream_enum(
     let variants: Vec<TokenStream> = streaming_methods
         .iter()
         .map(|method| {
-            let variant_name = format_ident!("{}", method.varlink_name);
+            let variant_name = format_ident!("{}", method.varlink_name.as_str());
             let stream_type = method.stream_return_type.as_ref().unwrap();
             quote! {
                 #variant_name { #[pin] stream: #stream_type }
@@ -800,7 +800,7 @@ fn generate_reply_stream_enum(
     let poll_arms: Vec<TokenStream> = streaming_methods
         .iter()
         .map(|method| {
-            let variant_name = format_ident!("{}", method.varlink_name);
+            let variant_name = format_ident!("{}", method.varlink_name.as_str());
             let item_type = method.stream_item_type.as_ref().unwrap();
             let type_str = item_type.to_token_stream().to_string();
             let params_variant = stream_item_type_map
@@ -977,6 +977,7 @@ fn generate_interface_descriptions<'name>(
             .map(|(idx, method)| {
                 let method_const_name = format_ident!("__METHOD_{}", idx);
                 let method_name = &method.varlink_name;
+                let method_name_str = method_name.as_str();
 
                 // Input parameters (excluding connection params).
                 let in_params: Vec<TokenStream> = method
@@ -1079,7 +1080,7 @@ fn generate_interface_descriptions<'name>(
                             );
                         };
                         #crate_path::idl::Method::new(
-                            #method_name,
+                            #method_name_str,
                             __IN_PARAMS,
                             __OUT_PARAMS,
                             &[#(#comment_objects),*],
@@ -1259,7 +1260,7 @@ fn generate_handle_body(
             continue;
         };
 
-        let enum_variant_name = format_ident!("{}", method.varlink_name);
+        let enum_variant_name = format_ident!("{}", method.varlink_name.as_str());
         let method_name = &method.name;
 
         // Only include serialized params in the pattern (exclude connection params).
@@ -1374,7 +1375,7 @@ fn generate_handle_body(
                 .unwrap_or_else(|| format_ident!("__Unknown"));
 
             // Use the method's varlink name for the enum variant.
-            let method_variant_name = format_ident!("{}", method.varlink_name);
+            let method_variant_name = format_ident!("{}", method.varlink_name.as_str());
 
             let streaming_reply = if *needs_stream_boxing {
                 // Use boxing when any streaming method uses `impl Trait`.

--- a/zlink-macros/src/service/codegen.rs
+++ b/zlink-macros/src/service/codegen.rs
@@ -5,6 +5,7 @@ use std::collections::{HashMap, HashSet};
 use proc_macro2::{Ident, TokenStream};
 use quote::{ToTokens, format_ident, quote};
 use syn::{Error, GenericParam, ItemImpl, Type};
+use zlink_names::{InterfaceName, OwnedInterfaceName};
 
 use super::{attrs::ServiceAttrs, method::MethodInfo};
 use crate::utils::convert_type_lifetimes;
@@ -23,7 +24,7 @@ struct HandleBodyContext<'a> {
     reply_stream_name: &'a Ident,
     error_type_map: &'a HashMap<String, usize>,
     stream_item_type_map: &'a HashMap<String, Ident>,
-    interfaces: &'a [String],
+    interfaces: &'a [InterfaceName<'a>],
     type_name: &'a str,
     /// Whether streaming methods require boxing (any uses `impl Trait`).
     needs_stream_boxing: bool,
@@ -42,7 +43,7 @@ fn extract_type_name(ty: &Type) -> Option<String> {
 }
 
 /// Collect all unique interfaces from methods.
-fn collect_interfaces(methods_info: &[MethodInfo]) -> Vec<String> {
+fn collect_interfaces(methods_info: &[MethodInfo]) -> Vec<OwnedInterfaceName> {
     let mut seen = HashSet::new();
     let mut interfaces = Vec::new();
     for method in methods_info {
@@ -77,7 +78,7 @@ pub(super) fn generate_service_impl(
     let reply_stream_name = format_ident!("__{}ReplyStream", type_name);
 
     // Collect interfaces for introspection.
-    let interfaces = collect_interfaces(methods_info);
+    let owned_interface_names = collect_interfaces(methods_info);
 
     // Generate the MethodCall enum (outer untagged wrapper + inner user methods).
     let method_call_enum = generate_method_call_enum(
@@ -102,6 +103,11 @@ pub(super) fn generate_service_impl(
     // Error type is always the reply error enum (includes varlink_service::Error).
     // The lifetime 'ser is used in the Service trait definition.
     let error_type: syn::Type = syn::parse_quote!(#reply_error_name<'ser>);
+
+    let interfaces: Vec<InterfaceName<'_>> = owned_interface_names
+        .iter()
+        .map(|owned| owned.as_ref())
+        .collect();
 
     // Generate interface description constants.
     let interface_descriptions = generate_interface_descriptions(
@@ -906,10 +912,10 @@ fn generate_reply_params_enum(
 }
 
 /// Generate interface description constants for each interface.
-fn generate_interface_descriptions(
+fn generate_interface_descriptions<'name>(
     methods_info: &[MethodInfo],
     service_attrs: &ServiceAttrs,
-    interfaces: &[String],
+    interfaces: &[InterfaceName<'name>],
     crate_path: &TokenStream,
     type_name: &str,
     impl_comments: &[String],
@@ -917,16 +923,12 @@ fn generate_interface_descriptions(
     let mut descriptions: Vec<TokenStream> = Vec::new();
 
     for interface in interfaces {
-        let const_name = format_ident!(
-            "__{}_INTERFACE_{}",
-            type_name.to_uppercase(),
-            interface.replace('.', "_").to_uppercase()
-        );
+        let const_name = interface_name_to_ident(type_name, interface);
 
         // Collect methods for this interface.
         let interface_methods: Vec<&MethodInfo> = methods_info
             .iter()
-            .filter(|m| m.interface.as_ref() == Some(interface))
+            .filter(|m| m.interface.as_ref().map(|i| i.inner()) == Some(interface))
             .collect();
 
         // Collect custom types scoped to this interface from method-level `types = [...]`,
@@ -934,7 +936,7 @@ fn generate_interface_descriptions(
         let mut seen_custom_types = HashSet::new();
         let per_interface_types: Vec<&Type> = methods_info
             .iter()
-            .filter(|m| m.interface.as_ref() == Some(interface))
+            .filter(|m| m.interface.as_ref().map(|i| i.inner()) == Some(interface))
             .flat_map(|m| m.custom_types.iter())
             .filter(|ty| {
                 let type_str = ty.to_token_stream().to_string();
@@ -1109,7 +1111,7 @@ fn generate_interface_descriptions(
         let mut seen_error_types = HashSet::new();
         let error_types: Vec<TokenStream> = methods_info
             .iter()
-            .filter(|m| m.interface.as_ref() == Some(interface))
+            .filter(|m| m.interface.as_ref().map(|i| i.inner()) == Some(interface))
             .flat_map(|m| {
                 m.error_type
                     .as_ref()
@@ -1162,12 +1164,13 @@ fn generate_interface_descriptions(
         let interface_comment_objects =
             crate::introspect::shared::generate_comment_objects(impl_comments, crate_path);
 
+        let interface_str = interface.as_str();
         descriptions.push(quote! {
             #[doc(hidden)]
             const #const_name: &#crate_path::idl::Interface<'static> = &{
                 #(#method_consts)*
                 #crate_path::idl::Interface::new(
-                    #interface,
+                    #crate_path::names::InterfaceName::from_static_str_unchecked(#interface_str),
                     &[#(#method_refs),*],
                     &[#(#custom_types),*],
                     #error_variants_expr,
@@ -1613,11 +1616,7 @@ fn generate_handle_body(
     let interface_match_arms: Vec<TokenStream> = interfaces
         .iter()
         .map(|interface| {
-            let const_name = format_ident!(
-                "__{}_INTERFACE_{}",
-                type_name.to_uppercase(),
-                interface.replace('.', "_").to_uppercase()
-            );
+            let const_name = interface_name_to_ident(type_name, interface);
             let desc_reply = wrap_handle_result_no_fds(quote! {
                 #crate_path::service::MethodReply::Single(Some(
                     #reply_params_name::#varlink_reply_variant(
@@ -1625,8 +1624,9 @@ fn generate_handle_body(
                     )
                 ))
             });
+            let interface_str = interface.as_str();
             quote! {
-                #interface => {
+                #interface_str => {
                     let desc =
                         #crate_path::varlink_service::InterfaceDescription::from(#const_name);
                     #desc_reply
@@ -1636,8 +1636,13 @@ fn generate_handle_body(
         .collect();
 
     // Build the interfaces list for GetInfo.
-    let interfaces_list: Vec<TokenStream> =
-        interfaces.iter().map(|iface| quote! { #iface }).collect();
+    let interfaces_list: Vec<TokenStream> = interfaces
+        .iter()
+        .map(|iface| {
+            let iface_str = iface.as_str();
+            quote! { #iface_str }
+        })
+        .collect();
 
     // Service metadata.
     let vendor = service_attrs
@@ -1689,7 +1694,7 @@ fn generate_handle_body(
         #method_call_name::__VarlinkService(__varlink_method) => {
             match __varlink_method {
                 #crate_path::varlink_service::Method::GetInfo => {
-                    let info = #crate_path::varlink_service::Info::new(
+                    let info = #crate_path::varlink_service::Info::from_static_str_unchecked(
                         #vendor,
                         #product,
                         #version,
@@ -1702,7 +1707,7 @@ fn generate_handle_body(
                     #get_info_reply
                 }
                 #crate_path::varlink_service::Method::GetInterfaceDescription { interface } => {
-                    match *interface {
+                    match interface.as_str() {
                         #(#interface_match_arms)*
                         #crate_path::varlink_service::INTERFACE_NAME => {
                             let desc =
@@ -1738,4 +1743,17 @@ fn generate_handle_body(
             #user_methods_match
         }
     })
+}
+
+/// Replaces . and - with _ and uppercases the interface name
+fn interface_name_to_ident<'name>(type_name: &str, interface: &InterfaceName<'name>) -> Ident {
+    format_ident!(
+        "__{}_INTERFACE_{}",
+        type_name.to_uppercase(),
+        interface
+            .chars()
+            .map(|c| if matches!(c, '.' | '-') { '_' } else { c })
+            .flat_map(char::to_uppercase)
+            .collect::<String>()
+    )
 }

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -1,12 +1,14 @@
 //! Method information extraction for service macro.
 
+use crate::naming::{self, NameSource};
 use proc_macro2::TokenStream;
 use syn::{
     Attribute, Error, Expr, GenericArgument, Ident, ImplItemFn, Lit, LitStr, Meta, PathArguments,
     ReturnType, Type, parse::Parse,
 };
 
-use crate::naming::{self, Grammar, NameSource};
+use crate::naming::Grammar;
+use zlink_names::OwnedInterfaceName;
 
 use super::types::ParamInfo;
 
@@ -17,7 +19,7 @@ pub(super) struct MethodInfo {
     /// The Varlink method name (PascalCase or renamed).
     pub varlink_name: String,
     /// The interface name for this method.
-    pub interface: Option<String>,
+    pub interface: Option<OwnedInterfaceName>,
     /// Custom types scoped to this method's interface (from `#[zlink(types = [...])]`).
     pub custom_types: Vec<Type>,
     /// Parameters for this method (excluding self).
@@ -52,7 +54,7 @@ impl MethodInfo {
     /// interface attribute is found.
     pub(super) fn extract(
         method: &mut ImplItemFn,
-        current_interface: &mut Option<String>,
+        current_interface: &mut Option<OwnedInterfaceName>,
     ) -> Result<Self, Error> {
         let name = method.sig.ident.clone();
 
@@ -359,7 +361,7 @@ impl MethodInfo {
 #[derive(Default)]
 struct MethodAttrs {
     /// The interface name for this method.
-    interface: Option<String>,
+    interface: Option<OwnedInterfaceName>,
     /// Custom types scoped to this method's interface.
     custom_types: Vec<Type>,
     /// Custom method name.
@@ -396,8 +398,8 @@ impl MethodAttrs {
             let parser = syn::meta::parser(|meta| {
                 if meta.path.is_ident("interface") {
                     let value: syn::LitStr = meta.value()?.parse()?;
-                    naming::validate_interface(&value)?;
-                    result.interface = Some(value.value());
+                    let validated = naming::validate_interface(&value)?;
+                    result.interface = Some(validated);
                 } else if meta.path.is_ident("rename") {
                     let value: syn::LitStr = meta.value()?.parse()?;
                     result.rename = Some(value);
@@ -697,7 +699,7 @@ mod tests {
             let mut method: ImplItemFn = parse_quote! {
                 async fn probe(&self, #param) -> Result<Reply, Error> { todo!() }
             };
-            let mut interface = Some("org.example.probe".to_owned());
+            let mut interface = Some(OwnedInterfaceName::try_from("org.example.probe").unwrap());
 
             let Err(err) = MethodInfo::extract(&mut method, &mut interface) else {
                 panic!("`{src}` must be rejected: it reaches the IDL as `_foo`");

--- a/zlink-macros/src/service/method.rs
+++ b/zlink-macros/src/service/method.rs
@@ -7,8 +7,7 @@ use syn::{
     ReturnType, Type, parse::Parse,
 };
 
-use crate::naming::Grammar;
-use zlink_names::OwnedInterfaceName;
+use zlink_names::{FieldName, OwnedInterfaceName, OwnedTypeName};
 
 use super::types::ParamInfo;
 
@@ -17,7 +16,7 @@ pub(super) struct MethodInfo {
     /// The original method name (snake_case).
     pub name: Ident,
     /// The Varlink method name (PascalCase or renamed).
-    pub varlink_name: String,
+    pub varlink_name: OwnedTypeName,
     /// The interface name for this method.
     pub interface: Option<OwnedInterfaceName>,
     /// Custom types scoped to this method's interface (from `#[zlink(types = [...])]`).
@@ -79,7 +78,8 @@ impl MethodInfo {
             ),
         };
         // A method is named like a type, so it must be expressible as one.
-        naming::validate(&varlink_name, Grammar::Type, "method name", name_source)?;
+        let varlink_name: OwnedTypeName =
+            naming::validate(&varlink_name, "method name", name_source)?;
 
         // Check if this is a streaming method.
         let is_streaming = method_attrs.is_streaming;
@@ -135,7 +135,7 @@ impl MethodInfo {
                 Some(lit) => (lit.value(), NameSource::Rename(lit)),
                 None => (naming::unraw(&param.name), NameSource::Ident(&param.name)),
             };
-            naming::validate(&wire_name, Grammar::Field, "parameter name", source)?;
+            let _: FieldName<'_> = naming::validate(&wire_name, "parameter name", source)?;
         }
 
         // Validate FD attributes.

--- a/zlink-macros/src/service/mod.rs
+++ b/zlink-macros/src/service/mod.rs
@@ -36,8 +36,7 @@ fn service_impl(attr: TokenStream, input: TokenStream) -> Result<TokenStream, Er
 
     // Process methods and collect method information.
     let mut methods_info = Vec::new();
-    let mut current_interface: Option<String> = service_attrs.interface.clone();
-
+    let mut current_interface = service_attrs.interface.clone();
     for item in &mut item_impl.items {
         let ImplItem::Fn(method) = item else {
             continue;

--- a/zlink-macros/tests/service/introspection.rs
+++ b/zlink-macros/tests/service/introspection.rs
@@ -47,7 +47,7 @@ async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::er
     // Parse the interface and verify the name.
     let interface = desc.parse()?;
     assert_eq!(
-        interface.name(),
+        interface.name().as_str(),
         "org.example.bank",
         "Expected org.example.bank interface"
     );
@@ -168,7 +168,7 @@ async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::er
         .unwrap();
     let interface = desc.parse()?;
     assert_eq!(
-        interface.name(),
+        interface.name().as_str(),
         "org.varlink.service",
         "Expected org.varlink.service interface"
     );

--- a/zlink-macros/tests/service/metadata.rs
+++ b/zlink-macros/tests/service/metadata.rs
@@ -70,3 +70,19 @@ impl MetadataService {
     // Add another method to verify all methods get the interface.
     async fn pong(&self) {}
 }
+
+#[allow(dead_code)]
+struct HyphenService;
+
+// Test if `service` macro can handle an interface with `-` in the name.
+#[zlink::service(
+    interface = "org.example.metadata-hyphen",
+    vendor = "Test Vendor",
+    product = "Test Product",
+    version = env!("CARGO_PKG_VERSION"),
+    url = env!("CARGO_PKG_REPOSITORY")
+)]
+impl HyphenService {
+    #[allow(dead_code)]
+    async fn hyphenhyphen(&self) {}
+}

--- a/zlink-macros/tests/service/per_interface_types.rs
+++ b/zlink-macros/tests/service/per_interface_types.rs
@@ -53,7 +53,7 @@ async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::er
         .await?
         .unwrap();
     let interface = desc.parse()?;
-    assert_eq!(interface.name(), "org.example.books");
+    assert_eq!(interface.name().as_str(), "org.example.books");
 
     let type_names: Vec<_> = interface.custom_types().map(|t| t.name()).collect();
     assert!(
@@ -96,7 +96,7 @@ async fn run_client(socket_path: &std::path::Path) -> Result<(), Box<dyn std::er
         .await?
         .unwrap();
     let interface = desc.parse()?;
-    assert_eq!(interface.name(), "org.example.music");
+    assert_eq!(interface.name().as_str(), "org.example.music");
 
     let type_names: Vec<_> = interface.custom_types().map(|t| t.name()).collect();
     assert!(

--- a/zlink-names/Cargo.toml
+++ b/zlink-names/Cargo.toml
@@ -1,22 +1,20 @@
 [package]
-name = "zlink-idl"
+name = "zlink-names"
 version = "0.7.0"
-description = "Varlink IDL types and parser"
+description = "Varlink name types"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
-[features]
-parse = ["dep:winnow"]
-
 [dependencies]
+regex = { version = "1.13.1", default-features = false }
 winnow = { version = "1.0.4", default-features = false, features = [
     "alloc",
-    "ascii",
-], optional = true }
-zlink-names = { path = "../zlink-names", version = "=0.7.0", default-features = false }
+    "parser",
+] }
+zcheapstr = "1.1.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zlink-names/Cargo.toml
+++ b/zlink-names/Cargo.toml
@@ -9,12 +9,12 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
-regex = { version = "1.13.1", default-features = false }
+serde = { version = "1.0.229" }
 winnow = { version = "1.0.4", default-features = false, features = [
     "alloc",
     "parser",
 ] }
-zcheapstr = "1.1.0"
+zcheapstr = { version = "1.1.0", default-features = false }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/zlink-names/src/error.rs
+++ b/zlink-names/src/error.rs
@@ -1,0 +1,29 @@
+use core::{
+    error::Error,
+    fmt::{Display, Write},
+};
+
+use alloc::string::String;
+use winnow::error::{ErrMode, InputError};
+
+#[derive(Debug)]
+pub struct TryFromError {
+    buf: String,
+}
+
+impl Error for TryFromError {}
+
+impl Display for TryFromError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str(&self.buf)
+    }
+}
+
+impl<'a> From<ErrMode<InputError<&'a [u8]>>> for TryFromError {
+    fn from(value: ErrMode<InputError<&'a [u8]>>) -> Self {
+        let mut buf = String::new();
+        // `write!` never fails for a `String` sink.
+        let _ = write!(buf, "{value}");
+        Self { buf }
+    }
+}

--- a/zlink-names/src/field_name.rs
+++ b/zlink-names/src/field_name.rs
@@ -1,0 +1,34 @@
+use crate::parser::{bytes_to_str, parses_fully};
+
+use winnow::{
+    ModalResult, Parser,
+    error::InputError,
+    token::{one_of, take_while},
+};
+
+/// Whether `name` is a valid Varlink field name.
+///
+/// Struct fields, method parameters and enum variants all follow this rule.
+///
+/// # Examples
+///
+/// ```
+/// use zlink_names::is_valid_field_name;
+///
+/// assert!(is_valid_field_name("user_name"));
+/// assert!(!is_valid_field_name("user-name"));
+/// ```
+pub fn is_valid_field_name(name: &str) -> bool {
+    parses_fully(parse_field_name, name)
+}
+
+/// Parse a field name: starts with letter, continues with alphanumeric and underscores.
+pub fn parse_field_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
+    (
+        one_of(|c: u8| c.is_ascii_alphabetic()),
+        take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'_'),
+    )
+        .take()
+        .map(bytes_to_str)
+        .parse_next(input)
+}

--- a/zlink-names/src/field_name.rs
+++ b/zlink-names/src/field_name.rs
@@ -1,10 +1,19 @@
-use crate::parser::{bytes_to_str, parses_fully};
+use crate::{
+    FromPattern, TryFromError,
+    parser::{bytes_to_str, parses_fully},
+};
 
+use alloc::string::String;
 use winnow::{
     ModalResult, Parser,
-    error::InputError,
-    token::{one_of, take_while},
+    combinator::{opt, repeat},
+    error::{ErrMode, InputError, ParserError},
+    token::one_of,
 };
+
+use core::fmt::{Display, Formatter};
+
+use zcheapstr::CheapStr;
 
 /// Whether `name` is a valid Varlink field name.
 ///
@@ -16,19 +25,190 @@ use winnow::{
 /// use zlink_names::is_valid_field_name;
 ///
 /// assert!(is_valid_field_name("user_name"));
+/// assert!(!is_valid_field_name("user_name_"));
 /// assert!(!is_valid_field_name("user-name"));
 /// ```
 pub fn is_valid_field_name(name: &str) -> bool {
     parses_fully(parse_field_name, name)
 }
 
-/// Parse a field name: starts with letter, continues with alphanumeric and underscores.
+/// Parse a field name: starts with letter, continues with alphanumeric, with single underscores
+/// allowed as separators (never trailing or doubled).
 pub fn parse_field_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
     (
         one_of(|c: u8| c.is_ascii_alphabetic()),
-        take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'_'),
+        repeat::<_, _, (), _, _>(
+            0..,
+            (
+                opt(one_of(|c: u8| c == b'_')),
+                one_of(|c: u8| c.is_ascii_alphanumeric()),
+            )
+                .void(),
+        ),
     )
         .take()
         .map(bytes_to_str)
         .parse_next(input)
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+/// A valid Varlink field name, e.g. `user_name`.
+///
+/// Struct fields, method parameters and enum variants all follow this rule.
+pub struct FieldName<'name>(CheapStr<'name>);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+/// Owned sibling of [`FieldName`].
+pub struct OwnedFieldName(FieldName<'static>);
+
+impl FromPattern for FieldName<'_> {
+    fn from_pattern() -> &'static str {
+        r"[A-Za-z](_?[A-Za-z0-9])*"
+    }
+}
+
+impl FieldName<'_> {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Clone into an owned field name.
+    pub fn to_owned(&self) -> OwnedFieldName {
+        OwnedFieldName(FieldName(self.0.to_owned()))
+    }
+}
+
+impl FromPattern for OwnedFieldName {
+    fn from_pattern() -> &'static str {
+        FieldName::from_pattern()
+    }
+}
+
+impl OwnedFieldName {
+    pub fn as_ref(&self) -> FieldName<'_> {
+        FieldName(self.0.0.as_ref())
+    }
+
+    pub fn inner(&self) -> &FieldName<'static> {
+        &self.0
+    }
+}
+
+/// Try constructing a field name. Only works if name is actually valid.
+/// # Examples
+///
+/// ```
+/// use zlink_names::FieldName;
+///
+/// assert!(FieldName::try_from("user_name").is_ok());
+/// assert!(FieldName::try_from("user-name").is_err());
+/// ```
+impl<'name> TryFrom<&'name str> for FieldName<'name> {
+    type Error = TryFromError;
+
+    fn try_from(name: &'name str) -> Result<Self, Self::Error> {
+        let mut input = name.as_bytes();
+        parse_field_name(&mut input)?;
+        // `parse_field_name` accepts a valid prefix; reject any leftover suffix.
+        if !input.is_empty() {
+            return Err(ErrMode::Backtrack(ParserError::from_input(&input)).into());
+        }
+        Ok(FieldName(CheapStr::from(name)))
+    }
+}
+
+impl<'s> TryFrom<&'s str> for OwnedFieldName {
+    type Error = TryFromError;
+
+    fn try_from(name: &'s str) -> Result<Self, Self::Error> {
+        let mut input = name.as_bytes();
+        parse_field_name(&mut input)?;
+        // `parse_field_name` accepts a valid prefix; reject any leftover suffix.
+        if !input.is_empty() {
+            return Err(ErrMode::Backtrack(ParserError::from_input(&input)).into());
+        }
+        Ok(OwnedFieldName(FieldName(CheapStr::from(name).into_owned())))
+    }
+}
+
+impl TryFrom<String> for OwnedFieldName {
+    type Error = TryFromError;
+
+    fn try_from(name: String) -> Result<Self, Self::Error> {
+        let mut input = name.as_bytes();
+        parse_field_name(&mut input).map_err(TryFromError::from)?;
+        // `parse_field_name` accepts a valid prefix; reject any leftover suffix.
+        if !input.is_empty() {
+            return Err(ErrMode::Backtrack(ParserError::from_input(&input)).into());
+        }
+        Ok(OwnedFieldName(FieldName(CheapStr::from(name))))
+    }
+}
+
+impl Display for FieldName<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl core::ops::Deref for FieldName<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl core::ops::Deref for OwnedFieldName {
+    type Target = FieldName<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for OwnedFieldName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl PartialEq<FieldName<'_>> for OwnedFieldName {
+    fn eq(&self, other: &FieldName<'_>) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<OwnedFieldName> for FieldName<'_> {
+    fn eq(&self, other: &OwnedFieldName) -> bool {
+        *self == other.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: [&str; 6] = ["a", "Z", "user_name", "user0", "a_0_b", "type"];
+    const INVALID: [&str; 9] = [
+        "",
+        "_foo",
+        "0foo",
+        "user-name",
+        "user name",
+        "user!",
+        "a_",
+        "x__",
+        "a__b",
+    ];
+
+    #[test]
+    fn field_names() {
+        for name in VALID {
+            assert!(is_valid_field_name(name), "`{name}` must be valid");
+        }
+        for name in INVALID {
+            assert!(!is_valid_field_name(name), "`{name}` must be invalid");
+        }
+    }
 }

--- a/zlink-names/src/interface_name.rs
+++ b/zlink-names/src/interface_name.rs
@@ -1,0 +1,82 @@
+use crate::parser::{bytes_to_str, parses_fully};
+
+use winnow::{
+    ModalResult, Parser,
+    combinator::repeat,
+    error::InputError,
+    token::{literal, one_of, take_while},
+};
+
+/// Whether `name` is a valid Varlink interface name.
+///
+/// Interface names are reverse-domain notation: dot-separated segments, at least one dot.
+///
+/// # Examples
+///
+/// ```
+/// use zlink_names::is_valid_interface_name;
+///
+/// assert!(is_valid_interface_name("org.example.Foo"));
+/// assert!(!is_valid_interface_name("Foo"));
+/// ```
+pub fn is_valid_interface_name(name: &str) -> bool {
+    parses_fully(parse_interface_name, name)
+}
+
+/// Parse an interface name: reverse domain notation like `org.example.test`.
+///
+/// Grammar:
+///   first segment      = \[A-Za-z\]\[A-Za-z0-9-\]*
+///   subsequent segment = "." \[A-Za-z0-9\]\[A-Za-z0-9-\]*
+///   name               = first_segment subsequent_segment+
+pub fn parse_interface_name<'a>(
+    input: &mut &'a [u8],
+) -> ModalResult<&'a str, InputError<&'a [u8]>> {
+    (
+        // First segment.
+        (
+            one_of(|c: u8| c.is_ascii_alphabetic()),
+            take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'-'),
+        ),
+        // One or more dotted segments (so the name has at least one `.`).
+        repeat::<_, _, (), _, _>(
+            1..,
+            (
+                literal("."),
+                one_of(|c: u8| c.is_ascii_alphanumeric()),
+                take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'-'),
+            )
+                .void(),
+        ),
+    )
+        .take()
+        .map(bytes_to_str)
+        .parse_next(input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_parse_interface_name() {
+        let input = b"org.example.test";
+        let mut input_mut = input.as_slice();
+        let result = parse_interface_name(&mut input_mut).unwrap();
+        assert_eq!(result, "org.example.test");
+        assert!(input_mut.is_empty());
+
+        let input = b"com.example.foo.bar";
+        let mut input_mut = input.as_slice();
+        let result = parse_interface_name(&mut input_mut).unwrap();
+        assert_eq!(result, "com.example.foo.bar");
+        assert!(input_mut.is_empty());
+
+        // Invalid: no dot
+        let mut input_mut = b"example".as_slice();
+        assert!(parse_interface_name(&mut input_mut).is_err());
+
+        // Invalid: starts with number
+        let mut input_mut = b"1example.test".as_slice();
+        assert!(parse_interface_name(&mut input_mut).is_err());
+    }
+}

--- a/zlink-names/src/interface_name.rs
+++ b/zlink-names/src/interface_name.rs
@@ -1,62 +1,249 @@
-use crate::parser::{bytes_to_str, parses_fully};
+use crate::{
+    FromPattern, TryFromError,
+    parser::{bytes_to_str, parses_fully},
+};
 
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use winnow::{
     ModalResult, Parser,
     combinator::repeat,
-    error::InputError,
+    error::{ErrMode, InputError, ParserError},
     token::{literal, one_of, take_while},
 };
 
-/// Whether `name` is a valid Varlink interface name.
+use alloc::string::String;
+use core::fmt::{Display, Formatter};
+
+use zcheapstr::CheapStr;
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+/// A valid Varlink interface name, e.g. `org.example.Foo`.
 ///
 /// Interface names are reverse-domain notation: dot-separated segments, at least one dot.
-///
+pub struct InterfaceName<'name>(CheapStr<'name>);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+/// Owned sibling of [`InterfaceName`].
+pub struct OwnedInterfaceName(InterfaceName<'static>);
+
+impl AsRef<str> for InterfaceName<'_> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl PartialEq<&str> for InterfaceName<'_> {
+    fn eq(&self, other: &&str) -> bool {
+        self.as_str() == *other
+    }
+}
+
+impl Serialize for InterfaceName<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de: 'name, 'name> Deserialize<'de> for InterfaceName<'name> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let name = <&str>::deserialize(deserializer)?;
+        Self::try_from(name).map_err(|_| de::Error::custom("invalid Varlink interface name"))
+    }
+}
+
+impl Serialize for OwnedInterfaceName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for OwnedInterfaceName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let name = String::deserialize(deserializer)?;
+        Self::try_from(name).map_err(|_| de::Error::custom("invalid Varlink interface name"))
+    }
+}
+
+impl FromPattern for InterfaceName<'_> {
+    fn from_pattern() -> &'static str {
+        r"[A-Za-z]([-]*[A-Za-z0-9])*(\.[A-Za-z0-9]([-]*[A-Za-z0-9])*)+"
+    }
+}
+
+impl InterfaceName<'_> {
+    /// Returns the interface name as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Internal function only. Do not call this directly in your own code!
+    pub const fn from_static_str_unchecked(name: &'static str) -> Self {
+        Self(CheapStr::from_static(name))
+    }
+
+    /// Convert this interface name into an owned version with `'static` lifetime.
+    pub fn into_owned(self) -> InterfaceName<'static> {
+        InterfaceName(self.0.into_owned())
+    }
+
+    /// Clone into an owned interface name.
+    pub fn to_owned(&self) -> OwnedInterfaceName {
+        OwnedInterfaceName(InterfaceName(self.0.to_owned()))
+    }
+}
+
+impl FromPattern for OwnedInterfaceName {
+    fn from_pattern() -> &'static str {
+        InterfaceName::from_pattern()
+    }
+}
+
+impl OwnedInterfaceName {
+    pub fn as_ref(&self) -> InterfaceName<'_> {
+        InterfaceName(self.0.0.as_ref())
+    }
+
+    pub fn inner(&self) -> &InterfaceName<'static> {
+        &self.0
+    }
+}
+
+/// Try constructing a Interface name. Only works if name is actually valid.
 /// # Examples
 ///
 /// ```
-/// use zlink_names::is_valid_interface_name;
+/// use zlink_names::InterfaceName;
 ///
-/// assert!(is_valid_interface_name("org.example.Foo"));
-/// assert!(!is_valid_interface_name("Foo"));
+/// assert!(InterfaceName::try_from("org.example.Foo").is_ok());
+/// assert!(InterfaceName::try_from("Foo").is_err());
 /// ```
-pub fn is_valid_interface_name(name: &str) -> bool {
-    parses_fully(parse_interface_name, name)
+impl<'name> TryFrom<&'name str> for InterfaceName<'name> {
+    type Error = TryFromError;
+
+    fn try_from(name: &'name str) -> Result<Self, Self::Error> {
+        let mut input = name.as_bytes();
+        parse_interface_name(&mut input)?;
+        // `parse_interface_name` accepts a valid prefix; reject any leftover suffix.
+        if !input.is_empty() {
+            return Err(ErrMode::Backtrack(ParserError::from_input(&input)).into());
+        }
+        Ok(Self(CheapStr::from(name)))
+    }
 }
 
-/// Parse an interface name: reverse domain notation like `org.example.test`.
-///
-/// Grammar:
-///   first segment      = \[A-Za-z\]\[A-Za-z0-9-\]*
-///   subsequent segment = "." \[A-Za-z0-9\]\[A-Za-z0-9-\]*
-///   name               = first_segment subsequent_segment+
-pub fn parse_interface_name<'a>(
-    input: &mut &'a [u8],
-) -> ModalResult<&'a str, InputError<&'a [u8]>> {
-    (
-        // First segment.
-        (
-            one_of(|c: u8| c.is_ascii_alphabetic()),
-            take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'-'),
-        ),
-        // One or more dotted segments (so the name has at least one `.`).
-        repeat::<_, _, (), _, _>(
-            1..,
-            (
-                literal("."),
-                one_of(|c: u8| c.is_ascii_alphanumeric()),
-                take_while(0.., |c: u8| c.is_ascii_alphanumeric() || c == b'-'),
-            )
-                .void(),
-        ),
-    )
-        .take()
-        .map(bytes_to_str)
-        .parse_next(input)
+impl<'s> TryFrom<&'s str> for OwnedInterfaceName {
+    type Error = TryFromError;
+
+    fn try_from(name: &'s str) -> Result<Self, Self::Error> {
+        let mut input = name.as_bytes();
+        parse_interface_name(&mut input)?;
+        if !input.is_empty() {
+            return Err(ErrMode::Backtrack(ParserError::from_input(&input)).into());
+        }
+        Ok(Self(InterfaceName(CheapStr::from(name).into_owned())))
+    }
+}
+
+impl TryFrom<String> for OwnedInterfaceName {
+    type Error = TryFromError;
+
+    fn try_from(name: String) -> Result<Self, Self::Error> {
+        let mut input = name.as_bytes();
+        parse_interface_name(&mut input).map_err(TryFromError::from)?;
+        if !input.is_empty() {
+            return Err(ErrMode::Backtrack(ParserError::from_input(&input)).into());
+        }
+        Ok(Self(InterfaceName(CheapStr::from(name))))
+    }
+}
+
+impl Display for InterfaceName<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl core::ops::Deref for InterfaceName<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl core::ops::Deref for OwnedInterfaceName {
+    type Target = InterfaceName<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for OwnedInterfaceName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl PartialEq<InterfaceName<'_>> for OwnedInterfaceName {
+    fn eq(&self, other: &InterfaceName<'_>) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<OwnedInterfaceName> for InterfaceName<'_> {
+    fn eq(&self, other: &OwnedInterfaceName) -> bool {
+        *self == other.0
+    }
+}
+
+impl From<OwnedInterfaceName> for InterfaceName<'static> {
+    fn from(name: OwnedInterfaceName) -> Self {
+        name.0
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const VALID: [&str; 4] = ["org.example.Foo", "a.b", "org.varlink.service", "a1.b-2.c3"];
+    const INVALID: [&str; 11] = [
+        "",
+        "Foo",          // No dot.
+        "org.",         // Trailing dot, empty segment.
+        ".org",         // Leading dot.
+        "org..example", // Empty segment.
+        "org.example.", // Trailing dot.
+        "1org.example", // First segment must start with a letter.
+        "org.example.Foo bar",
+        "org.example.Foö",
+        "org-.example", // First segment ends in a hyphen.
+        "org.example-", // Subsequent segment ends in a hyphen.
+    ];
+
+    #[test]
+    fn interface_names() {
+        for name in VALID {
+            assert!(is_valid_interface_name(name), "`{name}` must be valid");
+        }
+        for name in INVALID {
+            assert!(!is_valid_interface_name(name), "`{name}` must be invalid");
+        }
+    }
+
     #[test]
     fn test_parse_interface_name() {
         let input = b"org.example.test";
@@ -79,4 +266,62 @@ mod tests {
         let mut input_mut = b"1example.test".as_slice();
         assert!(parse_interface_name(&mut input_mut).is_err());
     }
+}
+
+/// Whether `name` is a valid Varlink interface name.
+///
+/// Interface names are reverse-domain notation: dot-separated segments, at least one dot.
+///
+/// # Examples
+///
+/// ```
+/// use zlink_names::is_valid_interface_name;
+///
+/// assert!(is_valid_interface_name("org.example.Foo"));
+/// assert!(!is_valid_interface_name("Foo"));
+/// ```
+pub fn is_valid_interface_name(name: &str) -> bool {
+    parses_fully(parse_interface_name, name)
+}
+
+/// Parse an interface name: reverse domain notation like `org.example.test`.
+///
+/// Grammar:
+///   first segment      = \[A-Za-z\](\[-\]*\[A-Za-z0-9\])*
+///   subsequent segment = "." \[A-Za-z0-9\](\[-\]*\[A-Za-z0-9\])*
+///   name               = first_segment subsequent_segment+
+pub fn parse_interface_name<'a>(
+    input: &mut &'a [u8],
+) -> ModalResult<&'a str, InputError<&'a [u8]>> {
+    (
+        // First segment.
+        (one_of(|c: u8| c.is_ascii_alphabetic()), segment_rest),
+        // One or more dotted segments (so the name has at least one `.`).
+        repeat::<_, _, (), _, _>(
+            1..,
+            (
+                literal("."),
+                one_of(|c: u8| c.is_ascii_alphanumeric()),
+                segment_rest,
+            )
+                .void(),
+        ),
+    )
+        .take()
+        .map(bytes_to_str)
+        .parse_next(input)
+}
+
+/// Rest of a segment after its leading character: zero or more runs of hyphens each
+/// immediately followed by an alphanumeric, so a segment can never end in `-`.
+fn segment_rest<'a>(input: &mut &'a [u8]) -> ModalResult<(), InputError<&'a [u8]>> {
+    repeat::<_, _, (), _, _>(
+        0..,
+        (
+            take_while(0.., |c: u8| c == b'-'),
+            one_of(|c: u8| c.is_ascii_alphanumeric()),
+        )
+            .void(),
+    )
+    .parse_next(input)
 }

--- a/zlink-names/src/lib.rs
+++ b/zlink-names/src/lib.rs
@@ -1,0 +1,13 @@
+//! Varlink name types and validation.
+//!
+//! This crate provides parsers and validators for the different kinds of names used in Varlink:
+//! field names, type names and interface names. It is standalone: it does not pull in the rest of
+//! zlink.
+mod field_name;
+mod interface_name;
+mod parser;
+mod type_name;
+
+pub use field_name::{is_valid_field_name, parse_field_name};
+pub use interface_name::{is_valid_interface_name, parse_interface_name};
+pub use type_name::{is_valid_type_name, parse_type_name};

--- a/zlink-names/src/lib.rs
+++ b/zlink-names/src/lib.rs
@@ -3,11 +3,21 @@
 //! This crate provides parsers and validators for the different kinds of names used in Varlink:
 //! field names, type names and interface names. It is standalone: it does not pull in the rest of
 //! zlink.
+#![no_std]
+
+extern crate alloc;
+
+mod error;
 mod field_name;
 mod interface_name;
 mod parser;
+mod pattern;
 mod type_name;
 
+pub use error::TryFromError;
 pub use field_name::{is_valid_field_name, parse_field_name};
-pub use interface_name::{is_valid_interface_name, parse_interface_name};
+#[deprecated(note = "Use OwnedInterfaceName or InterfaceName in zlink-names instead")]
+pub use interface_name::is_valid_interface_name;
+pub use interface_name::{InterfaceName, OwnedInterfaceName, parse_interface_name};
+pub use pattern::FromPattern;
 pub use type_name::{is_valid_type_name, parse_type_name};

--- a/zlink-names/src/lib.rs
+++ b/zlink-names/src/lib.rs
@@ -22,4 +22,6 @@ pub use field_name::{is_valid_field_name, parse_field_name};
 pub use interface_name::is_valid_interface_name;
 pub use interface_name::{InterfaceName, OwnedInterfaceName, parse_interface_name};
 pub use pattern::FromPattern;
-pub use type_name::{is_valid_type_name, parse_type_name};
+#[deprecated(note = "Use OwnedTypeName or TypeName in zlink-names instead")]
+pub use type_name::is_valid_type_name;
+pub use type_name::{OwnedTypeName, TypeName, parse_type_name};

--- a/zlink-names/src/lib.rs
+++ b/zlink-names/src/lib.rs
@@ -15,6 +15,8 @@ mod pattern;
 mod type_name;
 
 pub use error::TryFromError;
+pub use field_name::{FieldName, OwnedFieldName};
+#[deprecated(note = "Use OwnedFieldName or FieldName in zlink-names instead")]
 pub use field_name::{is_valid_field_name, parse_field_name};
 #[deprecated(note = "Use OwnedInterfaceName or InterfaceName in zlink-names instead")]
 pub use interface_name::is_valid_interface_name;

--- a/zlink-names/src/parser.rs
+++ b/zlink-names/src/parser.rs
@@ -1,0 +1,20 @@
+use winnow::error::{ErrMode, InputError};
+
+/// Whether `parser` accepts the whole of `name`, leaving nothing behind.
+///
+/// The parsers succeed on a valid prefix (e.g. `field_name` takes `foo` out of `foo-bar`), so a
+/// name is only valid when parsing also consumes every byte.
+pub(crate) fn parses_fully<'a, P, T>(mut parser: P, name: &'a str) -> bool
+where
+    P: FnMut(&mut &'a [u8]) -> Result<T, ErrMode<InputError<&'a [u8]>>>,
+{
+    let mut input = name.as_bytes();
+
+    parser(&mut input).is_ok() && input.is_empty()
+}
+
+/// Convert bytes to str with input lifetime.
+pub(crate) fn bytes_to_str(bytes: &[u8]) -> &str {
+    // SAFETY: We only accept ASCII characters in our parsers
+    core::str::from_utf8(bytes).unwrap()
+}

--- a/zlink-names/src/pattern.rs
+++ b/zlink-names/src/pattern.rs
@@ -1,0 +1,5 @@
+/// A type that can be validated or parsed using a fixed regular expression.
+pub trait FromPattern {
+    /// The regular expression matching valid values of this type.
+    fn from_pattern() -> &'static str;
+}

--- a/zlink-names/src/type_name.rs
+++ b/zlink-names/src/type_name.rs
@@ -1,0 +1,34 @@
+use crate::parser::{bytes_to_str, parses_fully};
+
+use winnow::{
+    ModalResult, Parser,
+    error::InputError,
+    token::{one_of, take_while},
+};
+
+/// Whether `name` is a valid Varlink type name.
+///
+/// Method and error names follow this rule too.
+///
+/// # Examples
+///
+/// ```
+/// use zlink_names::is_valid_type_name;
+///
+/// assert!(is_valid_type_name("FileNotFound"));
+/// assert!(!is_valid_type_name("fileNotFound"));
+/// ```
+pub fn is_valid_type_name(name: &str) -> bool {
+    parses_fully(parse_type_name, name)
+}
+
+/// Parse a type name: starts with uppercase letter, continues with alphanumeric.
+pub fn parse_type_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputError<&'a [u8]>> {
+    (
+        one_of(|c: u8| c.is_ascii_uppercase()),
+        take_while(0.., |c: u8| c.is_ascii_alphanumeric()),
+    )
+        .take()
+        .map(bytes_to_str)
+        .parse_next(input)
+}

--- a/zlink-names/src/type_name.rs
+++ b/zlink-names/src/type_name.rs
@@ -1,10 +1,16 @@
-use crate::parser::{bytes_to_str, parses_fully};
+use crate::{
+    FromPattern, TryFromError,
+    parser::{bytes_to_str, parses_fully},
+};
 
+use alloc::string::String;
+use core::fmt::{Display, Formatter};
 use winnow::{
     ModalResult, Parser,
-    error::InputError,
+    error::{ErrMode, InputError, ParserError},
     token::{one_of, take_while},
 };
+use zcheapstr::CheapStr;
 
 /// Whether `name` is a valid Varlink type name.
 ///
@@ -31,4 +37,139 @@ pub fn parse_type_name<'a>(input: &mut &'a [u8]) -> ModalResult<&'a str, InputEr
         .take()
         .map(bytes_to_str)
         .parse_next(input)
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+/// A valid Varlink type name, e.g. `FileNotFound`.
+///
+/// Method and error names follow this rule too.
+pub struct TypeName<'name>(CheapStr<'name>);
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+/// Owned sibling of [`TypeName`].
+pub struct OwnedTypeName(TypeName<'static>);
+
+impl FromPattern for TypeName<'_> {
+    fn from_pattern() -> &'static str {
+        r"[A-Z][A-Za-z0-9]*"
+    }
+}
+
+impl TypeName<'_> {
+    /// Returns the type name as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Clone into an owned type name.
+    pub fn to_owned(&self) -> OwnedTypeName {
+        OwnedTypeName(TypeName(self.0.to_owned()))
+    }
+}
+
+impl FromPattern for OwnedTypeName {
+    fn from_pattern() -> &'static str {
+        TypeName::from_pattern()
+    }
+}
+
+impl OwnedTypeName {
+    pub fn as_ref(&self) -> TypeName<'_> {
+        TypeName(self.0.0.as_ref())
+    }
+
+    pub fn inner(&self) -> &TypeName<'static> {
+        &self.0
+    }
+}
+
+/// Try constructing a type name. Only works if name is actually valid.
+/// # Examples
+///
+/// ```
+/// use zlink_names::TypeName;
+///
+/// assert!(TypeName::try_from("FileNotFound").is_ok());
+/// assert!(TypeName::try_from("fileNotFound").is_err());
+/// ```
+impl<'name> TryFrom<&'name str> for TypeName<'name> {
+    type Error = TryFromError;
+
+    fn try_from(name: &'name str) -> Result<Self, Self::Error> {
+        let mut input = name.as_bytes();
+        parse_type_name(&mut input)?;
+        // `parse_field_name` accepts a valid prefix; reject any leftover suffix.
+        if !input.is_empty() {
+            return Err(ErrMode::Backtrack(ParserError::from_input(&input)).into());
+        }
+        Ok(TypeName(CheapStr::from(name)))
+    }
+}
+
+impl<'s> TryFrom<&'s str> for OwnedTypeName {
+    type Error = TryFromError;
+
+    fn try_from(name: &'s str) -> Result<Self, Self::Error> {
+        let mut input = name.as_bytes();
+        parse_type_name(&mut input)?;
+        // `parse_type_name` accepts a valid prefix; reject any leftover suffix.
+        if !input.is_empty() {
+            return Err(ErrMode::Backtrack(ParserError::from_input(&input)).into());
+        }
+        Ok(OwnedTypeName(TypeName(CheapStr::from(name).into_owned())))
+    }
+}
+
+impl TryFrom<String> for OwnedTypeName {
+    type Error = TryFromError;
+
+    fn try_from(name: String) -> Result<Self, Self::Error> {
+        let mut input = name.as_bytes();
+        parse_type_name(&mut input).map_err(TryFromError::from)?;
+        // `parse_type_name` accepts a valid prefix; reject any leftover
+        if !input.is_empty() {
+            return Err(ErrMode::Backtrack(ParserError::from_input(&input)).into());
+        }
+        Ok(OwnedTypeName(TypeName(CheapStr::from(name))))
+    }
+}
+
+impl Display for TypeName<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl core::ops::Deref for TypeName<'_> {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl core::ops::Deref for OwnedTypeName {
+    type Target = TypeName<'static>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl Display for OwnedTypeName {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl PartialEq<TypeName<'_>> for OwnedTypeName {
+    fn eq(&self, other: &TypeName<'_>) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<OwnedTypeName> for TypeName<'_> {
+    fn eq(&self, other: &OwnedTypeName) -> bool {
+        *self == other.0
+    }
 }

--- a/zlink/Cargo.toml
+++ b/zlink/Cargo.toml
@@ -33,6 +33,7 @@ defmt = ["zlink-core/defmt", "zlink-tokio?/defmt", "zlink-smol?/defmt"]
 
 [dependencies]
 zlink-core = { path = "../zlink-core", version = "=0.7.0", default-features = false }
+zlink-names = { path = "../zlink-names", version = "=0.7.0", default-features = false }
 zlink-tokio = { path = "../zlink-tokio", version = "=0.7.0", default-features = false, optional = true }
 zlink-smol = { path = "../zlink-smol", version = "=0.7.0", default-features = false, optional = true }
 

--- a/zlink/src/lib.rs
+++ b/zlink/src/lib.rs
@@ -42,6 +42,11 @@ mod doctests {
 }
 
 pub use zlink_core::*;
+/// API for working with Varlink names
+pub mod names {
+    #[doc(inline)]
+    pub use zlink_names::*;
+}
 
 /// API specific to the [tokio](https://tokio.rs/) runtime.
 #[cfg(feature = "tokio")]

--- a/zlink/tests/ftl.rs
+++ b/zlink/tests/ftl.rs
@@ -92,7 +92,7 @@ async fn run_client(
             .await?
             .map_err(|e| e.to_string())?;
         let interface = interface.parse().unwrap();
-        assert_eq!(interface.name(), "org.example.ftl");
+        assert_eq!(interface.name().as_str(), "org.example.ftl");
         // Verify methods are present.
         let method_names: Vec<_> = interface.methods().map(|m| m.name()).collect();
         assert!(method_names.contains(&"GetDriveCondition"));

--- a/zlink/tests/machined_proxy_e2e.rs
+++ b/zlink/tests/machined_proxy_e2e.rs
@@ -59,7 +59,7 @@ async fn introspect_machined() {
         let interface = interface.parse().unwrap();
 
         // Verify interface details
-        assert_eq!(interface.name(), "io.systemd.Machine");
+        assert_eq!(interface.name().as_str(), "io.systemd.Machine");
         assert!(!interface.is_empty());
 
         // Check for expected methods


### PR DESCRIPTION
This introduces a zlink-names package with structs:
- `FieldName`
- `OwnedFieldName`
- `InterfaceName`
- `OwnedInterfaceName`
- `TypeName`
- `OwnedTypeName`

All of these hold immutable strings and should only be constructed via name validation.

Instead of passing around strings, use these new names for validation and storage of names.

The structs have a minimal implementation heavily inspired by zbus-names.

Fixes https://github.com/z-galaxy/zlink/issues/304.
Fixes https://github.com/z-galaxy/zlink/issues/307