### PR TITLE
🐛 zlink-idl: Comma-separate variants of multi-line inline enums

### DIFF
--- a/zlink-idl/src/parse/tests.rs
+++ b/zlink-idl/src/parse/tests.rs
@@ -1018,6 +1018,45 @@ method M (
 }
 
 #[test]
+fn nested_enum_variant_comments_round_trip() {
+    // The multi-line format used for inline enums with variant comments
+    // must be valid IDL: variants comma-separated, so it parses back.
+    let input = r#"
+interface a.b
+
+method M (
+    x: (
+        # the no variant
+        no,
+        # the yes variant
+        yes
+    )
+) -> ()
+    "#;
+
+    let interface = parse_interface(input).unwrap();
+    let displayed = interface.to_string();
+    assert!(
+        displayed.contains("(\n\t# the no variant\n\tno,\n\t# the yes variant\n\tyes\n)"),
+        "unexpected inline enum format:\n{displayed}"
+    );
+
+    let reparsed = parse_interface(&displayed).unwrap();
+    let methods: Vec<_> = reparsed.methods().collect();
+    let inputs: Vec<_> = methods[0].inputs().collect();
+    let Type::Enum(variants) = inputs[0].ty() else {
+        panic!("Expected x to be an inline enum, got: {:?}", inputs[0].ty());
+    };
+    let names: Vec<_> = variants.iter().map(|v| v.name()).collect();
+    assert_eq!(names, ["no", "yes"]);
+    let comments: Vec<_> = variants
+        .iter()
+        .flat_map(|v| v.comments().map(|c| c.text()))
+        .collect();
+    assert_eq!(comments, ["the no variant", "the yes variant"]);
+}
+
+#[test]
 fn method_with_parameter_comments() {
     let input = r#"
 interface org.example.test

--- a/zlink-idl/src/type/mod.rs
+++ b/zlink-idl/src/type/mod.rs
@@ -106,13 +106,18 @@ impl<'a> fmt::Display for Type<'a> {
                 if has_variant_comments {
                     // Multi-line format when any variant has comments
                     writeln!(f, "(")?;
-                    for variant in variants.iter() {
+                    let last = variants.len().saturating_sub(1);
+                    for (i, variant) in variants.iter().enumerate() {
                         // Write comments first
                         for comment in variant.comments() {
                             writeln!(f, "\t{}", comment)?;
                         }
-                        // Then write the variant name
-                        writeln!(f, "\t{}", variant.name())?;
+                        // Then write the variant name, comma-separated
+                        if i == last {
+                            writeln!(f, "\t{}", variant.name())?;
+                        } else {
+                            writeln!(f, "\t{},", variant.name())?;
+                        }
                     }
                     write!(f, ")")
                 } else {
@@ -271,6 +276,6 @@ mod tests {
 
         let mut buf = String::new();
         write!(buf, "{}", enum_with_comments).unwrap();
-        assert_eq!(buf, "(\n\t# Primary color\n\tred\n\tgreen\n\tblue\n)");
+        assert_eq!(buf, "(\n\t# Primary color\n\tred,\n\tgreen,\n\tblue\n)");
     }
 }


### PR DESCRIPTION
When any variant of an inline (anonymous) enum carries a comment, `Display for Type::Enum` switches to a one-variant-per-line layout, but wrote the variant names without the `,` separators the Varlink grammar requires:

    method Enroll() -> (outcome: (
    	Enrolled
    	# Not approved yet.
    	NotApproved
    	Unavailable
    ))

Such an interface description is rejected by our own parser and by systemd's (`varlinkctl introspect` fails with "Bad message"), so any service that embeds a documented enum in a method signature could not be introspected. `CustomEnum` already handles the multi-line case correctly; do the same here and add a parse → display → parse round trip test for the inline enum with variant comments.

<!--

Thank you for your contribution! 🙏

We hope you have read our contribution guideline and followed it to the best of your abilities:

https://github.com/zeenix/zlink/blob/main/CONTRIBUTING.md#submitting-pull-requests

-->
