### PR TITLE
🔧 Support skipping the changelog via a commit trailer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,10 @@ This file provides guidance to AI coding agents when working with code in this r
 For contribution conventions — commit-message format, atomic commits, code layout, and
 more — follow the guidelines in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
+- **Changelog-skip trailer**: end a commit message with a `Changelog: skip` git trailer to
+  keep it out of the user-facing changelog (use for AI-workflow artifacts such as design docs
+  and implementation plans).
+
 ## Development Commands
 
 ### Testing

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -58,6 +58,8 @@ protect_breaking_commits = true
 # Categorize commits based on gimoji emojis.
 # See: https://zeenix.github.io/gimoji/
 commit_parsers = [
+    # Skip commits carrying a "Changelog: skip" trailer (see the preprocessor above).
+    { message = "^changelog-skip$", skip = true },
     # Skip merge commits, release commits, and empty commits (just emojis).
     { message = "^[Mm]erge", skip = true },
     { message = "^🔖", skip = true },
@@ -136,6 +138,17 @@ ref=$(git log -1 --format=%b $COMMIT_SHA 2>/dev/null \
 | grep -oE "(Fixes|Closes|Resolves).*#[0-9]+" \
 | grep -oE "#[0-9]+" | head -1); \
 if [ -n "$ref" ]; then printf "%s||%s\n" "$title" "$ref"; \
+else printf "%s\n" "$title"; fi'
+'''
+
+# Replace the message of commits carrying a "Changelog: skip" git trailer with a sentinel
+# that the first commit parser below drops (e.g. AI-workflow design docs and plans).
+[[changelog.commit_preprocessors]]
+pattern = ".*"
+replace_command = '''
+sh -c 'title=$(cat); \
+if git log -1 --format="%(trailers:key=Changelog,valueonly)" $COMMIT_SHA 2>/dev/null \
+| grep -qix skip; then echo changelog-skip; \
 else printf "%s\n" "$title"; fi'
 '''
 


### PR DESCRIPTION
AI-workflow artifact commits (design docs, implementation plans) pollute the user-facing
changelog. `git-cliff` commit parsers can't see git trailers directly (they only match on the
commit message), so this adds a preprocessor that replaces the message of any commit carrying a
`Changelog: skip` trailer with a sentinel, plus a parser entry that drops commits matching that
sentinel. Also documents the convention in `AGENTS.md`.

Usage: end a commit message with a `Changelog: skip` git trailer to keep it out of the
user-facing changelog.

**Verification** (scratch commits on top of this branch, reverted before pushing): three test
commits appending lines to `zlink/examples/README.md` — `📝 Skip me A` (body ending in the
`Changelog: skip` trailer), `📝 Keep me B` (prose mention of "Changelog: skip" mid-body, not a
trailer), `📝 Keep me C` (no body). After `release-plz update`, the resulting
`zlink/CHANGELOG.md` diff:

```
## 0.7.1 - 2026-08-10

### Documentation
- 📝 Keep me C.
- 📝 Keep me B.
```

`Skip me A` is absent; `Keep me B` and `Keep me C` are present, as expected.

Generated by Claude Fable 5 (claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vw5uRE2AL6ddxgwqoPTxVr